### PR TITLE
fix: use Cargo.lock resolved versions for minimal version syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix false-positive "update available" reports when using minimal version syntax (e.g., `bon = "3.9"`) by reading resolved versions from `Cargo.lock` ([#184](https://github.com/mpiton/zed-dependi/issues/184))
 - Fix false-positive vulnerability reports by normalizing version operators before OSV.dev queries ([#181](https://github.com/mpiton/zed-dependi/issues/181))
 
 ## [1.5.0] - 2026-03-16

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -103,7 +103,43 @@ impl ProcessingContext {
             return;
         };
 
-        let dependencies = self.parse_document(uri, content);
+        let mut dependencies = self.parse_document(uri, content);
+
+        // Resolve versions from Cargo.lock for Cargo dependencies
+        if file_type == FileType::Cargo {
+            if let Ok(cargo_toml_path) = uri.to_file_path() {
+                if let Some(lock_path) =
+                    crate::parsers::cargo_lock::find_cargo_lock(&cargo_toml_path)
+                {
+                    match tokio::fs::read_to_string(&lock_path).await {
+                        Ok(lock_content) => {
+                            let lock_versions =
+                                crate::parsers::cargo_lock::parse_cargo_lock(&lock_content);
+                            for dep in &mut dependencies {
+                                if let Some(resolved) = lock_versions.get(&dep.name) {
+                                    dep.resolved_version = Some(resolved.clone());
+                                }
+                            }
+                            tracing::debug!(
+                                "Resolved {} versions from {}",
+                                dependencies
+                                    .iter()
+                                    .filter(|d| d.resolved_version.is_some())
+                                    .count(),
+                                lock_path.display()
+                            );
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                "Could not read Cargo.lock at {}: {}",
+                                lock_path.display(),
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+        }
 
         tracing::info!(
             "Parsed {} dependencies from {}",
@@ -504,14 +540,14 @@ impl DependiBackend {
         let queries: Vec<VulnerabilityQuery> = dependencies
             .iter()
             .filter(|dep| {
-                let normalized_version = normalize_version_for_osv(&dep.version);
+                let normalized_version = normalize_version_for_osv(dep.effective_version());
                 let vuln_key = VulnCacheKey::new(ecosystem, &dep.name, &normalized_version);
                 !vuln_cache.contains(&vuln_key)
             })
             .map(|dep| VulnerabilityQuery {
                 ecosystem,
                 package_name: dep.name.clone(),
-                version: normalize_version_for_osv(&dep.version),
+                version: normalize_version_for_osv(dep.effective_version()),
             })
             .collect();
 

--- a/dependi-lsp/src/parsers/cargo.rs
+++ b/dependi-lsp/src/parsers/cargo.rs
@@ -88,6 +88,7 @@ impl Parser for CargoParser {
                                 dev: is_dev,
                                 optional,
                                 registry,
+                                resolved_version: None,
                             });
                         }
                     }
@@ -133,6 +134,7 @@ fn parse_dependency(name: &str, node: &Node, content: &str, is_dev: bool) -> Opt
                 dev: is_dev,
                 optional: false,
                 registry: None,
+                resolved_version: None,
             })
         }
         Node::Table(table) => {
@@ -164,6 +166,7 @@ fn parse_dependency(name: &str, node: &Node, content: &str, is_dev: bool) -> Opt
                 dev: is_dev,
                 optional,
                 registry,
+                resolved_version: None,
             })
         }
         _ => None,

--- a/dependi-lsp/src/parsers/cargo_lock.rs
+++ b/dependi-lsp/src/parsers/cargo_lock.rs
@@ -1,0 +1,122 @@
+//! Parser for Cargo.lock files — resolves exact locked versions for Cargo dependencies.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Parse a Cargo.lock file and return a map of package name → resolved version.
+///
+/// Cargo.lock uses `[[package]]` TOML array-of-tables entries with `name` and `version` fields.
+/// When multiple versions of the same package exist (uncommon but possible), the first one is kept.
+pub fn parse_cargo_lock(content: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+
+    let value: toml::Value = match toml::from_str(content) {
+        Ok(v) => v,
+        Err(_) => return map,
+    };
+
+    let packages = match value.get("package").and_then(|p| p.as_array()) {
+        Some(pkgs) => pkgs,
+        None => return map,
+    };
+
+    for pkg in packages {
+        let name = match pkg.get("name").and_then(|n| n.as_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        let version = match pkg.get("version").and_then(|v| v.as_str()) {
+            Some(v) => v.to_string(),
+            None => continue,
+        };
+        // Keep the first entry when multiple versions exist
+        map.entry(name).or_insert(version);
+    }
+
+    map
+}
+
+/// Find the Cargo.lock file by walking up from a Cargo.toml path.
+///
+/// Handles both single-crate and workspace layouts by searching parent directories.
+/// Stops after 10 levels to prevent infinite traversal on unusual file systems.
+pub fn find_cargo_lock(cargo_toml_path: &Path) -> Option<PathBuf> {
+    let start_dir = cargo_toml_path.parent()?;
+
+    let mut current = start_dir;
+    let mut depth = 0;
+    const MAX_DEPTH: usize = 10;
+
+    loop {
+        let candidate = current.join("Cargo.lock");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+
+        depth += 1;
+        if depth >= MAX_DEPTH {
+            return None;
+        }
+
+        current = current.parent()?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_cargo_lock() {
+        let content = r#"
+version = 3
+
+[[package]]
+name = "serde"
+version = "1.0.195"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "tokio"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+"#;
+        let map = parse_cargo_lock(content);
+        assert_eq!(map.get("serde").map(|s| s.as_str()), Some("1.0.195"));
+        assert_eq!(map.get("tokio").map(|s| s.as_str()), Some("1.36.0"));
+    }
+
+    #[test]
+    fn test_parse_empty_file() {
+        let map = parse_cargo_lock("");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_parse_no_packages() {
+        let content = "version = 3\n";
+        let map = parse_cargo_lock(content);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_parse_invalid_toml() {
+        let map = parse_cargo_lock("not valid toml ][");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_duplicate_package_keeps_first() {
+        let content = r#"
+[[package]]
+name = "serde"
+version = "1.0.100"
+
+[[package]]
+name = "serde"
+version = "1.0.195"
+"#;
+        let map = parse_cargo_lock(content);
+        assert_eq!(map.get("serde").map(|s| s.as_str()), Some("1.0.100"));
+    }
+}

--- a/dependi-lsp/src/parsers/csharp.rs
+++ b/dependi-lsp/src/parsers/csharp.rs
@@ -79,6 +79,7 @@ fn parse_package_reference(line: &str, line_num: u32) -> Option<Dependency> {
         dev: false, // NuGet doesn't have explicit dev dependencies in .csproj
         optional: false,
         registry: None,
+        resolved_version: None,
     })
 }
 

--- a/dependi-lsp/src/parsers/dart.rs
+++ b/dependi-lsp/src/parsers/dart.rs
@@ -167,6 +167,7 @@ fn parse_dart_dependency_line(line: &str, line_num: u32, dev: bool) -> Option<De
         dev,
         optional: false,
         registry: None,
+        resolved_version: None,
     })
 }
 

--- a/dependi-lsp/src/parsers/go.rs
+++ b/dependi-lsp/src/parsers/go.rs
@@ -137,6 +137,7 @@ fn parse_require_with_positions(
         dev: false,
         optional: is_indirect,
         registry: None,
+        resolved_version: None,
     })
 }
 

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -25,6 +25,17 @@ pub struct Dependency {
     pub optional: bool,
     /// Custom registry name (Cargo only, e.g., "kellnr")
     pub registry: Option<String>,
+    /// Resolved version from the lock file (e.g., Cargo.lock), if available
+    #[serde(default)]
+    pub resolved_version: Option<String>,
+}
+
+impl Dependency {
+    /// Returns the resolved version (from lock file) if available,
+    /// otherwise falls back to the declared version from the manifest.
+    pub fn effective_version(&self) -> &str {
+        self.resolved_version.as_deref().unwrap_or(&self.version)
+    }
 }
 
 /// Trait for parsing dependency files
