### PR TITLE
fix: normalize version operators before OSV queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix false-positive vulnerability reports by normalizing version operators before OSV.dev queries ([#181](https://github.com/mpiton/zed-dependi/issues/181))
+
 ## [1.5.0] - 2026-03-16
 
 ### Added

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -39,9 +39,9 @@ use crate::registries::pypi::PyPiRegistry;
 use crate::registries::rubygems::RubyGemsRegistry;
 use crate::registries::{Registry, VersionInfo, VulnerabilitySeverity};
 use crate::reports::{VulnerabilityReportEntry, VulnerabilitySummary, generate_markdown_report};
-use crate::vulnerabilities::VulnerabilityQuery;
 use crate::vulnerabilities::cache::VulnerabilityCache;
 use crate::vulnerabilities::osv::OsvClient;
+use crate::vulnerabilities::{VulnerabilityQuery, normalize_version_for_osv};
 
 /// Compute cache key for a dependency, including registry for Cargo alternative registries.
 ///
@@ -504,13 +504,14 @@ impl DependiBackend {
         let queries: Vec<VulnerabilityQuery> = dependencies
             .iter()
             .filter(|dep| {
-                let vuln_key = VulnCacheKey::new(ecosystem, &dep.name, &dep.version);
+                let normalized_version = normalize_version_for_osv(&dep.version);
+                let vuln_key = VulnCacheKey::new(ecosystem, &dep.name, &normalized_version);
                 !vuln_cache.contains(&vuln_key)
             })
             .map(|dep| VulnerabilityQuery {
                 ecosystem,
                 package_name: dep.name.clone(),
-                version: dep.version.clone(),
+                version: normalize_version_for_osv(&dep.version),
             })
             .collect();
 

--- a/dependi-lsp/src/vulnerabilities/mod.rs
+++ b/dependi-lsp/src/vulnerabilities/mod.rs
@@ -53,3 +53,133 @@ pub struct VulnerabilityQuery {
     /// Target ecosystem
     pub ecosystem: Ecosystem,
 }
+
+/// Normalize a version string for use with the OSV.dev API.
+///
+/// Strips version operators (e.g. `>=`, `^`, `~`) and prefixes (e.g. `v`)
+/// so that OSV receives a bare version number like `1.23.0`.
+///
+/// If normalization would produce an empty string (e.g. operator-only input),
+/// the original trimmed input is returned unchanged.
+pub(crate) fn normalize_version_for_osv(version: &str) -> String {
+    // Step 1: trim surrounding whitespace
+    let trimmed = version.trim();
+
+    if trimmed.is_empty() {
+        return trimmed.to_string();
+    }
+
+    // Step 2: handle comma-separated constraints — take only the first part
+    let part = match trimmed.split(',').next() {
+        Some(v) => v.trim(),
+        None => trimmed,
+    };
+
+    // Step 3: strip version operators (longest first to avoid partial matches)
+    let operators = [
+        "===", "==", ">=", "<=", "!=", "~=", "~>", "^", "~", ">", "<", "=",
+    ];
+    let stripped = {
+        let mut v = part;
+        for op in &operators {
+            if let Some(s) = v.strip_prefix(op) {
+                v = s;
+                break;
+            }
+        }
+        v
+    };
+
+    // Step 4: strip 'v' or 'V' prefix only if followed by a digit (Go versions)
+    let result = if stripped.starts_with('v') || stripped.starts_with('V') {
+        let rest = &stripped[1..];
+        if rest.starts_with(|c: char| c.is_ascii_digit()) {
+            rest
+        } else {
+            stripped
+        }
+    } else {
+        stripped
+    };
+
+    // Step 5: trim again; if empty after stripping, return original to avoid sending
+    // an empty version to OSV (better to send the raw string than nothing)
+    let result = result.trim();
+    if result.is_empty() {
+        trimmed.to_string()
+    } else {
+        result.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_version_for_osv;
+
+    #[test]
+    fn test_python_operators() {
+        assert_eq!(normalize_version_for_osv(">=1.23.0"), "1.23.0");
+        assert_eq!(normalize_version_for_osv("==2.0.0"), "2.0.0");
+        assert_eq!(normalize_version_for_osv("~=4.0"), "4.0");
+        assert_eq!(normalize_version_for_osv("!=1.0"), "1.0");
+        assert_eq!(normalize_version_for_osv("===1.0.0"), "1.0.0");
+    }
+
+    #[test]
+    fn test_cargo_npm_operators() {
+        assert_eq!(normalize_version_for_osv("^1.0.0"), "1.0.0");
+        assert_eq!(normalize_version_for_osv("~1.0.0"), "1.0.0");
+    }
+
+    #[test]
+    fn test_ruby_operator() {
+        assert_eq!(normalize_version_for_osv("~>1.0"), "1.0");
+    }
+
+    #[test]
+    fn test_go_prefix() {
+        assert_eq!(normalize_version_for_osv("v1.0.0"), "1.0.0");
+        assert_eq!(normalize_version_for_osv("V1.0.0"), "1.0.0");
+    }
+
+    #[test]
+    fn test_plain_version() {
+        assert_eq!(normalize_version_for_osv("1.23.0"), "1.23.0");
+    }
+
+    #[test]
+    fn test_comma_separated() {
+        assert_eq!(normalize_version_for_osv(">=1.0,<2.0"), "1.0");
+    }
+
+    #[test]
+    fn test_whitespace() {
+        assert_eq!(normalize_version_for_osv(" >=1.0 "), "1.0");
+    }
+
+    #[test]
+    fn test_greater_less() {
+        assert_eq!(normalize_version_for_osv(">1.0"), "1.0");
+        assert_eq!(normalize_version_for_osv("<2.0"), "2.0");
+    }
+
+    #[test]
+    fn test_bare_equals() {
+        assert_eq!(normalize_version_for_osv("=1.0"), "1.0");
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        // Empty string stays empty
+        assert_eq!(normalize_version_for_osv(""), "");
+        // Whitespace-only becomes empty
+        assert_eq!(normalize_version_for_osv("   "), "");
+        // Operator-only: returns original (not empty) to avoid bad OSV queries
+        assert_eq!(normalize_version_for_osv("==="), "===");
+        assert_eq!(normalize_version_for_osv(">="), ">=");
+        // Double operator: strips first match, leaves remainder
+        assert_eq!(normalize_version_for_osv(">>1.0"), ">1.0");
+        // Multiple commas: takes first constraint
+        assert_eq!(normalize_version_for_osv(">=1.0,<2.0,>1.5"), "1.0");
+    }
+}

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -420,4 +420,46 @@ mod tests {
         let vuln = &result.vulnerabilities[0];
         assert!(vuln.id.starts_with("RUSTSEC"));
     }
+
+    #[test]
+    fn test_normalize_version_strips_operators_for_osv() {
+        use super::super::normalize_version_for_osv;
+
+        // These are real-world version strings from Python pyproject.toml
+        assert_eq!(normalize_version_for_osv(">=1.23.0"), "1.23.0");
+        assert_eq!(normalize_version_for_osv("==2.0.0"), "2.0.0");
+        assert_eq!(normalize_version_for_osv("~=4.0"), "4.0");
+        // Cargo/npm style
+        assert_eq!(normalize_version_for_osv("^1.0.27"), "1.0.27");
+    }
+
+    #[tokio::test]
+    async fn test_version_normalization_prevents_false_positives() {
+        use super::super::normalize_version_for_osv;
+
+        // urllib3 1.26.0 should NOT have GHSA-m5vv-6r4h-3vj9 (only affects <1.16.1)
+        let raw_version = ">=1.26.0";
+        let normalized = normalize_version_for_osv(raw_version);
+        assert_eq!(normalized, "1.26.0");
+
+        let client = OsvClient::new().unwrap();
+        let query = VulnerabilityQuery {
+            ecosystem: crate::vulnerabilities::Ecosystem::PyPI,
+            package_name: "urllib3".to_string(),
+            version: normalized,
+        };
+
+        let results = client.query_batch(&[query]).await.unwrap();
+        assert!(!results.is_empty());
+
+        let result = &results[0];
+        // Verify the specific false-positive vulnerability is NOT present
+        let has_false_positive = result.vulnerabilities.iter().any(|v| {
+            v.id.contains("GHSA-m5vv-6r4h-3vj9") || v.description.contains("GHSA-m5vv-6r4h-3vj9")
+        });
+        assert!(
+            !has_false_positive,
+            "urllib3 1.26.0 should NOT have GHSA-m5vv-6r4h-3vj9 (only affects <1.16.1)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes false-positive vulnerability reports caused by version operators (`>=`, `==`, `~=`, `^`, etc.) being sent raw to OSV.dev API
- Adds `normalize_version_for_osv()` to strip operators before querying, ensuring OSV correctly filters by version
- Affects all ecosystems (Python, Cargo, npm, Go, Ruby, PHP, Dart, C#)

Closes #181

## Changes

- **`dependi-lsp/src/vulnerabilities/mod.rs`**: New `normalize_version_for_osv()` function with 11 unit tests covering all operator formats and edge cases
- **`dependi-lsp/src/backend.rs`**: Apply normalization in both VulnCacheKey check and VulnerabilityQuery construction for consistency
- **`dependi-lsp/src/vulnerabilities/osv.rs`**: Integration tests verifying urllib3 1.26.0 no longer shows GHSA-m5vv-6r4h-3vj9 (only affects <1.16.1)
- **`CHANGELOG.md`**: Document bugfix

## Root cause

Dependency parsers extract version strings with operators (e.g., `>=1.23.0` from pyproject.toml). These were sent directly to OSV.dev's `/querybatch` endpoint which expects plain version numbers. OSV could not filter by version and returned all known vulnerabilities for the package.

## Test plan

- [x] 11 unit tests for normalization (Python, Cargo, npm, Ruby, Go, edge cases)
- [x] Integration test: urllib3 1.26.0 no longer shows false-positive GHSA-m5vv-6r4h-3vj9
- [x] All 350 existing tests pass
- [x] Clippy clean, fmt clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false-positive vulnerability reports by normalizing version operators before querying vulnerability databases, improving accuracy of dependency security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->