### PR TITLE
chore: release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-01-25
+
+### Added
+
+- Workspace dependencies parsing for Cargo.toml (#114)
+
+### Fixed
+
+- Python pyproject.toml parser panics by switching to taplo for TOML parsing
+- Python pyproject.toml detection for `[project.*]` subsections and inline comments
+- Fuzz testing crashes in parsers (#115)
+
+### Changed
+
+- Updated chrono from 0.4.42 to 0.4.43
+- Updated thiserror from 2.0.17 to 2.0.18
+
 ## [1.2.0] - 2026-01-10
 
 ### Added
@@ -146,7 +163,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory caching for version data
 - Parallel registry requests (5 concurrent)
 
-[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/mpiton/zed-dependi/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/mpiton/zed-dependi/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/mpiton/zed-dependi/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/mpiton/zed-dependi/compare/v0.3.1...v1.0.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Dependency management extension for the [Zed](https://zed.dev) editor.
 
-**Version:** 1.2.0
+**Version:** 1.3.0
 
 ![Demo](docs/demo.gif)
 

--- a/dependi-zed/extension.toml
+++ b/dependi-zed/extension.toml
@@ -1,7 +1,7 @@
 id = "dependi"
 name = "Dependi"
 description = "Dependency management for Zed - version hints, updates, and vulnerability detection"
-version = "1.2.0"
+version = "1.3.0"
 schema_version = 1
 authors = ["Mathieu Piton"]
 repository = "https://github.com/mpiton/zed-dependi"


### PR DESCRIPTION
## Summary

Release v1.3.0 with the following changes:

### Added
- Workspace dependencies parsing for Cargo.toml (#114)

### Fixed
- Python pyproject.toml parser panics by switching to taplo for TOML parsing
- Python pyproject.toml detection for `[project.*]` subsections and inline comments
- Fuzz testing crashes in parsers (#115)

### Changed
- Updated chrono from 0.4.42 to 0.4.43
- Updated thiserror from 2.0.17 to 2.0.18

## Checklist
- [x] CHANGELOG.md updated
- [x] README.md version updated
- [x] extension.toml version updated

## After merge
Create and push the tag:
```bash
git tag -a v1.3.0 -m "Release v1.3.0"
git push origin v1.3.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing workspace dependencies in Cargo.toml files.

* **Bug Fixes**
  * Fixed parsing panic when processing Python pyproject.toml files.
  * Improved detection of project subsections and inline comments in pyproject.toml.
  * Resolved fuzz testing crashes in parsers for improved stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->