### PR TITLE
feat: add PHP lockfile version resolution (composer.lock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Pipfile.lock` (Pipenv)
 - Add Go lockfile version resolution to eliminate false-positive "update available" warnings for `go.mod` dependencies ([#186](https://github.com/mpiton/zed-dependi/issues/186))
   - `go.sum` (Go modules checksum database)
+- Add PHP lockfile version resolution to eliminate false-positive "update available" warnings for `composer.json` dependencies ([#186](https://github.com/mpiton/zed-dependi/issues/186))
+  - `composer.lock` (Composer)
 
 ### Fixed
 

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -265,6 +265,46 @@ impl ProcessingContext {
             }
         }
 
+        // Resolve versions from composer.lock for PHP dependencies
+        if file_type == FileType::Php {
+            if let Ok(composer_json_path) = uri.to_file_path() {
+                if let Some(lock_path) =
+                    crate::parsers::composer_lock::find_composer_lock(&composer_json_path).await
+                {
+                    match tokio::fs::read_to_string(&lock_path).await {
+                        Ok(lock_content) => {
+                            let lock_versions =
+                                crate::parsers::composer_lock::parse_composer_lock(&lock_content);
+                            for dep in &mut dependencies {
+                                let normalized =
+                                    crate::parsers::composer_lock::normalize_composer_name(
+                                        &dep.name,
+                                    );
+                                if let Some(resolved) = lock_versions.get(&normalized) {
+                                    dep.resolved_version = Some(resolved.clone());
+                                }
+                            }
+                            tracing::debug!(
+                                "Resolved {} versions from {}",
+                                dependencies
+                                    .iter()
+                                    .filter(|d| d.resolved_version.is_some())
+                                    .count(),
+                                lock_path.display()
+                            );
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                "Could not read composer.lock at {}: {}",
+                                lock_path.display(),
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
         tracing::info!(
             "Parsed {} dependencies from {}",
             dependencies.len(),

--- a/dependi-lsp/src/parsers/composer_lock.rs
+++ b/dependi-lsp/src/parsers/composer_lock.rs
@@ -1,0 +1,190 @@
+//! Parser for composer.lock files — resolves exact locked versions for PHP (Composer) dependencies.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Normalize a Composer package name to lowercase.
+///
+/// Composer package names are case-insensitive (e.g., "Vendor/Package" == "vendor/package").
+/// This function ensures consistent lookup between manifest and lockfile entries.
+pub fn normalize_composer_name(name: &str) -> String {
+    name.to_lowercase()
+}
+
+/// Parse a composer.lock file and return a map of package name → resolved version.
+///
+/// Composer.lock is a JSON file with `"packages"` and `"packages-dev"` arrays.
+/// Each entry has `"name"` and `"version"` fields.
+/// Names are normalized to lowercase since Composer is case-insensitive.
+/// Versions with a `v` prefix (e.g., "v3.2.0") are stored as-is since both
+/// Packagist API and composer.lock use the same format per package.
+/// When a package appears multiple times, the first entry is kept.
+pub fn parse_composer_lock(content: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+
+    let value: serde_json::Value = match serde_json::from_str(content) {
+        Ok(v) => v,
+        Err(_) => return map,
+    };
+
+    for key in &["packages", "packages-dev"] {
+        let packages = match value.get(*key).and_then(|p| p.as_array()) {
+            Some(pkgs) => pkgs,
+            None => continue,
+        };
+
+        for pkg in packages {
+            let name = match pkg.get("name").and_then(|n| n.as_str()) {
+                Some(n) => normalize_composer_name(n),
+                None => continue,
+            };
+            let version = match pkg.get("version").and_then(|v| v.as_str()) {
+                Some(v) => v.to_string(),
+                None => continue,
+            };
+            map.entry(name).or_insert(version);
+        }
+    }
+
+    map
+}
+
+/// Find the composer.lock file by walking up from a composer.json path.
+///
+/// Handles both single-project and monorepo layouts by searching parent directories.
+/// Uses async I/O to avoid blocking the Tokio executor on slow or networked filesystems.
+/// Stops after 10 levels to prevent infinite traversal on unusual file systems.
+pub async fn find_composer_lock(manifest_path: &Path) -> Option<PathBuf> {
+    let start_dir = manifest_path.parent()?;
+
+    let mut current = start_dir.to_path_buf();
+    let mut depth = 0;
+    const MAX_DEPTH: usize = 10;
+
+    loop {
+        let candidate = current.join("composer.lock");
+        if tokio::fs::try_exists(&candidate).await.unwrap_or(false) {
+            return Some(candidate);
+        }
+
+        depth += 1;
+        if depth >= MAX_DEPTH {
+            return None;
+        }
+
+        current = current.parent()?.to_path_buf();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_composer_lock() {
+        let content = r#"{
+            "packages": [
+                {"name": "vendor/package-a", "version": "1.2.3"},
+                {"name": "vendor/package-b", "version": "4.5.6"}
+            ],
+            "packages-dev": []
+        }"#;
+        let map = parse_composer_lock(content);
+        assert_eq!(
+            map.get("vendor/package-a").map(|s| s.as_str()),
+            Some("1.2.3")
+        );
+        assert_eq!(
+            map.get("vendor/package-b").map(|s| s.as_str()),
+            Some("4.5.6")
+        );
+    }
+
+    #[test]
+    fn test_parse_packages_dev() {
+        let content = r#"{
+            "packages": [
+                {"name": "vendor/package-a", "version": "1.0.0"}
+            ],
+            "packages-dev": [
+                {"name": "vendor/dev-tool", "version": "2.0.0"}
+            ]
+        }"#;
+        let map = parse_composer_lock(content);
+        assert_eq!(
+            map.get("vendor/package-a").map(|s| s.as_str()),
+            Some("1.0.0")
+        );
+        assert_eq!(
+            map.get("vendor/dev-tool").map(|s| s.as_str()),
+            Some("2.0.0")
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_content() {
+        let map = parse_composer_lock("");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_parse_empty_arrays() {
+        let content = r#"{"packages":[],"packages-dev":[]}"#;
+        let map = parse_composer_lock(content);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_parse_invalid_json() {
+        let map = parse_composer_lock("not valid json {[");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_duplicate_package_keeps_first() {
+        let content = r#"{
+            "packages": [
+                {"name": "vendor/package", "version": "1.0.0"},
+                {"name": "vendor/package", "version": "2.0.0"}
+            ],
+            "packages-dev": []
+        }"#;
+        let map = parse_composer_lock(content);
+        assert_eq!(map.get("vendor/package").map(|s| s.as_str()), Some("1.0.0"));
+    }
+
+    #[test]
+    fn test_case_insensitive_names() {
+        let content = r#"{
+            "packages": [
+                {"name": "Vendor/Package", "version": "1.0.0"}
+            ],
+            "packages-dev": []
+        }"#;
+        let map = parse_composer_lock(content);
+        assert!(map.contains_key("vendor/package"));
+        assert!(!map.contains_key("Vendor/Package"));
+    }
+
+    #[test]
+    fn test_various_version_formats() {
+        let content = r#"{
+            "packages": [
+                {"name": "vendor/stable", "version": "1.2.3"},
+                {"name": "vendor/prefixed", "version": "v3.2.0"},
+                {"name": "vendor/dev", "version": "dev-master"}
+            ],
+            "packages-dev": []
+        }"#;
+        let map = parse_composer_lock(content);
+        assert_eq!(map.get("vendor/stable").map(|s| s.as_str()), Some("1.2.3"));
+        assert_eq!(
+            map.get("vendor/prefixed").map(|s| s.as_str()),
+            Some("v3.2.0")
+        );
+        assert_eq!(
+            map.get("vendor/dev").map(|s| s.as_str()),
+            Some("dev-master")
+        );
+    }
+}

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -46,6 +46,7 @@ pub trait Parser: Send + Sync {
 
 pub mod cargo;
 pub mod cargo_lock;
+pub mod composer_lock;
 pub mod csharp;
 pub mod dart;
 pub mod go;


### PR DESCRIPTION
## Summary

- Add `composer.lock` parsing to resolve exact PHP dependency versions, eliminating false-positive "update available" warnings for `composer.json` dependencies
- Part of cross-ecosystem lockfile support tracking (#186)

## Changes

- **New:** `dependi-lsp/src/parsers/composer_lock.rs` — `parse_composer_lock()` extracts `name → version` from both `packages` and `packages-dev` arrays; `find_composer_lock()` walks up directories; `normalize_composer_name()` ensures case-insensitive matching
- **Modified:** `dependi-lsp/src/backend.rs` — PHP lockfile resolution block after Go block, using `normalize_composer_name` for lookups
- **Modified:** `dependi-lsp/src/parsers/mod.rs` — Register `composer_lock` module
- **Modified:** `CHANGELOG.md` — Document new feature

## Test plan

- [x] 8 unit tests covering: basic parsing, packages-dev, empty content, invalid JSON, duplicates, case normalization, version formats
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -D warnings` — 0 warnings
- [x] `cargo test --lib` — 458 passed
- [x] `cargo test --test integration_test` — 7 passed
- [x] Adversarial code review completed — normalization asymmetry fixed

Closes partially #186 (PHP ecosystem done, 3 remaining: Dart, C#, Ruby)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PHP dependency version resolution through composer.lock file support. PHP projects now automatically resolve locked package versions, bringing feature parity with existing Node.js, Python, and Go language support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->