### PR TITLE
fix: update Cargo.toml versions to 1.3.0

### DIFF
--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-lsp"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-lsp"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 license = "MIT"
 description = "Language server for dependency management in Zed"

--- a/dependi-zed/Cargo.lock
+++ b/dependi-zed/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-zed"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "hex",
  "sha2",

--- a/dependi-zed/Cargo.toml
+++ b/dependi-zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-zed"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 license = "MIT"
 description = "Zed extension for dependency management"


### PR DESCRIPTION
## Summary

Updates the version in both `Cargo.toml` files that were missed during the v1.3.0 release.

- `dependi-lsp/Cargo.toml`: 1.2.0 → 1.3.0
- `dependi-zed/Cargo.toml`: 1.2.0 → 1.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 1.3.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->