### PR TITLE
fix: disable ANSI escape sequences in LSP log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Disable ANSI escape sequences in LSP log output (#162)
+
 ## [1.4.3] - 2026-02-24
 
 ### Fixed

--- a/dependi-lsp/src/main.rs
+++ b/dependi-lsp/src/main.rs
@@ -102,7 +102,11 @@ async fn main() -> ExitCode {
     // Initialize tracing
     tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
-        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(std::io::stderr),
+        )
         .init();
 
     match cli.command {


### PR DESCRIPTION
## Summary

- Disable ANSI color codes in tracing subscriber output to prevent raw escape sequences (`^[[2m`, `^[[32m`, etc.) from appearing in editor log panels

Closes #162

## Changes

- `dependi-lsp/src/main.rs`: Add `.with_ansi(false)` to the `tracing_subscriber::fmt` layer
- `CHANGELOG.md`: Add entry under `[Unreleased]`

## Test plan

- [x] Release build successful
- [x] 322 unit tests passed (1 ignored)
- [x] Clippy: no warnings
- [x] Format check: clean
- [x] Fuzz testing: ~475k runs across Python and Cargo parsers, zero crashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LSP log output by disabling ANSI escape sequences. This prevents unwanted formatting characters from appearing in logs, ensuring clean, readable output in all environments. Logs now display correctly whether viewed in terminals, text editors, or processed by external tools, improving compatibility with various log analysis systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->