### PR TITLE
chore: consolidate CI dependency upgrades and bump Cargo packages

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,7 +48,7 @@ jobs:
             --timeout 300
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage/

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -82,14 +82,14 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: fuzz-crashes-${{ matrix.target }}
           path: dependi-lsp/fuzz/artifacts/
           retention-days: 30
 
       - name: Upload corpus
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: fuzz-corpus-${{ matrix.target }}
           path: dependi-lsp/fuzz/corpus/fuzz_${{ matrix.target }}/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload artifact (Unix)
         if: matrix.os != 'windows-latest'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset_name }}
           path: |
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload artifact (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset_name }}
           path: |
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Disable ANSI escape sequences in LSP log output (#162)
 
+### Changed
+
+- Bump `actions/upload-artifact` from v6 to v7
+- Bump `actions/download-artifact` from v7 to v8
+- Bump `tokio` from 1.49 to 1.50
+- Bump `toml` from 1.0.3 to 1.0.4
+
 ## [1.4.3] - 2026-02-24
 
 ### Fixed

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -2127,9 +2127,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2178,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.3+spec-1.1.0"
+version = "1.0.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+checksum = "c94c3321114413476740df133f0d8862c61d87c8d26f04c6841e033c8c80db47"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -17,12 +17,12 @@ path = "src/main.rs"
 
 [dependencies]
 tower-lsp = "0.20"
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.50", features = ["full"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 reqwest = { version = "0.12.28", features = ["json", "rustls-tls"], default-features = false }
 dashmap = "6.1"
-toml = "1.0.3"
+toml = "1.0.4"
 semver = "1.0.27"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }


### PR DESCRIPTION
## Summary

Consolidates the changes from Dependabot PRs #160 and #161 into a single PR, and adds safe Cargo dependency bumps.

## Changes

### GitHub Actions
- Bump `actions/upload-artifact` from v6 to v7 (release, coverage, fuzz workflows)
- Bump `actions/download-artifact` from v7 to v8 (release workflow)

### Cargo dependencies
- Bump `tokio` from 1.49 to 1.50 (minor)
- Bump `toml` from 1.0.3 to 1.0.4 (patch)

### Excluded
- `reqwest` 0.12 → 0.13: breaking change (`rustls-tls` feature obsoleted), requires separate migration

## Compatibility notes

- `upload-artifact` v7 and `download-artifact` v8 are designed to work together (see [GitHub blog post](https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts))
- Default behavior unchanged (archives still zipped by default)
- v8 download-artifact enforces digest checks by default (security improvement)

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo test --lib` — 322 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — formatted

Closes #160, closes #161.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions artifact upload/download actions to latest versions across all workflows
  * Bumped runtime dependencies (tokio, toml) to latest stable versions for maintenance and performance improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->