@@ -34,6 +45,7 @@ pub trait Parser: Send + Sync {
 }
 
 pub mod cargo;
+pub mod cargo_lock;
 pub mod csharp;
 pub mod dart;
 pub mod go;

--- a/dependi-lsp/src/parsers/npm.rs
+++ b/dependi-lsp/src/parsers/npm.rs
@@ -187,6 +187,7 @@ fn find_dependency_position(
                     dev,
                     optional,
                     registry: None,
+                    resolved_version: None,
                 });
             }
         }

--- a/dependi-lsp/src/parsers/php.rs
+++ b/dependi-lsp/src/parsers/php.rs
@@ -156,6 +156,7 @@ fn find_dependency_position(
                     dev,
                     optional: false,
                     registry: None,
+                    resolved_version: None,
                 });
             }
         }

--- a/dependi-lsp/src/parsers/python.rs
+++ b/dependi-lsp/src/parsers/python.rs
@@ -191,6 +191,7 @@ fn parse_requirement_line(line: &str, line_num: u32, dev: bool) -> Option<Depend
         dev,
         optional: false,
         registry: None,
+        resolved_version: None,
     })
 }
 
@@ -431,6 +432,7 @@ fn find_dependency_position(
                     dev,
                     optional: dev, // optional-dependencies are optional
                     registry: None,
+                    resolved_version: None,
                 });
             }
         }
