### PR TITLE
feat: add yanked version warnings for Cargo dependencies

### DIFF
--- a/dependi-lsp/src/cache/sqlite.rs
+++ b/dependi-lsp/src/cache/sqlite.rs
@@ -154,6 +154,7 @@ mod tests {
             vulnerabilities: vec![],
             deprecated: false,
             yanked: false,
+            yanked_versions: vec![],
         }
     }
 

--- a/dependi-lsp/src/registries/crates_io.rs
+++ b/dependi-lsp/src/registries/crates_io.rs
@@ -139,7 +139,15 @@ impl Registry for CratesIoRegistry {
             .first()
             .and_then(|v| v.license.clone());
 
-        // Check if any version is yanked
+        // Collect all yanked versions
+        let yanked_versions: Vec<String> = crate_response
+            .versions
+            .iter()
+            .filter(|v| v.yanked)
+            .map(|v| v.num.clone())
+            .collect();
+
+        // Check if latest version is yanked (kept for backwards compatibility)
         let yanked = crate_response.versions.first().is_some_and(|v| v.yanked);
 
         Ok(VersionInfo {
@@ -153,6 +161,7 @@ impl Registry for CratesIoRegistry {
             vulnerabilities: vec![], // Filled by OSV
             deprecated: false,       // Filled by OSV
             yanked,
+            yanked_versions,
         })
     }
 }

--- a/dependi-lsp/src/registries/go_proxy.rs
+++ b/dependi-lsp/src/registries/go_proxy.rs
@@ -84,6 +84,7 @@ impl Registry for GoProxyRegistry {
             vulnerabilities: vec![], // TODO: Integrate vuln.go.dev
             deprecated: false,
             yanked: false,
+            yanked_versions: vec![], // Not applicable to Go
         })
     }
 }

--- a/dependi-lsp/src/registries/npm.rs
+++ b/dependi-lsp/src/registries/npm.rs
@@ -176,6 +176,7 @@ impl Registry for NpmRegistry {
             vulnerabilities: vec![], // TODO: Integrate npm audit
             deprecated,
             yanked: false,
+            yanked_versions: vec![], // Not applicable to npm
         })
     }
 }

--- a/dependi-lsp/src/registries/nuget.rs
+++ b/dependi-lsp/src/registries/nuget.rs
@@ -165,6 +165,7 @@ impl Registry for NuGetRegistry {
             vulnerabilities: vec![], // Will be filled by OSV
             deprecated,
             yanked: false,
+            yanked_versions: vec![], // Not applicable to NuGet
         })
     }
 }

--- a/dependi-lsp/src/registries/packagist.rs
+++ b/dependi-lsp/src/registries/packagist.rs
@@ -133,6 +133,7 @@ impl Registry for PackagistRegistry {
             vulnerabilities: vec![], // TODO: Check PHP Security Advisories
             deprecated,
             yanked: false,
+            yanked_versions: vec![], // Not applicable to Packagist
         })
     }
 }

--- a/dependi-lsp/src/registries/pub_dev.rs
+++ b/dependi-lsp/src/registries/pub_dev.rs
@@ -105,6 +105,7 @@ impl Registry for PubDevRegistry {
             vulnerabilities: vec![], // Will be filled by OSV
             deprecated: pkg.latest.pubspec.discontinued,
             yanked: pkg.latest.retracted,
+            yanked_versions: vec![], // Not applicable to pub.dev
         })
     }
 }

--- a/dependi-lsp/src/registries/pypi.rs
+++ b/dependi-lsp/src/registries/pypi.rs
@@ -146,6 +146,7 @@ impl Registry for PyPiRegistry {
             vulnerabilities: vec![], // TODO: Integrate Safety/OSV
             deprecated,
             yanked: false,
+            yanked_versions: vec![], // Not applicable to PyPI
         })
     }
 }

--- a/dependi-lsp/src/registries/rubygems.rs
+++ b/dependi-lsp/src/registries/rubygems.rs
@@ -86,6 +86,7 @@ impl Registry for RubyGemsRegistry {
             vulnerabilities: vec![], // Will be filled by OSV
             deprecated: false,       // RubyGems doesn't have a deprecation flag in API
             yanked: false,
+            yanked_versions: vec![], // Not applicable to RubyGems
         })
     }
 }

--- a/dependi-lsp/tests/integration_test.rs
+++ b/dependi-lsp/tests/integration_test.rs
@@ -144,6 +144,7 @@ fn test_cache_integration() {
         vulnerabilities: vec![],
         deprecated: false,
         yanked: false,
+        yanked_versions: vec![],
     };
 
     cache.insert("crates:serde".to_string(), serde_info.clone());


### PR DESCRIPTION
## Summary

- Add yanked version warnings for Cargo dependencies with highest priority display
- Show `🚫 Yanked` inlay hint for yanked versions (or `🚫 Yanked -> X.Y.Z` when update available)
- Add diagnostic with WARNING severity explaining the yanked version issue
- Add helpful tooltips explaining what yanked means and recommended actions

## Screenshot

<img width="1186" height="39" alt="Capture d’écran du 2026-01-07 08-39-31" src="https://github.com/user-attachments/assets/545067ab-6cf1-4247-aa33-eb121c1bd073" />


## Changes

### Core Changes
- Added `yanked_versions: Vec<String>` field to `VersionInfo` to track all yanked version numbers
- Added `is_version_yanked()` method to check if a specific version is yanked
- Updated crates.io registry to populate yanked versions from API response

### Display Priority
Yanked warnings now have the highest priority:
1. **Yanked** (🚫 Yanked) - Critical issue
2. **Deprecated** (⚠ Deprecated) - Package-level warning
3. **Vulnerabilities** (⚠ N) - Security issues
4. **Update Available** (⬆ X.Y.Z) - Newer version exists

### Files Modified
- `registries/mod.rs` - Added yanked_versions field and is_version_yanked method
- `registries/crates_io.rs` - Populate yanked versions from API
- `providers/inlay_hints.rs` - Display yanked warning with tooltip
- `providers/diagnostics.rs` - Create yanked diagnostic
- All other registries - Added empty yanked_versions (Rust-specific feature)

## Test Plan
- [x] All 248 unit tests pass
- [x] All 7 integration tests pass
- [x] Clippy passes with no warnings
- [x] Code is properly formatted

Closes #39