### PR TITLE
feat: add Dart lockfile version resolution (pubspec.lock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `go.sum` (Go modules checksum database)
 - Add PHP lockfile version resolution to eliminate false-positive "update available" warnings for `composer.json` dependencies ([#186](https://github.com/mpiton/zed-dependi/issues/186))
   - `composer.lock` (Composer)
+- Add Dart lockfile version resolution (`pubspec.lock`) to eliminate false-positive update warnings
 
 ### Fixed
 

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -305,6 +305,41 @@ impl ProcessingContext {
             }
         }
 
+        // Resolve versions from pubspec.lock for Dart dependencies
+        if file_type == FileType::Dart {
+            if let Ok(pubspec_yaml_path) = uri.to_file_path() {
+                if let Some(lock_path) =
+                    crate::parsers::pubspec_lock::find_pubspec_lock(&pubspec_yaml_path).await
+                {
+                    match tokio::fs::read_to_string(&lock_path).await {
+                        Ok(lock_content) => {
+                            let lock_versions =
+                                crate::parsers::pubspec_lock::parse_pubspec_lock(&lock_content);
+                            for dep in &mut dependencies {
+                                if let Some(resolved) = lock_versions.get(&dep.name) {
+                                    dep.resolved_version = Some(resolved.clone());
+                                }
+                            }
+                            tracing::debug!(
+                                "Resolved {} Dart versions from pubspec.lock at {}",
+                                dependencies
+                                    .iter()
+                                    .filter(|d| d.resolved_version.is_some())
+                                    .count(),
+                                lock_path.display()
+                            );
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                "Could not read pubspec.lock at {}: {e}",
+                                lock_path.display(),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
         tracing::info!(
             "Parsed {} dependencies from {}",
             dependencies.len(),

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -54,6 +54,7 @@ pub mod go_sum;
 pub mod npm;
 pub mod npm_lock;
 pub mod php;
+pub mod pubspec_lock;
 pub mod python;
 pub mod python_lock;
 pub mod ruby;

--- a/dependi-lsp/src/parsers/pubspec_lock.rs
+++ b/dependi-lsp/src/parsers/pubspec_lock.rs
@@ -1,0 +1,234 @@
+//! Parser for pubspec.lock files — resolves exact locked versions for Dart (pub) dependencies.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Parse a pubspec.lock file and return a map of package name → resolved version.
+///
+/// pubspec.lock is a YAML file with a `packages:` top-level section.
+/// Each package name appears at 2-space indent, ending with `:`.
+/// The version is at 4-space indent: `    version: "X.Y.Z"`.
+/// Quotes around version values are stripped.
+/// Dart package names are case-sensitive — no normalization is applied.
+/// When a package appears multiple times, the first entry is kept.
+pub fn parse_pubspec_lock(content: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let mut in_packages = false;
+    let mut current_package: Option<String> = None;
+
+    for line in content.lines() {
+        // Top-level key (no leading whitespace): switch section tracking
+        if !line.starts_with(' ') {
+            in_packages = line.starts_with("packages:");
+            current_package = None;
+            continue;
+        }
+
+        if !in_packages {
+            continue;
+        }
+
+        // Package name at exactly 2-space indent: "  <name>:"
+        if line.starts_with("  ") && !line.starts_with("   ") {
+            let trimmed = line.trim();
+            if let Some(name) = trimmed.strip_suffix(':') {
+                current_package = Some(name.to_string());
+            }
+            continue;
+        }
+
+        // Version at exactly 4-space indent: "    version: ..."
+        if line.starts_with("    ") && !line.starts_with("     ") {
+            if let Some(ref pkg) = current_package {
+                let trimmed = line.trim();
+                if let Some(rest) = trimmed.strip_prefix("version:") {
+                    let version = rest.trim().trim_matches('"').to_string();
+                    if !version.is_empty() {
+                        map.entry(pkg.clone()).or_insert(version);
+                    }
+                }
+            }
+        }
+    }
+
+    map
+}
+
+/// Find the pubspec.lock file co-located with a pubspec.yaml manifest.
+///
+/// Unlike Composer or npm, Dart's `pub` tool always places `pubspec.lock` in the
+/// same directory as `pubspec.yaml`. Each Dart package has its own independent
+/// lockfile, so walking up parent directories would risk resolving versions from
+/// a different package in a monorepo layout.
+/// Uses async I/O to avoid blocking the Tokio executor on slow or networked filesystems.
+pub async fn find_pubspec_lock(manifest_path: &Path) -> Option<PathBuf> {
+    let candidate = manifest_path.parent()?.join("pubspec.lock");
+    if tokio::fs::try_exists(&candidate).await.unwrap_or(false) {
+        Some(candidate)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_pubspec_lock() {
+        let content = r#"packages:
+  http:
+    dependency: direct main
+    description:
+      name: http
+      sha256: "abc123"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  path:
+    dependency: direct main
+    description:
+      name: path
+      sha256: "def456"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.0"
+sdks:
+  dart: ">=3.0.0 <4.0.0"
+"#;
+        let map = parse_pubspec_lock(content);
+        assert_eq!(map.get("http").map(|s| s.as_str()), Some("1.1.0"));
+        assert_eq!(map.get("path").map(|s| s.as_str()), Some("1.9.0"));
+        assert!(!map.contains_key("dart"));
+    }
+
+    #[test]
+    fn test_parse_sdk_source() {
+        let content = r#"packages:
+  flutter:
+    dependency: direct main
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+"#;
+        let map = parse_pubspec_lock(content);
+        assert_eq!(map.get("flutter").map(|s| s.as_str()), Some("0.0.0"));
+    }
+
+    #[test]
+    fn test_parse_git_source() {
+        let content = r#"packages:
+  my_package:
+    dependency: direct main
+    description:
+      path: "."
+      ref: main
+      resolved-ref: "abc123def456"
+      url: "https://github.com/example/my_package.git"
+    source: git
+    version: "2.0.0"
+"#;
+        let map = parse_pubspec_lock(content);
+        assert_eq!(map.get("my_package").map(|s| s.as_str()), Some("2.0.0"));
+    }
+
+    #[test]
+    fn test_parse_path_source() {
+        let content = r#"packages:
+  local_lib:
+    dependency: direct main
+    description:
+      path: "../local_lib"
+      relative: true
+    source: path
+    version: "0.1.0"
+"#;
+        let map = parse_pubspec_lock(content);
+        assert_eq!(map.get("local_lib").map(|s| s.as_str()), Some("0.1.0"));
+    }
+
+    #[test]
+    fn test_parse_empty_content() {
+        let map = parse_pubspec_lock("");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_parse_malformed_content() {
+        let map = parse_pubspec_lock("}{not valid content at all}}{{");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_version_at_wrong_indent_ignored() {
+        let content = r#"packages:
+  http:
+    dependency: direct main
+    source: hosted
+     version: "1.0.0"
+"#;
+        // version at 5-space indent (wrong) should be ignored
+        let map = parse_pubspec_lock(content);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_package_without_version_omitted() {
+        let content = r#"packages:
+  incomplete_pkg:
+    dependency: direct main
+    source: hosted
+  complete_pkg:
+    dependency: direct main
+    source: hosted
+    version: "1.0.0"
+"#;
+        let map = parse_pubspec_lock(content);
+        assert!(!map.contains_key("incomplete_pkg"));
+        assert_eq!(map.get("complete_pkg").map(|s| s.as_str()), Some("1.0.0"));
+    }
+
+    #[test]
+    fn test_duplicate_package_keeps_first() {
+        let content = r#"packages:
+  http:
+    dependency: direct main
+    source: hosted
+    version: "1.0.0"
+  http:
+    dependency: transitive
+    source: hosted
+    version: "2.0.0"
+"#;
+        let map = parse_pubspec_lock(content);
+        assert_eq!(map.get("http").map(|s| s.as_str()), Some("1.0.0"));
+    }
+
+    #[test]
+    fn test_various_version_formats() {
+        let content = r#"packages:
+  stable_pkg:
+    dependency: direct main
+    source: hosted
+    version: "1.2.3"
+  prerelease_pkg:
+    dependency: direct main
+    source: hosted
+    version: "2.0.0-beta.1"
+  dev_pkg:
+    dependency: direct dev
+    source: hosted
+    version: "0.0.1+hotfix.1"
+"#;
+        let map = parse_pubspec_lock(content);
+        assert_eq!(map.get("stable_pkg").map(|s| s.as_str()), Some("1.2.3"));
+        assert_eq!(
+            map.get("prerelease_pkg").map(|s| s.as_str()),
+            Some("2.0.0-beta.1")
+        );
+        assert_eq!(
+            map.get("dev_pkg").map(|s| s.as_str()),
+            Some("0.0.1+hotfix.1")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `pubspec.lock` parser (`dependi-lsp/src/parsers/pubspec_lock.rs`) to resolve exact locked versions for Dart dependencies, eliminating false-positive "update available" warnings when `pubspec.yaml` uses version ranges (e.g., `^1.0.0`)
- Integrate lockfile resolution in backend for `FileType::Dart` following the established pattern (Cargo, npm, Python, Go, PHP)
- Unlike other lockfile parsers, `find_pubspec_lock` only checks the co-located directory (no upward traversal) because Dart's `pub` tool always places `pubspec.lock` alongside `pubspec.yaml`

**Part of #186** — Dart is the 6th ecosystem with lockfile support (3 remaining: C#, Ruby, ~~Dart~~)

### Files changed
| File | Change |
|------|--------|
| `dependi-lsp/src/parsers/pubspec_lock.rs` | New parser with `parse_pubspec_lock()`, `find_pubspec_lock()`, and 10 unit tests |
| `dependi-lsp/src/parsers/mod.rs` | Register `pubspec_lock` module |
| `dependi-lsp/src/backend.rs` | Add Dart lockfile resolution block |
| `CHANGELOG.md` | Add feature entry |

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test --lib` — 468 tests pass (including 10 new pubspec_lock tests)
- [x] `cargo test --test integration_test` — 7 tests pass
- [ ] Manual test with a Dart project using version ranges in pubspec.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive Dart programming language support with `pubspec.lock` lockfile parsing capabilities to accurately resolve dependency versions
  * Implemented automatic version tracking and resolution for Dart packages to provide precise dependency status information

* **Bug Fixes**
  * Eliminated false-positive "update available" warnings for Dart dependencies through proper lockfile version analysis and resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->