### PR TITLE
refactor: extract is_prerelease logic into shared version_utils module

### DIFF
--- a/dependi-lsp/src/registries/crates_io.rs
+++ b/dependi-lsp/src/registries/crates_io.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use tokio::sync::Mutex;
 
 use super::http_client::create_shared_client;
+use super::version_utils::is_prerelease_rust;
 use super::{Registry, VersionInfo};
 
 /// Rate limiter to respect crates.io's 1 request/second limit
@@ -149,7 +150,7 @@ impl Registry for CratesIoRegistry {
                 crate_response
                     .versions
                     .iter()
-                    .find(|v| !v.yanked && !is_prerelease(&v.num))
+                    .find(|v| !v.yanked && !is_prerelease_rust(&v.num))
                     .map(|v| v.num.clone())
             });
 
@@ -157,7 +158,7 @@ impl Registry for CratesIoRegistry {
         let latest_prerelease = crate_response
             .versions
             .iter()
-            .find(|v| !v.yanked && is_prerelease(&v.num))
+            .find(|v| !v.yanked && is_prerelease_rust(&v.num))
             .map(|v| v.num.clone());
 
         // Get all versions (not yanked)
@@ -215,23 +216,16 @@ impl Registry for CratesIoRegistry {
     }
 }
 
-fn is_prerelease(version: &str) -> bool {
-    version.contains('-')
-        || version.contains("alpha")
-        || version.contains("beta")
-        || version.contains("rc")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_is_prerelease() {
-        assert!(is_prerelease("1.0.0-alpha"));
-        assert!(is_prerelease("1.0.0-beta.1"));
-        assert!(is_prerelease("1.0.0-rc1"));
-        assert!(!is_prerelease("1.0.0"));
-        assert!(!is_prerelease("2.3.4"));
+        assert!(is_prerelease_rust("1.0.0-alpha"));
+        assert!(is_prerelease_rust("1.0.0-beta.1"));
+        assert!(is_prerelease_rust("1.0.0-rc1"));
+        assert!(!is_prerelease_rust("1.0.0"));
+        assert!(!is_prerelease_rust("2.3.4"));
     }
 }

--- a/dependi-lsp/src/registries/mod.rs
+++ b/dependi-lsp/src/registries/mod.rs
@@ -151,6 +151,7 @@ pub mod packagist;
 pub mod pub_dev;
 pub mod pypi;
 pub mod rubygems;
