### PR TITLE
fix(deps): bump bytes 1.11.0 → 1.11.1 — fix integer overflow in BytesMut::reserve

### DIFF
--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -189,9 +189,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"

--- a/dependi-lsp/fuzz/Cargo.lock
+++ b/dependi-lsp/fuzz/Cargo.lock
@@ -180,9 +180,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
## Summary

- Bumps `bytes` from 1.11.0 to 1.11.1 in both `dependi-lsp/Cargo.lock` and `dependi-lsp/fuzz/Cargo.lock`
- Fixes **integer overflow in `BytesMut::reserve`** (medium severity security vulnerability)
- `bytes` is a transitive dependency (via `tokio` and `reqwest`) — no source code changes needed

## Security

Resolves Dependabot security alerts **`#3`** and **`#4`**.
Supersedes Dependabot PRs **#126** and **#127** (can be closed after merge).

## Verification

- [x] `cargo build --release` — passes
- [x] `cargo test --lib` — 293 passed, 0 failed
- [x] `cargo test --test integration_test` — 7 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] No breaking changes (lock-file only, patch version bump)
- [x] No `BytesMut` usage in codebase (transitive dependency only)

## Test plan

- [x] Verify CI passes
- [ ] After merge, confirm Dependabot alerts `#3 `and `#4` are resolved
- [ ] Close Dependabot PRs #126 and #127