### PR TITLE
chore: release v1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.4] - 2026-03-05
+
 ### Fixed
 
 - Disable ANSI escape sequences in LSP log output (#162)
@@ -252,7 +254,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory caching for version data
 - Parallel registry requests (5 concurrent)
 
-[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.4.3...HEAD
+[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.4.4...HEAD
+[1.4.4]: https://github.com/mpiton/zed-dependi/compare/v1.4.3...v1.4.4
 [1.4.3]: https://github.com/mpiton/zed-dependi/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/mpiton/zed-dependi/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/mpiton/zed-dependi/compare/v1.4.0...v1.4.1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Dependency management extension for the [Zed](https://zed.dev) editor.
 
-**Version:** 1.4.3
+**Version:** 1.4.4
 
 ![Demo](docs/demo.gif)
 

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-lsp"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-lsp"
-version = "1.4.3"
+version = "1.4.4"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/dependi-lsp/fuzz/Cargo.lock
+++ b/dependi-lsp/fuzz/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-lsp"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1897,9 +1897,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -1948,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.3+spec-1.1.0"
+version = "1.0.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+checksum = "c94c3321114413476740df133f0d8862c61d87c8d26f04c6841e033c8c80db47"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/dependi-zed/Cargo.lock
+++ b/dependi-zed/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-zed"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "hex",
  "sha2",

--- a/dependi-zed/Cargo.toml
+++ b/dependi-zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-zed"
-version = "1.4.3"
+version = "1.4.4"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/dependi-zed/extension.toml
+++ b/dependi-zed/extension.toml
@@ -1,7 +1,7 @@
 id = "dependi"
 name = "Dependi"
 description = "Dependency management for Zed - version hints, updates, and vulnerability detection"
-version = "1.4.3"
+version = "1.4.4"
 schema_version = 1
 authors = ["Mathieu Piton"]
 repository = "https://github.com/mpiton/zed-dependi"


### PR DESCRIPTION
## Summary

Release v1.4.4 with version bumps across all crates and manifests.

## Changes included in this release

### Fixed
- Disable ANSI escape sequences in LSP log output (#162)

### Changed
- Bump `actions/upload-artifact` from v6 to v7
- Bump `actions/download-artifact` from v7 to v8
- Bump `tokio` from 1.49 to 1.50
- Bump `toml` from 1.0.3 to 1.0.4

## Version bumps (1.4.3 → 1.4.4)
- `dependi-lsp/Cargo.toml`
- `dependi-zed/Cargo.toml`
- `dependi-zed/extension.toml`
- `README.md`
- `CHANGELOG.md`
- All `Cargo.lock` files regenerated

## Test plan
- [x] `cargo build --release` — compiles as v1.4.4
- [x] `cargo test --lib` — 322 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — formatted
- [x] No remaining `1.4.3` references outside CHANGELOG history

## Post-merge
After merging, tag with `v1.4.4` to trigger the release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ANSI escape sequences appearing in LSP log output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->