### PR TITLE
refactor: extract truncate_string to shared utils module

### DIFF
--- a/dependi-lsp/src/lib.rs
+++ b/dependi-lsp/src/lib.rs
@@ -9,4 +9,5 @@ pub mod config;
 pub mod parsers;
 pub mod providers;
 pub mod registries;
+pub mod utils;
 pub mod vulnerabilities;

--- a/dependi-lsp/src/main.rs
+++ b/dependi-lsp/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod parsers;
 mod providers;
 mod registries;
+mod utils;
 mod vulnerabilities;
 
 use std::path::PathBuf;

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -6,6 +6,7 @@ use crate::cache::ReadCache;
 use crate::parsers::Dependency;
 use crate::providers::inlay_hints::{VersionStatus, compare_versions, is_local_dependency};
 use crate::registries::{VersionInfo, Vulnerability, VulnerabilitySeverity};
+use crate::utils::truncate_string;
 
 /// Create diagnostics for a list of dependencies
 ///
@@ -336,15 +337,6 @@ fn create_vulnerability_summary_diagnostic(
                 .and_then(|url| Url::parse(url).ok().map(|href| CodeDescription { href }))
         }),
         data: None,
-    }
-}
-
-/// Truncate a string to max length with ellipsis
-fn truncate_string(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
-        s.to_string()
-    } else {
-        format!("{}...", &s[..max_len.saturating_sub(3)])
     }
 }
 

--- a/dependi-lsp/src/providers/inlay_hints.rs
+++ b/dependi-lsp/src/providers/inlay_hints.rs
@@ -4,6 +4,7 @@ use tower_lsp::lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, Position};
 
 use crate::parsers::Dependency;
 use crate::registries::{VersionInfo, VulnerabilitySeverity};
+use crate::utils::truncate_string;
 
 /// Result of comparing a dependency version with the latest available
 #[derive(Debug, Clone)]
@@ -316,15 +317,6 @@ pub fn is_local_dependency(version: &str) -> bool {
         || version.starts_with("portal:")
         // npm aliases
         || version.starts_with("npm:")
-}
-
-/// Truncate a string to max length with ellipsis
-fn truncate_string(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
-        s.to_string()
-    } else {
-        format!("{}...", &s[..max_len.saturating_sub(3)])
-    }
 }
 
 /// Compare a dependency version with the latest available

--- a/dependi-lsp/src/utils.rs
+++ b/dependi-lsp/src/utils.rs
@@ -1,0 +1,83 @@
+//! Common utility functions used across the LSP implementation.
+
+/// Truncates a string to a maximum character count with ellipsis.
+///
+/// This function properly handles UTF-8 strings by counting characters,
+/// not bytes. If the string needs truncation, an ellipsis ("...") is
+/// appended and counted toward the maximum length.
+///
+/// # Arguments
+///
+/// * `s` - The string to truncate
+/// * `max_chars` - Maximum number of characters to display (including ellipsis)
+///
+/// # Returns
+///
+/// The truncated string, or the original string if it fits within `max_chars`.
+pub fn truncate_string(s: &str, max_chars: usize) -> String {
+    let char_count = s.chars().count();
+    if char_count <= max_chars {
+        return s.to_string();
+    }
+
+    let keep_chars = max_chars.saturating_sub(3);
+    let truncated: String = s.chars().take(keep_chars).collect();
+    format!("{}...", truncated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_truncation_needed() {
+        assert_eq!(truncate_string("hello", 10), "hello");
+        assert_eq!(truncate_string("", 10), "");
+        assert_eq!(truncate_string("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_ascii_truncation() {
+        assert_eq!(truncate_string("hello world", 8), "hello...");
+        assert_eq!(truncate_string("abcdefghij", 7), "abcd...");
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        assert_eq!(truncate_string("hello", 3), "...");
+        assert_eq!(truncate_string("hello", 4), "h...");
+        assert_eq!(truncate_string("ab", 1), "...");
+        assert_eq!(truncate_string("a", 0), "...");
+    }
+
+    #[test]
+    fn test_utf8_japanese() {
+        // "日本語" = 3 characters, 9 bytes
+        assert_eq!(truncate_string("日本語", 10), "日本語");
+        assert_eq!(truncate_string("日本語", 3), "日本語");
+        // "日本語test" = 7 characters
+        // truncate to 6 means keep 3 + "..." = 6 total
+        assert_eq!(truncate_string("日本語test", 6), "日本語...");
+        // 7 chars <= 8, so no truncation needed
+        assert_eq!(truncate_string("日本語test", 8), "日本語test");
+        // 7 chars <= 7, so no truncation needed
+        assert_eq!(truncate_string("日本語test", 7), "日本語test");
+        // truncate to 5 means keep 2 + "..." = 5
+        assert_eq!(truncate_string("日本語test", 5), "日本...");
+    }
+
+    #[test]
+    fn test_utf8_emoji() {
+        // "hello" = 5 characters, fits in 8
+        assert_eq!(truncate_string("hello", 8), "hello");
+        // "hello world" = 11 characters, truncate to 8 means keep 5 + "..."
+        let emoji_str = "hello world";
+        assert_eq!(truncate_string(emoji_str, 8), "hello...");
+    }
+
+    #[test]
+    fn test_mixed_content() {
+        assert_eq!(truncate_string("Hello 日本", 10), "Hello 日本");
+        assert_eq!(truncate_string("Hello 日本語 world", 12), "Hello 日本語...");
+    }
+}


### PR DESCRIPTION
## Summary

- Create new `utils.rs` module with UTF-8 safe `truncate_string` function
- Remove duplicate implementations from `diagnostics.rs` and `inlay_hints.rs`
- Fix potential panic on multi-byte UTF-8 characters by using `chars().count()` instead of byte length

## Changes

- **New file**: `dependi-lsp/src/utils.rs` - shared utility module with comprehensive tests
- **Modified**: `diagnostics.rs` - imports from utils module, removes local function
- **Modified**: `inlay_hints.rs` - imports from utils module, removes local function
- **Modified**: `lib.rs` and `main.rs` - add utils module declaration

## Test plan

- [x] All existing tests pass (`cargo test --lib`)
- [x] Clippy passes with no warnings
- [x] Format check passes

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate string truncation logic from multiple modules into a shared utility module for improved code maintainability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->