+pub mod version_utils;
 
 #[cfg(test)]
 mod tests {

--- a/dependi-lsp/src/registries/npm.rs
+++ b/dependi-lsp/src/registries/npm.rs
@@ -8,6 +8,7 @@ use reqwest::Client;
 use serde::Deserialize;
 
 use super::http_client::create_shared_client;
+use super::version_utils::is_prerelease_npm;
 use super::{Registry, VersionInfo};
 
 /// Client for the npm registry
@@ -178,7 +179,7 @@ impl Registry for NpmRegistry {
             .dist_tags
             .as_ref()
             .and_then(|t| t.next.clone())
-            .or_else(|| versions.iter().find(|v| is_prerelease(v)).cloned());
+            .or_else(|| versions.iter().find(|v| is_prerelease_npm(v)).cloned());
 
         // Check if latest version is deprecated
         let deprecated = pkg
@@ -224,27 +225,18 @@ impl Registry for NpmRegistry {
     }
 }
 
-fn is_prerelease(version: &str) -> bool {
-    version.contains('-')
-        || version.contains("alpha")
-        || version.contains("beta")
-        || version.contains("rc")
-        || version.contains("canary")
-        || version.contains("next")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_is_prerelease() {
-        assert!(is_prerelease("1.0.0-alpha"));
-        assert!(is_prerelease("1.0.0-beta.1"));
-        assert!(is_prerelease("1.0.0-rc.1"));
-        assert!(is_prerelease("18.3.0-canary"));
-        assert!(!is_prerelease("1.0.0"));
-        assert!(!is_prerelease("2.3.4"));
+        assert!(is_prerelease_npm("1.0.0-alpha"));
+        assert!(is_prerelease_npm("1.0.0-beta.1"));
+        assert!(is_prerelease_npm("1.0.0-rc.1"));
+        assert!(is_prerelease_npm("18.3.0-canary"));
+        assert!(!is_prerelease_npm("1.0.0"));
+        assert!(!is_prerelease_npm("2.3.4"));
     }
 
     #[test]

--- a/dependi-lsp/src/registries/nuget.rs
+++ b/dependi-lsp/src/registries/nuget.rs
@@ -8,6 +8,7 @@ use reqwest::Client;
 use serde::Deserialize;
 
 use super::http_client::create_shared_client;
+use super::version_utils::is_prerelease_nuget;
 use super::{Registry, VersionInfo};
 
 /// Client for the NuGet registry
@@ -165,10 +166,10 @@ impl Registry for NuGetRegistry {
             .collect();
 
         // Find latest stable version
-        let latest_stable = versions.iter().find(|v| !is_prerelease(v)).cloned();
+        let latest_stable = versions.iter().find(|v| !is_prerelease_nuget(v)).cloned();
 
         // Find latest prerelease
-        let latest_prerelease = versions.iter().find(|v| is_prerelease(v)).cloned();
+        let latest_prerelease = versions.iter().find(|v| is_prerelease_nuget(v)).cloned();
 
         // Get metadata from latest version
         let latest_entry = all_versions.first();
@@ -206,26 +207,18 @@ impl Registry for NuGetRegistry {
     }
 }
 
-fn is_prerelease(version: &str) -> bool {
-    version.contains('-')
-        || version.to_lowercase().contains("alpha")
-        || version.to_lowercase().contains("beta")
-        || version.to_lowercase().contains("preview")
-        || version.to_lowercase().contains("rc")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_is_prerelease() {
-        assert!(is_prerelease("1.0.0-alpha"));
-        assert!(is_prerelease("1.0.0-beta.1"));
-        assert!(is_prerelease("1.0.0-preview"));
-        assert!(is_prerelease("1.0.0-rc.1"));
-        assert!(is_prerelease("1.0.0-Alpha"));
-        assert!(!is_prerelease("1.0.0"));
-        assert!(!is_prerelease("2.0.0"));
+        assert!(is_prerelease_nuget("1.0.0-alpha"));
+        assert!(is_prerelease_nuget("1.0.0-beta.1"));
+        assert!(is_prerelease_nuget("1.0.0-preview"));
+        assert!(is_prerelease_nuget("1.0.0-rc.1"));
+        assert!(is_prerelease_nuget("1.0.0-Alpha"));
+        assert!(!is_prerelease_nuget("1.0.0"));
+        assert!(!is_prerelease_nuget("2.0.0"));
     }
 }

--- a/dependi-lsp/src/registries/packagist.rs
+++ b/dependi-lsp/src/registries/packagist.rs
@@ -8,6 +8,7 @@ use reqwest::Client;
 use serde::Deserialize;
 
 use super::http_client::create_shared_client;
+use super::version_utils::is_prerelease_php;
 use super::{Registry, VersionInfo};
 
 /// Client for the Packagist registry
@@ -123,10 +124,10 @@ impl Registry for PackagistRegistry {
         versions.sort_by(|a, b| compare_packagist_versions(b, a));
 
         // Find latest stable version
-        let latest_stable = versions.iter().find(|v| !is_prerelease(v)).cloned();
+        let latest_stable = versions.iter().find(|v| !is_prerelease_php(v)).cloned();
 
         // Find latest prerelease
-        let latest_prerelease = versions.iter().find(|v| is_prerelease(v)).cloned();
+        let latest_prerelease = versions.iter().find(|v| is_prerelease_php(v)).cloned();
 
         // Get metadata from first (latest) entry
         let latest_entry = entries.first();
@@ -179,16 +180,6 @@ impl Registry for PackagistRegistry {
 /// Check if a version is a dev version (e.g., dev-master, dev-main)
 fn is_dev_version(version: &str) -> bool {
     version.starts_with("dev-") || version.ends_with("-dev")
-}
-
-/// Check if a version is a prerelease
-fn is_prerelease(version: &str) -> bool {
-    let v = version.to_lowercase();
-    v.contains("alpha")
-        || v.contains("beta")
-        || v.contains("rc")
-        || v.contains("-rc")
-        || v.contains("dev")
 }
 
 /// Compare Packagist versions for sorting
@@ -261,12 +252,12 @@ mod tests {
 
     #[test]
     fn test_is_prerelease() {
-        assert!(is_prerelease("1.0.0-alpha"));
-        assert!(is_prerelease("1.0.0-beta.1"));
-        assert!(is_prerelease("1.0.0-RC1"));
-        assert!(is_prerelease("dev-master"));
-        assert!(!is_prerelease("1.0.0"));
-        assert!(!is_prerelease("v2.3.4"));
+        assert!(is_prerelease_php("1.0.0-alpha"));
+        assert!(is_prerelease_php("1.0.0-beta.1"));
+        assert!(is_prerelease_php("1.0.0-RC1"));
+        assert!(is_prerelease_php("dev-master"));
+        assert!(!is_prerelease_php("1.0.0"));
+        assert!(!is_prerelease_php("v2.3.4"));
     }
 
     #[test]

--- a/dependi-lsp/src/registries/pub_dev.rs
+++ b/dependi-lsp/src/registries/pub_dev.rs
@@ -8,6 +8,7 @@ use reqwest::Client;
 use serde::Deserialize;
 
 use super::http_client::create_shared_client;
+use super::version_utils::is_prerelease_dart;
 use super::{Registry, VersionInfo};
 
 /// Client for the pub.dev registry
@@ -109,12 +110,12 @@ impl Registry for PubDevRegistry {
         // Find latest stable version
         let latest_stable = versions
             .iter()
-            .find(|v| !is_prerelease(v))
+            .find(|v| !is_prerelease_dart(v))
             .cloned()
             .or_else(|| Some(pkg.latest.version.clone()));
 
         // Find latest prerelease
-        let latest_prerelease = versions.iter().find(|v| is_prerelease(v)).cloned();
+        let latest_prerelease = versions.iter().find(|v| is_prerelease_dart(v)).cloned();
 
         // Collect release dates
         let release_dates: HashMap<String, DateTime<Utc>> = pkg
@@ -146,25 +147,17 @@ impl Registry for PubDevRegistry {
     }
 }
 
-fn is_prerelease(version: &str) -> bool {
-    version.contains('-')
-        || version.contains("dev")
-        || version.contains("alpha")
-        || version.contains("beta")
-        || version.contains("rc")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_is_prerelease() {
-        assert!(is_prerelease("1.0.0-dev.1"));
-        assert!(is_prerelease("1.0.0-alpha"));
-        assert!(is_prerelease("1.0.0-beta.1"));
-        assert!(is_prerelease("1.0.0-rc.1"));
-        assert!(!is_prerelease("1.0.0"));
-        assert!(!is_prerelease("2.0.0"));
+        assert!(is_prerelease_dart("1.0.0-dev.1"));
+        assert!(is_prerelease_dart("1.0.0-alpha"));
+        assert!(is_prerelease_dart("1.0.0-beta.1"));
+        assert!(is_prerelease_dart("1.0.0-rc.1"));
+        assert!(!is_prerelease_dart("1.0.0"));
+        assert!(!is_prerelease_dart("2.0.0"));
     }
 }

--- a/dependi-lsp/src/registries/version_utils.rs
+++ b/dependi-lsp/src/registries/version_utils.rs
@@ -1,0 +1,172 @@
+//! Version parsing and comparison utilities for registry clients.
+//!
+//! This module provides common version-related functions used across
+//! different package registries, with support for registry-specific
+//! behavior where needed.
+
+/// Checks if a Rust crate version is a prerelease.
+///
+/// Uses semver-compatible prerelease detection. A version is considered
+/// a prerelease if it contains a hyphen (prerelease separator) or common
+/// prerelease identifiers.
+pub fn is_prerelease_rust(version: &str) -> bool {
+    let v = version.to_lowercase();
+    v.contains('-') || v.contains("alpha") || v.contains("beta") || v.contains("rc")
+}
+
+/// Checks if an npm package version is a prerelease.
+///
+/// npm-specific prerelease identifiers include `canary` and `next` tags
+/// in addition to common patterns.
+pub fn is_prerelease_npm(version: &str) -> bool {
+    let v = version.to_lowercase();
+    v.contains('-')
+        || v.contains("alpha")
+        || v.contains("beta")
+        || v.contains("rc")
+        || v.contains("canary")
+        || v.contains("next")
+}
+
+/// Checks if a PyPI package version is a prerelease.
+///
+/// Python-specific prerelease identifiers per PEP 440, including
+/// shorthand notation like `a1` for alpha and `b2` for beta.
+/// Note: Post-releases (`.postN`) are stable releases per PEP 440.
+pub fn is_prerelease_python(version: &str) -> bool {
+    let v = version.to_lowercase();
+    v.contains("dev")
+        || v.contains("alpha")
+        || v.contains("beta")
+        || v.contains("rc")
+        || (v.contains('a') && v.chars().last().is_some_and(|c| c.is_ascii_digit()))
+        || (v.contains('b') && v.chars().last().is_some_and(|c| c.is_ascii_digit()))
+        || v.contains(".dev")
+}
+
+/// Checks if a Go module version is a prerelease.
+///
+/// Go uses semver-like versions with hyphenated prerelease suffixes.
+pub fn is_prerelease_go(version: &str) -> bool {
+    let v = version.to_lowercase();
+    v.contains("-rc") || v.contains("-alpha") || v.contains("-beta") || v.contains("-pre")
+}
+
+/// Checks if a PHP Composer package version is a prerelease.
+///
+/// Composer-specific stability flags including `dev` and common
+/// prerelease identifiers.
+pub fn is_prerelease_php(version: &str) -> bool {
+    let v = version.to_lowercase();
+    v.contains("alpha")
+        || v.contains("beta")
+        || v.contains("rc")
+        || v.contains("-rc")
+        || v.contains("dev")
+}
+
+/// Checks if a Dart/Flutter package version is a prerelease.
+///
+/// Dart uses semver with hyphenated prerelease suffixes and common
+/// prerelease identifiers.
+pub fn is_prerelease_dart(version: &str) -> bool {
+    let v = version.to_lowercase();
+    v.contains('-')
+        || v.contains("dev")
+        || v.contains("alpha")
+        || v.contains("beta")
+        || v.contains("rc")
+}
+
+/// Checks if a NuGet package version is a prerelease.
+///
+/// NuGet-specific prerelease identifiers include `preview` in addition
+/// to common patterns.
+pub fn is_prerelease_nuget(version: &str) -> bool {
+    let v = version.to_lowercase();
+    v.contains('-')
+        || v.contains("alpha")
+        || v.contains("beta")
+        || v.contains("preview")
+        || v.contains("rc")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_prerelease_rust() {
+        assert!(is_prerelease_rust("1.0.0-alpha"));
+        assert!(is_prerelease_rust("1.0.0-beta.1"));
+        assert!(is_prerelease_rust("1.0.0-rc1"));
+        assert!(is_prerelease_rust("1.0.0-ALPHA"));
+        assert!(!is_prerelease_rust("1.0.0"));
+        assert!(!is_prerelease_rust("2.3.4"));
+    }
+
+    #[test]
+    fn test_is_prerelease_npm() {
+        assert!(is_prerelease_npm("1.0.0-alpha"));
+        assert!(is_prerelease_npm("1.0.0-beta.1"));
+        assert!(is_prerelease_npm("1.0.0-rc.1"));
+        assert!(is_prerelease_npm("18.3.0-canary"));
+        assert!(is_prerelease_npm("1.0.0-next.0"));
+        assert!(!is_prerelease_npm("1.0.0"));
+        assert!(!is_prerelease_npm("2.3.4"));
+    }
+
+    #[test]
+    fn test_is_prerelease_python() {
+        assert!(is_prerelease_python("1.0.0a1"));
+        assert!(is_prerelease_python("1.0.0b2"));
+        assert!(is_prerelease_python("1.0.0rc1"));
+        assert!(is_prerelease_python("1.0.0.dev1"));
+        assert!(is_prerelease_python("2.0.0alpha"));
+        assert!(is_prerelease_python("2.0.0beta"));
+        assert!(!is_prerelease_python("1.0.0.post1")); // post-releases are stable per PEP 440
+        assert!(!is_prerelease_python("1.0.0"));
+        assert!(!is_prerelease_python("2.3.4"));
+    }
+
+    #[test]
+    fn test_is_prerelease_go() {
+        assert!(is_prerelease_go("v1.0.0-rc1"));
+        assert!(is_prerelease_go("v2.0.0-beta.1"));
+        assert!(is_prerelease_go("v3.0.0-alpha"));
+        assert!(is_prerelease_go("v1.0.0-pre.1"));
+        assert!(!is_prerelease_go("v1.0.0"));
+        assert!(!is_prerelease_go("v2.3.4"));
+    }
+
+    #[test]
+    fn test_is_prerelease_php() {
+        assert!(is_prerelease_php("1.0.0-alpha"));
+        assert!(is_prerelease_php("1.0.0-beta.1"));
+        assert!(is_prerelease_php("1.0.0-RC1"));
+        assert!(is_prerelease_php("dev-master"));
+        assert!(!is_prerelease_php("1.0.0"));
+        assert!(!is_prerelease_php("v2.3.4"));
+    }
+
+    #[test]
+    fn test_is_prerelease_dart() {
+        assert!(is_prerelease_dart("1.0.0-dev.1"));
+        assert!(is_prerelease_dart("1.0.0-alpha"));
+        assert!(is_prerelease_dart("1.0.0-beta.1"));
+        assert!(is_prerelease_dart("1.0.0-rc.1"));
+        assert!(!is_prerelease_dart("1.0.0"));
+        assert!(!is_prerelease_dart("2.0.0"));
+    }
+
+    #[test]
+    fn test_is_prerelease_nuget() {
+        assert!(is_prerelease_nuget("1.0.0-alpha"));
+        assert!(is_prerelease_nuget("1.0.0-beta.1"));
+        assert!(is_prerelease_nuget("1.0.0-preview"));
+        assert!(is_prerelease_nuget("1.0.0-rc.1"));
+        assert!(is_prerelease_nuget("1.0.0-Alpha"));
+        assert!(!is_prerelease_nuget("1.0.0"));
+        assert!(!is_prerelease_nuget("2.0.0"));
+    }
+}


### PR DESCRIPTION
## Summary

- Create new `version_utils.rs` module with ecosystem-specific prerelease detection functions
- Consolidate duplicated `is_prerelease` implementations from 7 registry files
- Each registry now uses a dedicated function with ecosystem-specific patterns:
  - `is_prerelease_rust`: semver with hyphen, alpha, beta, rc
  - `is_prerelease_npm`: adds canary, next support
  - `is_prerelease_python`: PEP 440 patterns (a1, b2, .dev, .post)
  - `is_prerelease_go`: hyphenated prefixes (-rc, -alpha, -beta, -pre)
  - `is_prerelease_php`: composer stability flags including dev
  - `is_prerelease_dart`: semver with dev support
  - `is_prerelease_nuget`: adds preview support
- Add consistent case-insensitive matching across all functions

## Benefits

- Reduces code duplication by ~50 lines
- Single source of truth for prerelease detection
- Easier to maintain and test
- Consistent behavior across registries

Closes #27

## Test plan

- [x] All existing unit tests pass
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` check passes
- [x] New tests added in `version_utils.rs` for all functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and expanded prerelease detection with ecosystem-specific heuristics for Rust, npm, Python, Go, PHP, Dart, and NuGet; registries now use these shared utilities instead of local helpers.
* **Tests**
  * Updated and consolidated tests to validate the new ecosystem-specific prerelease detection across registries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->