### PR TITLE
chore: release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-02-04
+
+### Security
+
+- Bump `bytes` from 1.11.0 to 1.11.1 (fix integer overflow in `BytesMut::reserve`)
+
+### Changed
+
+- Bump `clap` from 4.5.54 to 4.5.57
+
 ## [1.3.2] - 2026-01-31
 
 ### Fixed
@@ -175,7 +185,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory caching for version data
 - Parallel registry requests (5 concurrent)
 
-[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.3.2...HEAD
+[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.3.3...HEAD
+[1.3.3]: https://github.com/mpiton/zed-dependi/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/mpiton/zed-dependi/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/mpiton/zed-dependi/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/mpiton/zed-dependi/compare/v1.2.0...v1.3.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Dependency management extension for the [Zed](https://zed.dev) editor.
 
-**Version:** 1.3.2
+**Version:** 1.3.3
 
 ![Demo](docs/demo.gif)
 

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-lsp"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-lsp"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2024"
 license = "MIT"
 description = "Language server for dependency management in Zed"

--- a/dependi-lsp/fuzz/Cargo.lock
+++ b/dependi-lsp/fuzz/Cargo.lock
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-lsp"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/dependi-zed/Cargo.lock
+++ b/dependi-zed/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-zed"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "hex",
  "sha2",

--- a/dependi-zed/Cargo.toml
+++ b/dependi-zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-zed"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2024"
 license = "MIT"
 description = "Zed extension for dependency management"

--- a/dependi-zed/extension.toml
+++ b/dependi-zed/extension.toml
@@ -1,7 +1,7 @@
 id = "dependi"
 name = "Dependi"
 description = "Dependency management for Zed - version hints, updates, and vulnerability detection"
-version = "1.3.2"
+version = "1.3.3"
 schema_version = 1
 authors = ["Mathieu Piton"]
 repository = "https://github.com/mpiton/zed-dependi"


### PR DESCRIPTION
## Summary

Patch release v1.3.3 with dependency updates and a security fix.

### Security
- Bump `bytes` 1.11.0 → 1.11.1 — fixes integer overflow in `BytesMut::reserve` (medium severity)

### Changed
- Bump `clap` 4.5.54 → 4.5.57

### Version bumps
- `dependi-lsp/Cargo.toml` → 1.3.3
- `dependi-zed/Cargo.toml` → 1.3.3
- `dependi-zed/extension.toml` → 1.3.3
- `README.md` → 1.3.3
- `CHANGELOG.md` → new 1.3.3 entry
- All `Cargo.lock` files updated

## Verification

- [x] `cargo build --release` — passes
- [x] `cargo test --lib` — 293 passed, 0 failed
- [x] `cargo test --test integration_test` — 7 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] No remaining 1.3.2 references (except bitflags crate and changelog history)

## Post-merge

1. Tag `v1.3.3` and create GitHub release
2. Submit to zed/extensions via fork
3. Close Dependabot PRs #125, #126, #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated bytes dependency.

* **Changed**
  * Updated clap dependency.

* **Chores**
  * Released version 1.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->