### PR TITLE
deps(rust): bump clap from 4.5.54 to 4.5.57

### DIFF
--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -33,7 +33,7 @@ r2d2_sqlite = "0.32"
 dirs = "6"
 serde_yaml = "0.9.34"
 chrono = { version = "0.4.43", features = ["serde"] }
-clap = { version = "4.5.54", features = ["derive"] }
+clap = { version = "4.5.57", features = ["derive"] }
 futures = "0.3.31"
 taplo = "0.14"
 


### PR DESCRIPTION
## Summary

- Bumps `clap` from 4.5.54 to 4.5.57 (and `clap_builder` 4.5.54→4.5.57, `clap_derive` 4.5.49→4.5.55)
- Patch-level update for the CLI argument parser — no API changes
- Supersedes Dependabot PR #125 (which targeted 4.5.56, but 4.5.57 is now available)

## Verification

- [x] `cargo build --release` — passes
- [x] `cargo test --lib` — 293 passed, 0 failed
- [x] `cargo test --test integration_test` — 7 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] No breaking changes (patch version bump)

## Test plan

- [x] Verify CI passes
- [ ] After merge, close Dependabot PR #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to a newer patch version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->