### PR TITLE
chore: release v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-01-31
+
+### Fixed
+
+- pub.dev registry now returns newest version as latest instead of oldest
+
 ## [1.3.1] - 2026-01-25
 
 ### Fixed
@@ -169,7 +175,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory caching for version data
 - Parallel registry requests (5 concurrent)
 
-[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.3.1...HEAD
+[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.3.2...HEAD
+[1.3.2]: https://github.com/mpiton/zed-dependi/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/mpiton/zed-dependi/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/mpiton/zed-dependi/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/mpiton/zed-dependi/compare/v1.1.0...v1.2.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Dependency management extension for the [Zed](https://zed.dev) editor.
 
-**Version:** 1.3.1
+**Version:** 1.3.2
 
 ![Demo](docs/demo.gif)
 

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-lsp"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-lsp"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2024"
 license = "MIT"
 description = "Language server for dependency management in Zed"

--- a/dependi-lsp/fuzz/Cargo.lock
+++ b/dependi-lsp/fuzz/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-lsp"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/dependi-zed/Cargo.lock
+++ b/dependi-zed/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-zed"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "hex",
  "sha2",

--- a/dependi-zed/Cargo.toml
+++ b/dependi-zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-zed"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2024"
 license = "MIT"
 description = "Zed extension for dependency management"

--- a/dependi-zed/extension.toml
+++ b/dependi-zed/extension.toml
@@ -1,7 +1,7 @@
 id = "dependi"
 name = "Dependi"
 description = "Dependency management for Zed - version hints, updates, and vulnerability detection"
-version = "1.3.1"
+version = "1.3.2"
 schema_version = 1
 authors = ["Mathieu Piton"]
 repository = "https://github.com/mpiton/zed-dependi"


### PR DESCRIPTION
## Summary

- Fix pub.dev registry returning oldest version as latest instead of newest
- Update all version references from 1.3.1 to 1.3.2

## Changes since v1.3.1

| Commit | Description |
|--------|-------------|
| faab910 | fix: pub.dev registry now returns newest version as latest |
| 1e1e3c9 | Add docstrings to pub.dev registry |
| 48a23bf | fix: add ignore attribute to doctest to prevent CI failure |

## Files Updated

- `CHANGELOG.md` - Added v1.3.2 section
- `dependi-zed/Cargo.toml` - Version bump
- `dependi-zed/extension.toml` - Version bump
- `dependi-lsp/Cargo.toml` - Version bump
- `README.md` - Version badge
- 3× `Cargo.lock` files - Auto-updated

## Test Plan

- [ ] CI passes
- [ ] Manual testing of pub.dev packages shows correct latest version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pub.dev registry handling to correctly identify and return the newest version as latest.

* **Chores**
  * Version bumped to 1.3.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->