@@ -473,6 +475,7 @@ fn find_poetry_dependency_position(
                     dev,
                     optional: false,
                     registry: None,
+                    resolved_version: None,
                 });
             }
         }

--- a/dependi-lsp/src/parsers/ruby.rs
+++ b/dependi-lsp/src/parsers/ruby.rs
@@ -103,6 +103,7 @@ fn parse_gem_declaration(line: &str, line_num: u32, dev: bool) -> Option<Depende
         dev,
         optional: false,
         registry: None,
+        resolved_version: None,
     })
 }
 

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -133,9 +133,9 @@ fn create_update_action(
     let cache_key = cache_key_fn(&dep.name);
     let version_info = cache.get(&cache_key)?;
 
-    match compare_versions(&dep.version, &version_info) {
+    match compare_versions(dep.effective_version(), &version_info) {
         VersionStatus::UpdateAvailable(new_version) => {
-            let update_type = compare_update_type(&dep.version, &new_version);
+            let update_type = compare_update_type(dep.effective_version(), &new_version);
             let new_text = format_version_for_dep(&new_version, file_type, &dep.version);
 
             let edit = TextEdit {
@@ -195,7 +195,7 @@ fn create_update_all_action(
             let cache_key = cache_key_fn(&dep.name);
             let version_info = cache.get(&cache_key)?;
 
-            match compare_versions(&dep.version, &version_info) {
+            match compare_versions(dep.effective_version(), &version_info) {
                 VersionStatus::UpdateAvailable(new_version) => Some((dep, new_version)),
                 _ => None,
             }
@@ -315,6 +315,7 @@ mod tests {
             dev: false,
             optional: false,
             registry: None,
+            resolved_version: None,
         }
     }
 

--- a/dependi-lsp/src/providers/completion.rs
+++ b/dependi-lsp/src/providers/completion.rs
@@ -153,6 +153,7 @@ mod tests {
             dev: false,
             optional: false,
             registry: None,
+            resolved_version: None,
         }
     }
 

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -90,7 +90,7 @@ fn create_outdated_diagnostic(
     let cache_key = cache_key_fn(&dep.name);
     let version_info = cache.get(&cache_key)?;
 
-    match compare_versions(&dep.version, &version_info) {
+    match compare_versions(dep.effective_version(), &version_info) {
         VersionStatus::UpdateAvailable(new_version) => Some(Diagnostic {
             range: Range {
                 start: Position {
@@ -105,7 +105,11 @@ fn create_outdated_diagnostic(
             severity: Some(DiagnosticSeverity::HINT),
             code: Some(NumberOrString::String("outdated".to_string())),
             source: Some("dependi".to_string()),
-            message: format!("Update available: {} -> {}", dep.version, new_version),
+            message: format!(
+                "Update available: {} -> {}",
+                dep.effective_version(),
+                new_version
+            ),
             related_information: None,
             tags: None,
             code_description: None,
@@ -358,6 +362,7 @@ mod tests {
             dev: false,
             optional: false,
             registry: None,
+            resolved_version: None,
         }
     }
 

--- a/dependi-lsp/src/providers/document_links.rs
+++ b/dependi-lsp/src/providers/document_links.rs
@@ -63,6 +63,7 @@ mod tests {
             dev: false,
             optional: false,
             registry: None,
+            resolved_version: None,
         }
     }
 

--- a/dependi-lsp/src/providers/inlay_hints.rs
+++ b/dependi-lsp/src/providers/inlay_hints.rs
@@ -20,7 +20,7 @@ pub enum VersionStatus {
 /// Generate an inlay hint for a dependency
 pub fn create_inlay_hint(dep: &Dependency, version_info: Option<&VersionInfo>) -> InlayHint {
     let status = match version_info {
-        Some(info) => compare_versions(&dep.version, info),
+        Some(info) => compare_versions(dep.effective_version(), info),
         None => VersionStatus::Unknown,
     };
 
@@ -490,6 +490,7 @@ mod tests {
             dev: false,
             optional: false,
             registry: None,
+            resolved_version: None,
         }
     }
 
@@ -1159,6 +1160,114 @@ mod tests {
                     s
                 );
             }
+            _ => panic!("Expected string label"),
+        }
+    }
+
+    // --- Cargo.lock resolved version tests (issue #184) ---
+
+    fn make_test_dep_with_resolved(name: &str, version: &str, resolved: &str) -> Dependency {
+        Dependency {
+            name: name.to_string(),
+            version: version.to_string(),
+            line: 5,
+            name_start: 0,
+            name_end: name.len() as u32,
+            version_start: name.len() as u32 + 4,
+            version_end: name.len() as u32 + 4 + version.len() as u32,
+            dev: false,
+            optional: false,
+            registry: None,
+            resolved_version: Some(resolved.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_effective_version_with_resolved() {
+        let dep = make_test_dep_with_resolved("bon", "3.9", "3.9.1");
+        assert_eq!(dep.effective_version(), "3.9.1");
+    }
+
+    #[test]
+    fn test_effective_version_without_resolved() {
+        let dep = make_test_dep("bon", "3.9");
+        assert_eq!(dep.effective_version(), "3.9");
+    }
+
+    #[test]
+    fn test_resolved_version_prevents_false_positive() {
+        // Issue #184: "bon = 3.9" with Cargo.lock having 3.9.1, latest is 3.9.1
+        // Without resolved_version: compare_versions("3.9", info) → "3.9.0" < "3.9.1" → UpdateAvailable (BUG)
+        // With resolved_version: compare_versions("3.9.1", info) → UpToDate (FIXED)
+        let dep = make_test_dep_with_resolved("bon", "3.9", "3.9.1");
+        let info = make_version_info("3.9.1");
+        assert!(matches!(
+            compare_versions(dep.effective_version(), &info),
+            VersionStatus::UpToDate
+        ));
+    }
+
+    #[test]
+    fn test_resolved_version_caret_syntax() {
+        // "^3.9" with Cargo.lock having 3.9.1, latest is 3.9.1
+        let dep = make_test_dep_with_resolved("bon", "^3.9", "3.9.1");
+        let info = make_version_info("3.9.1");
+        assert!(matches!(
+            compare_versions(dep.effective_version(), &info),
+            VersionStatus::UpToDate
+        ));
+    }
+
+    #[test]
+    fn test_resolved_version_real_update_available() {
+        // "3.9" with Cargo.lock having 3.9.1, but latest is 3.10.0
+        let dep = make_test_dep_with_resolved("bon", "3.9", "3.9.1");
+        let info = make_version_info("3.10.0");
+        match compare_versions(dep.effective_version(), &info) {
+            VersionStatus::UpdateAvailable(v) => assert_eq!(v, "3.10.0"),
+            _ => panic!("Expected UpdateAvailable for genuine update"),
+        }
+    }
+
+    #[test]
+    fn test_resolved_version_major_only() {
+        // "1" with Cargo.lock having 1.5.3, latest is 1.5.3
+        let dep = make_test_dep_with_resolved("serde", "1", "1.5.3");
+        let info = make_version_info("1.5.3");
+        assert!(matches!(
+            compare_versions(dep.effective_version(), &info),
+            VersionStatus::UpToDate
+        ));
+    }
+
+    #[test]
+    fn test_inlay_hint_uses_resolved_version() {
+        // End-to-end: create_inlay_hint should show UpToDate when resolved matches latest
+        let dep = make_test_dep_with_resolved("bon", "3.9", "3.9.1");
+        let info = make_version_info("3.9.1");
+        let hint = create_inlay_hint(&dep, Some(&info));
+        match hint.label {
+            InlayHintLabel::String(s) => assert!(
+                s.contains("✓"),
+                "Expected ✓ (up to date) with resolved version, got: {}",
+                s
+            ),
+            _ => panic!("Expected string label"),
+        }
+    }
+
+    #[test]
+    fn test_inlay_hint_without_resolved_shows_update() {
+        // Without resolved_version, minimal syntax shows update available (original behavior)
+        let dep = make_test_dep("bon", "3.9");
+        let info = make_version_info("3.9.1");
+        let hint = create_inlay_hint(&dep, Some(&info));
+        match hint.label {
+            InlayHintLabel::String(s) => assert!(
+                s.contains("->"),
+                "Expected -> (update available) without resolved version, got: {}",
+                s
+            ),
             _ => panic!("Expected string label"),
         }
     }

--- a/dependi-lsp/tests/integration_test.rs
+++ b/dependi-lsp/tests/integration_test.rs
@@ -176,6 +176,7 @@ fn test_inlay_hint_generation() {
         dev: false,
         optional: false,
         registry: None,
+        resolved_version: None,
     };
 
     let info_up_to_date = VersionInfo {
@@ -203,6 +204,7 @@ fn test_inlay_hint_generation() {
         dev: false,
         optional: false,
         registry: None,
+        resolved_version: None,
     };
 
     let info_outdated = VersionInfo {


### PR DESCRIPTION
## Summary

- Fix false-positive "update available" reports when using minimal version syntax (e.g., `bon = "3.9"` or `bon = "^3.9"`) by reading resolved versions from `Cargo.lock` ([#184](https://github.com/mpiton/zed-dependi/issues/184))
- Add `Cargo.lock` parser that resolves actual installed versions
- Walk up directory tree to find workspace-level `Cargo.lock`
- Use resolved versions across all providers (diagnostics, inlay hints, code actions, vulnerability queries)

## Changes

- **New**: `dependi-lsp/src/parsers/cargo_lock.rs` — `parse_cargo_lock()` + `find_cargo_lock()` 
- **Modified**: `Dependency` struct gains `resolved_version: Option<String>` + `effective_version()` method
- **Modified**: `backend.rs` reads Cargo.lock during document processing, populates resolved versions
- **Modified**: All providers use `dep.effective_version()` instead of `&dep.version` for comparison
- **Modified**: Vulnerability queries use resolved versions for accurate OSV lookups

## Test plan

- [x] 364 unit tests passing (8 new tests for resolved version behavior)
- [x] Clippy: 0 warnings
- [x] `cargo fmt --check` passes
- [x] Adversarial code review completed (1 finding fixed: `#[serde(default)]`)
- [ ] Manual test: open a Cargo.toml with minimal versions, verify no false positives

Closes #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected false-positive "update available" reports for Rust dependencies specified with minimal version syntax (e.g., `bon = "3.9"`) by using resolved versions from Cargo.lock.

* **New Features**
  * Added automatic Cargo.lock resolution to provide accurate dependency version information for Rust projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->