### PR TITLE
fix: remove broken discussions links and Discord reference

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: Questions & Discussions
-    url: https://github.com/mpiton/zed-dependi/discussions
-    about: Ask questions and discuss ideas in GitHub Discussions
-  - name: Zed Discord
-    url: https://discord.gg/zed-industries
-    about: Join the Zed community on Discord

--- a/.github/workflows/contributor-experience.yml
+++ b/.github/workflows/contributor-experience.yml
@@ -64,7 +64,7 @@ A maintainer will review your PR soon. In the meantime, please make sure:
 - Your changes are documented if needed
 - You've filled out the PR template
 
-If you have any questions, feel free to ask here or in [GitHub Discussions](https://github.com/mpiton/zed-dependi/discussions).
+If you have any questions, feel free to ask here.
 
 Happy coding! 🚀`
             });
@@ -149,7 +149,7 @@ A maintainer will take a look as soon as possible.
 While you wait, you might find helpful information in:
 - [README](https://github.com/mpiton/zed-dependi#readme) - Features and configuration
 - [CONTRIBUTING.md](https://github.com/mpiton/zed-dependi/blob/main/CONTRIBUTING.md) - How to contribute
-- [Discussions](https://github.com/mpiton/zed-dependi/discussions) - Questions and ideas`
+- [Issues](https://github.com/mpiton/zed-dependi/issues) - Questions and bug reports`
             });
 
   auto-label-pr:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,8 +376,8 @@ By contributing to Dependi, you agree that your contributions will be licensed u
 
 ## Questions?
 
-- Open a GitHub Discussion for questions
-- Check existing issues and discussions first
+- Open a GitHub Issue for questions
+- Check existing issues first
 - Be specific and provide context
 
 Thank you for contributing to Dependi!


### PR DESCRIPTION
## Summary

Remove references to GitHub Discussions (not enabled for this repo) and Zed Discord.

## Changes

- Remove `config.yml` contact links (Discussions + Discord were 404/not applicable)
- Update `contributor-experience.yml` welcome messages to remove Discussions links
- Update `CONTRIBUTING.md` Questions section to reference Issues instead of Discussions

## Test plan

- [x] All links now point to valid URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines and issue templates to redirect questions and feedback to GitHub Issues instead of GitHub Discussions.
  * Modified first-time contributor welcome messages with streamlined guidance on where to ask questions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->