### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-01-10
+
 ### Added
 
 - Comprehensive private registry configuration documentation
@@ -19,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Troubleshooting guide and FAQ section
 - Comprehensive registry API documentation
 - CI/CD integration documentation for CLI scan command
+- Benchmark suite with criterion for performance testing
+- Fuzz testing for parsers with cargo-fuzz
+- GitHub Pages documentation site
 
 ### Changed
 
@@ -32,10 +37,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Share single HTTP client across all registry clients
 - Rewrite CargoParser with taplo for structured TOML parsing
 - Remove #[allow(dead_code)] directives and fix warnings
+- Optimize parsing performance for Go, npm, PHP, and Ruby dependency files
 
 ### Fixed
 
 - Remove broken discussions links and Zed Discord reference
+- Fix YAML syntax error in contributor-experience workflow
+- Fix CI paths for dependi-lsp build and binary
+- Prevent overflow in profiling and cap network iterations
+- Improve profiling command safety and accuracy
+- Improve test accuracy and prevent over-stripping in parsers
 
 ### Security
 
@@ -135,7 +146,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory caching for version data
 - Parallel registry requests (5 concurrent)
 
-[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/mpiton/zed-dependi/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/mpiton/zed-dependi/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/mpiton/zed-dependi/compare/v0.3.1...v1.0.0
 [0.3.1]: https://github.com/mpiton/zed-dependi/compare/v0.3.0...v0.3.1

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-lsp"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-lsp"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 license = "MIT"
 description = "Language server for dependency management in Zed"

--- a/dependi-zed/Cargo.lock
+++ b/dependi-zed/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-zed"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "hex",
  "sha2",

--- a/dependi-zed/Cargo.toml
+++ b/dependi-zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-zed"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 license = "MIT"
 description = "Zed extension for dependency management"


### PR DESCRIPTION
## Summary

Release v1.2.0 with major updates:
- Private npm registry support with authentication tokens and scope-based routing
- Performance improvements: lazy vulnerability loading, debounced notifications, parsing optimizations
- Architecture refactoring: split backend.rs into modules, SQLite WAL mode, shared HTTP client
- Quality improvements: benchmark suite, fuzz testing, test coverage infrastructure
- Documentation: GitHub Pages site, CONTRIBUTING.md, troubleshooting guide

## Changes

### Added
- Authentication token support for private npm registries
- Custom registry configuration with scope-based routing
- SHA256 checksum verification for LSP binary downloads
- Benchmark suite with criterion
- Fuzz testing for parsers
- GitHub Pages documentation site
- CONTRIBUTING.md, troubleshooting guide, registry API docs

### Changed
- Lazy load vulnerability checks in background
- Debounce didChange notifications
- Split backend.rs into domain-specific modules
- Enable SQLite WAL mode and r2d2 connection pooling
- Rewrite CargoParser with taplo
- Optimize parsing for Go, npm, PHP, Ruby files

### Fixed
- CI paths for dependi-lsp build
- Profiling safety and accuracy
- Test accuracy and parser stripping issues

### Security
- Background cache cleanup to prevent memory growth

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test --lib` passes (287 tests)
- [x] `cargo clippy -- -D warnings` passes

After merge, create and push tag `v1.2.0` to trigger release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive benchmark suite and fuzz testing capabilities

* **Bug Fixes**
  * Fixed YAML syntax errors and CI path configurations
  * Enhanced profiling safeguards and improved test accuracy

* **Changed**
  * Implemented performance optimizations
  * Applied security updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->