### PR TITLE
chore: release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-02-09
+
 ### Added
 
 - Cargo alternative registry support for private registries (Kellnr, Cloudsmith, Artifactory, etc.) (#133)
@@ -204,7 +206,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory caching for version data
 - Parallel registry requests (5 concurrent)
 
-[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.3.3...HEAD
+[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/mpiton/zed-dependi/compare/v1.3.3...v1.4.0
 [1.3.3]: https://github.com/mpiton/zed-dependi/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/mpiton/zed-dependi/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/mpiton/zed-dependi/compare/v1.3.0...v1.3.1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Dependency management extension for the [Zed](https://zed.dev) editor.
 
-**Version:** 1.3.3
+**Version:** 1.4.0
 
 ![Demo](docs/demo.gif)
 

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-lsp"
-version = "1.3.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-lsp"
-version = "1.3.3"
+version = "1.4.0"
 edition = "2024"
 license = "MIT"
 description = "Language server for dependency management in Zed"

--- a/dependi-lsp/fuzz/Cargo.lock
+++ b/dependi-lsp/fuzz/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-lsp"
-version = "1.3.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/dependi-zed/Cargo.lock
+++ b/dependi-zed/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-zed"
-version = "1.3.3"
+version = "1.4.0"
 dependencies = [
  "hex",
  "sha2",

--- a/dependi-zed/Cargo.toml
+++ b/dependi-zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-zed"
-version = "1.3.3"
+version = "1.4.0"
 edition = "2024"
 license = "MIT"
 description = "Zed extension for dependency management"

--- a/dependi-zed/extension.toml
+++ b/dependi-zed/extension.toml
@@ -1,7 +1,7 @@
 id = "dependi"
 name = "Dependi"
 description = "Dependency management for Zed - version hints, updates, and vulnerability detection"
-version = "1.3.3"
+version = "1.4.0"
 schema_version = 1
 authors = ["Mathieu Piton"]
 repository = "https://github.com/mpiton/zed-dependi"


### PR DESCRIPTION
## Summary

Release v1.4.0 with Cargo alternative registry support and dependency updates.

## Changes

### Added
- Cargo alternative registry support for private registries (Kellnr, Cloudsmith, Artifactory, etc.) (#133)
  - Sparse index protocol implementation
  - Per-dependency registry routing via `registry` field
  - Authentication via LSP configuration or `~/.cargo/credentials.toml` fallback
  - Registry-scoped cache keys
  - Cross-platform `CARGO_HOME` resolution

### Changed
- Bump `anyhow` from 1.0.100 to 1.0.101
- Bump `criterion` from 0.8.1 to 0.8.2
- Update 52 transitive dependencies via cargo update

### Removed
- Remove unused `serde_yaml` dependency (deprecated since March 2024, never imported)

## Version Bump
- All version references updated: 1.3.3 → 1.4.0
- Files updated: `dependi-lsp/Cargo.toml`, `dependi-zed/Cargo.toml`, `dependi-zed/extension.toml`, `README.md`, `CHANGELOG.md`
- Lock files regenerated: `dependi-lsp/Cargo.lock`, `dependi-zed/Cargo.lock`, `dependi-lsp/fuzz/Cargo.lock`

## Validation
- [x] `cargo fmt --check` - OK
- [x] `cargo clippy -- -D warnings` - 0 warnings
- [x] `cargo test --lib` - 305 tests passed
- [x] `cargo test --test integration_test` - 7 tests passed
- [x] `cargo build --release` - OK
- [x] Adversarial code review - 0 findings