### PR TITLE
fix(ci): use correct path for dependi-lsp build and binary

### DIFF
--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -63,17 +63,19 @@ jobs:
         run: cargo install flamegraph
 
       - name: Build release binary
-        run: cargo build --release --package dependi-lsp
+        run: |
+          cd dependi-lsp
+          cargo build --release
 
       - name: Profile parse operations
         if: ${{ inputs.profile_type == 'all' || inputs.profile_type == 'parse' }}
         run: |
           echo "Profiling parse operations..."
           # Run without flamegraph in CI (perf may not work in containers)
-          ./target/release/dependi-lsp profile-parse \
+          ./dependi-lsp/target/release/dependi-lsp profile-parse \
             --file tests/fixtures/cargo_50_deps.toml \
             --iterations ${{ inputs.iterations_parse }}
-          ./target/release/dependi-lsp profile-parse \
+          ./dependi-lsp/target/release/dependi-lsp profile-parse \
             --file tests/fixtures/package_100_deps.json \
             --iterations ${{ inputs.iterations_parse }}
 
@@ -81,7 +83,7 @@ jobs:
         if: ${{ inputs.profile_type == 'all' || inputs.profile_type == 'registry' }}
         run: |
           echo "Profiling registry requests..."
-          ./target/release/dependi-lsp profile-registry \
+          ./dependi-lsp/target/release/dependi-lsp profile-registry \
             --registry npm \
             --packages "lodash,express,react" \
             --iterations ${{ inputs.iterations_registry }}
@@ -90,7 +92,7 @@ jobs:
         if: ${{ inputs.profile_type == 'all' || inputs.profile_type == 'full' }}
         run: |
           echo "Profiling full workflow..."
-          ./target/release/dependi-lsp profile-full \
+          ./dependi-lsp/target/release/dependi-lsp profile-full \
             --file tests/fixtures/package_100_deps.json \
             --iterations ${{ inputs.iterations_full }}
 


### PR DESCRIPTION
## Summary

Fix the profile workflow that was failing because:
- `cargo build` ran from repo root but `Cargo.toml` is in `dependi-lsp/`
- Binary path was `./target/release/` but it's `./dependi-lsp/target/release/`

## Changes
- Build step now runs `cd dependi-lsp && cargo build --release`
- Binary paths updated to `./dependi-lsp/target/release/dependi-lsp`

## Test Plan
- [ ] CI workflow passes

Fixes failed run: https://github.com/mpiton/zed-dependi/actions/runs/20879327685