### PR TITLE
feat: split Cache trait into ReadCache and WriteCache

### DIFF
--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -7,7 +7,7 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
 
-use crate::cache::HybridCache;
+use crate::cache::{HybridCache, ReadCache, WriteCache};
 use crate::config::Config;
 use crate::parsers::cargo::CargoParser;
 use crate::parsers::csharp::CsharpParser;

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use tower_lsp::lsp_types::*;
 
 use crate::backend::FileType;
-use crate::cache::Cache;
+use crate::cache::ReadCache;
 use crate::parsers::Dependency;
 use crate::providers::inlay_hints::{VersionStatus, compare_versions};
 
@@ -87,7 +87,7 @@ fn normalize_version(version: &str) -> String {
 /// Create code actions for dependencies in the given range
 pub fn create_code_actions(
     dependencies: &[Dependency],
-    cache: &impl Cache,
+    cache: &impl ReadCache,
     uri: &Url,
     range: Range,
     file_type: FileType,
@@ -111,7 +111,7 @@ pub fn create_code_actions(
 /// Create an "Update to X.Y.Z" code action for a dependency
 fn create_update_action(
     dep: &Dependency,
-    cache: &impl Cache,
+    cache: &impl ReadCache,
     uri: &Url,
     file_type: FileType,
     cache_key_fn: impl Fn(&str) -> String,
@@ -170,7 +170,7 @@ fn create_update_action(
 /// Create an "Update All Dependencies" code action when 2+ updates are available
 fn create_update_all_action(
     dependencies: &[Dependency],
-    cache: &impl Cache,
+    cache: &impl ReadCache,
     uri: &Url,
     file_type: FileType,
     cache_key_fn: impl Fn(&str) -> String,
@@ -272,7 +272,7 @@ fn format_version(version: &str, file_type: FileType) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::MemoryCache;
+    use crate::cache::{MemoryCache, WriteCache};
     use crate::registries::VersionInfo;
 
     fn create_test_dependency(name: &str, version: &str, line: u32) -> Dependency {

--- a/dependi-lsp/src/providers/completion.rs
+++ b/dependi-lsp/src/providers/completion.rs
@@ -3,7 +3,7 @@
 use chrono::{DateTime, Utc};
 use tower_lsp::lsp_types::*;
 
-use crate::cache::Cache;
+use crate::cache::ReadCache;
 use crate::parsers::Dependency;
 
 /// Format a release date as a human-readable age string
@@ -54,7 +54,7 @@ pub fn format_release_age(released_at: DateTime<Utc>) -> String {
 pub fn get_completions(
     dependencies: &[Dependency],
     position: Position,
-    cache: &impl Cache,
+    cache: &impl ReadCache,
     cache_key_fn: impl Fn(&str) -> String,
 ) -> Option<Vec<CompletionItem>> {
     // Find if we're inside a version field
@@ -136,7 +136,7 @@ pub fn get_completions(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::MemoryCache;
+    use crate::cache::{MemoryCache, WriteCache};
     use crate::registries::VersionInfo;
     use chrono::Duration;
     use std::collections::HashMap;

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -2,7 +2,7 @@
 
 use tower_lsp::lsp_types::*;
 
-use crate::cache::Cache;
+use crate::cache::ReadCache;
 use crate::parsers::Dependency;
 use crate::providers::inlay_hints::{VersionStatus, compare_versions, is_local_dependency};
 use crate::registries::{VersionInfo, Vulnerability, VulnerabilitySeverity};
@@ -13,7 +13,7 @@ use crate::registries::{VersionInfo, Vulnerability, VulnerabilitySeverity};
 /// at or above the specified severity level.
 pub fn create_diagnostics(
     dependencies: &[Dependency],
-    cache: &impl Cache,
+    cache: &impl ReadCache,
     cache_key_fn: impl Fn(&str) -> String,
     min_severity: Option<VulnerabilitySeverity>,
 ) -> Vec<Diagnostic> {
@@ -83,7 +83,7 @@ fn meets_severity_threshold(severity: &VulnerabilitySeverity, min: &Vulnerabilit
 /// Create a diagnostic for an outdated dependency
 fn create_outdated_diagnostic(
     dep: &Dependency,
-    cache: &impl Cache,
+    cache: &impl ReadCache,
     cache_key_fn: impl Fn(&str) -> String,
 ) -> Option<Diagnostic> {
     let cache_key = cache_key_fn(&dep.name);
@@ -351,7 +351,7 @@ fn truncate_string(s: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::MemoryCache;
+    use crate::cache::{MemoryCache, WriteCache};
     use crate::registries::VersionInfo;
 
     fn create_test_dependency(name: &str, version: &str, line: u32) -> Dependency {

--- a/dependi-lsp/tests/integration_test.rs
+++ b/dependi-lsp/tests/integration_test.rs
@@ -1,6 +1,6 @@
 //! Integration tests for dependi-lsp
 
-use dependi_lsp::cache::MemoryCache;
+use dependi_lsp::cache::{MemoryCache, ReadCache, WriteCache};
 use dependi_lsp::parsers::Parser;
 use dependi_lsp::parsers::cargo::CargoParser;
 use dependi_lsp::parsers::npm::NpmParser;


### PR DESCRIPTION
## Summary
- Split `Cache` trait into `ReadCache` and `WriteCache` following the interface segregation principle
- Providers now use `ReadCache` for read-only access, making dependencies explicit
- Add `contains()`, `remove()`, and `clear()` methods to the trait interface
- Maintain backwards compatibility with deprecated `Cache` alias

## Implementation Details
Implements **Option 2** from the issue - separate Read/Write traits:

### New Traits
- `ReadCache`: `get()` + `contains()` (default impl)
- `WriteCache`: extends `ReadCache` with `insert()`, `remove()`, `clear()`

### Updated Types
- `MemoryCache` - implements both traits
- `HybridCache` - implements both traits  
- `SqliteCache` - implements both traits
- `Arc<T>` - blanket implementations for both traits

### Provider Changes
- `diagnostics.rs` - uses `ReadCache`
- `code_actions.rs` - uses `ReadCache`
- `completion.rs` - uses `ReadCache`

## Test plan
- [x] `cargo test --lib` - 171 tests pass
- [x] `cargo test --test integration_test` - 7 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` - no warnings
- [x] `cargo fmt --all -- --check` - formatting OK

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal cache system architecture with improved trait-based design for better code organization and maintainability while maintaining backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->