### PR TITLE
ci: grant checks:write permission to security-audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
 
   security-audit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Add `checks: write` permission to the `security-audit` job so `rustsec/audit-check@v2` can post check run results on PRs

## Context

The security-audit job was failing with:
```
Resource not accessible by integration - https://docs.github.com/rest/checks/runs#create-a-check-run
```

The workflow-level permission only grants `contents: read`. The audit action needs `checks: write` to create check runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow permissions to improve security and job authorization scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->