### PR TITLE
feat: add C# lockfile version resolution (packages.lock.json)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add PHP lockfile version resolution to eliminate false-positive "update available" warnings for `composer.json` dependencies ([#186](https://github.com/mpiton/zed-dependi/issues/186))
   - `composer.lock` (Composer)
 - Add Dart lockfile version resolution (`pubspec.lock`) to eliminate false-positive update warnings
+- Add C# lockfile version resolution (`packages.lock.json`) to eliminate false-positive update warnings
 
 ### Fixed
 

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -340,6 +340,47 @@ impl ProcessingContext {
             }
         }
 
+        // Resolve versions from packages.lock.json for C# dependencies
+        if file_type == FileType::Csharp {
+            if let Ok(csproj_path) = uri.to_file_path() {
+                if let Some(lock_path) =
+                    crate::parsers::packages_lock_json::find_packages_lock(&csproj_path).await
+                {
+                    match tokio::fs::read_to_string(&lock_path).await {
+                        Ok(lock_content) => {
+                            let lock_versions =
+                                crate::parsers::packages_lock_json::parse_packages_lock(
+                                    &lock_content,
+                                );
+                            for dep in &mut dependencies {
+                                let normalized =
+                                    crate::parsers::packages_lock_json::normalize_nuget_name(
+                                        &dep.name,
+                                    );
+                                if let Some(resolved) = lock_versions.get(&normalized) {
+                                    dep.resolved_version = Some(resolved.clone());
+                                }
+                            }
+                            tracing::debug!(
+                                "Resolved {} C# versions from packages.lock.json at {}",
+                                dependencies
+                                    .iter()
+                                    .filter(|d| d.resolved_version.is_some())
+                                    .count(),
+                                lock_path.display()
+                            );
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                "Could not read packages.lock.json at {}: {e}",
+                                lock_path.display(),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
         tracing::info!(
             "Parsed {} dependencies from {}",
             dependencies.len(),

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -53,6 +53,7 @@ pub mod go;
 pub mod go_sum;
 pub mod npm;
 pub mod npm_lock;
+pub mod packages_lock_json;
 pub mod php;
 pub mod pubspec_lock;
 pub mod python;

--- a/dependi-lsp/src/parsers/packages_lock_json.rs
+++ b/dependi-lsp/src/parsers/packages_lock_json.rs
@@ -1,0 +1,257 @@
+//! Parser for packages.lock.json files — resolves exact locked versions for C# (NuGet) dependencies.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Normalize a NuGet package name to lowercase.
+///
+/// NuGet package names are case-insensitive (e.g., "Newtonsoft.Json" == "newtonsoft.json").
+/// This function ensures consistent lookup between manifest and lockfile entries.
+pub fn normalize_nuget_name(name: &str) -> String {
+    name.to_lowercase()
+}
+
+/// Parse a packages.lock.json file and return a map of package name → resolved version.
+///
+/// packages.lock.json is a JSON file with a `"dependencies"` object whose keys are
+/// target framework monikers (e.g., "net8.0"). Each framework maps package names to
+/// objects with a `"resolved"` version field. Both "Direct" and "Transitive" entries
+/// are included. Names are normalized to lowercase since NuGet is case-insensitive.
+/// When a package appears in multiple target frameworks, the first entry is kept.
+pub fn parse_packages_lock(content: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+
+    let value: serde_json::Value = match serde_json::from_str(content) {
+        Ok(v) => v,
+        Err(_) => return map,
+    };
+
+    let dependencies = match value.get("dependencies").and_then(|d| d.as_object()) {
+        Some(deps) => deps,
+        None => return map,
+    };
+
+    for (_tfm, packages) in dependencies {
+        let packages_obj = match packages.as_object() {
+            Some(obj) => obj,
+            None => continue,
+        };
+
+        for (name, pkg_info) in packages_obj {
+            let normalized = normalize_nuget_name(name);
+            let resolved = match pkg_info.get("resolved").and_then(|v| v.as_str()) {
+                Some(v) => v.to_string(),
+                None => continue,
+            };
+            map.entry(normalized).or_insert(resolved);
+        }
+    }
+
+    map
+}
+
+/// Find the packages.lock.json file by walking up from a .csproj path.
+///
+/// Handles both single-project and monorepo layouts by searching parent directories.
+/// Uses async I/O to avoid blocking the Tokio executor on slow or networked filesystems.
+/// Stops after 10 levels to prevent infinite traversal on unusual file systems.
+pub async fn find_packages_lock(manifest_path: &Path) -> Option<PathBuf> {
+    let start_dir = manifest_path.parent()?;
+
+    let mut current = start_dir.to_path_buf();
+    let mut depth = 0;
+    const MAX_DEPTH: usize = 10;
+
+    loop {
+        let candidate = current.join("packages.lock.json");
+        if tokio::fs::try_exists(&candidate).await.unwrap_or(false) {
+            return Some(candidate);
+        }
+
+        depth += 1;
+        if depth >= MAX_DEPTH {
+            return None;
+        }
+
+        current = current.parent()?.to_path_buf();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_packages_lock() {
+        let content = r#"{
+            "version": 1,
+            "dependencies": {
+                "net8.0": {
+                    "Newtonsoft.Json": {
+                        "type": "Direct",
+                        "requested": "[13.0.1, )",
+                        "resolved": "13.0.1",
+                        "contentHash": "abc123",
+                        "dependencies": {}
+                    },
+                    "Microsoft.Extensions.Logging": {
+                        "type": "Transitive",
+                        "resolved": "8.0.0",
+                        "dependencies": {}
+                    }
+                }
+            }
+        }"#;
+        let map = parse_packages_lock(content);
+        assert_eq!(
+            map.get("newtonsoft.json").map(|s| s.as_str()),
+            Some("13.0.1")
+        );
+        assert_eq!(
+            map.get("microsoft.extensions.logging").map(|s| s.as_str()),
+            Some("8.0.0")
+        );
+    }
+
+    #[test]
+    fn test_parse_multiple_target_frameworks() {
+        let content = r#"{
+            "version": 1,
+            "dependencies": {
+                "net6.0": {
+                    "PackageA": {
+                        "type": "Direct",
+                        "resolved": "1.0.0",
+                        "dependencies": {}
+                    }
+                },
+                "net8.0": {
+                    "PackageB": {
+                        "type": "Direct",
+                        "resolved": "2.0.0",
+                        "dependencies": {}
+                    }
+                }
+            }
+        }"#;
+        let map = parse_packages_lock(content);
+        assert_eq!(map.get("packagea").map(|s| s.as_str()), Some("1.0.0"));
+        assert_eq!(map.get("packageb").map(|s| s.as_str()), Some("2.0.0"));
+    }
+
+    #[test]
+    fn test_parse_transitive_and_direct() {
+        let content = r#"{
+            "version": 1,
+            "dependencies": {
+                "net8.0": {
+                    "DirectPkg": {
+                        "type": "Direct",
+                        "resolved": "3.0.0",
+                        "dependencies": {}
+                    },
+                    "TransitivePkg": {
+                        "type": "Transitive",
+                        "resolved": "1.5.0",
+                        "dependencies": {}
+                    }
+                }
+            }
+        }"#;
+        let map = parse_packages_lock(content);
+        assert_eq!(map.get("directpkg").map(|s| s.as_str()), Some("3.0.0"));
+        assert_eq!(map.get("transitivepkg").map(|s| s.as_str()), Some("1.5.0"));
+    }
+
+    #[test]
+    fn test_parse_empty_content() {
+        let map = parse_packages_lock("");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_parse_invalid_json() {
+        let map = parse_packages_lock("not valid json {[");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_duplicate_package_keeps_first() {
+        let content = r#"{
+            "version": 1,
+            "dependencies": {
+                "net6.0": {
+                    "SharedPkg": {
+                        "type": "Direct",
+                        "resolved": "1.0.0",
+                        "dependencies": {}
+                    }
+                },
+                "net8.0": {
+                    "SharedPkg": {
+                        "type": "Direct",
+                        "resolved": "2.0.0",
+                        "dependencies": {}
+                    }
+                }
+            }
+        }"#;
+        let map = parse_packages_lock(content);
+        // First TFM entry wins; serde_json preserves insertion order for objects
+        assert!(map.contains_key("sharedpkg"));
+        let version = map.get("sharedpkg").unwrap();
+        assert!(version == "1.0.0" || version == "2.0.0");
+    }
+
+    #[test]
+    fn test_case_insensitive_names() {
+        let content = r#"{
+            "version": 1,
+            "dependencies": {
+                "net8.0": {
+                    "Newtonsoft.Json": {
+                        "type": "Direct",
+                        "resolved": "13.0.1",
+                        "dependencies": {}
+                    }
+                }
+            }
+        }"#;
+        let map = parse_packages_lock(content);
+        assert!(map.contains_key("newtonsoft.json"));
+        assert!(!map.contains_key("Newtonsoft.Json"));
+    }
+
+    #[test]
+    fn test_various_version_formats() {
+        let content = r#"{
+            "version": 1,
+            "dependencies": {
+                "net8.0": {
+                    "StablePkg": {
+                        "type": "Direct",
+                        "resolved": "13.0.1",
+                        "dependencies": {}
+                    },
+                    "PreviewPkg": {
+                        "type": "Direct",
+                        "resolved": "8.0.0-preview.1",
+                        "dependencies": {}
+                    },
+                    "FourPartPkg": {
+                        "type": "Direct",
+                        "resolved": "4.3.0.0",
+                        "dependencies": {}
+                    }
+                }
+            }
+        }"#;
+        let map = parse_packages_lock(content);
+        assert_eq!(map.get("stablepkg").map(|s| s.as_str()), Some("13.0.1"));
+        assert_eq!(
+            map.get("previewpkg").map(|s| s.as_str()),
+            Some("8.0.0-preview.1")
+        );
+        assert_eq!(map.get("fourpartpkg").map(|s| s.as_str()), Some("4.3.0.0"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add C# lockfile version resolution (`packages.lock.json`) to eliminate false-positive "update available" warnings when `.csproj` files use minimal version syntax
- Implements the 7th ecosystem lockfile integration for issue #186 (C# was one of 2 remaining: C# and Ruby)

## Changes

- **New file:** `dependi-lsp/src/parsers/packages_lock_json.rs` — Parser for NuGet's `packages.lock.json` format
  - `parse_packages_lock()` extracts `resolved` versions from all target framework sections
  - `find_packages_lock()` async directory traversal (up to 10 levels) to locate lockfile
  - `normalize_nuget_name()` for case-insensitive package name matching (NuGet convention)
  - 8 unit tests covering: basic parsing, multi-TFM, Direct+Transitive types, empty/invalid content, duplicates, case normalization, version formats (semver, pre-release, 4-part)
- **Modified:** `dependi-lsp/src/parsers/mod.rs` — Module registration
- **Modified:** `dependi-lsp/src/backend.rs` — C# lockfile resolution block in `process_document`
- **Modified:** `CHANGELOG.md` — Added entry under [Unreleased]

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test --lib` — 476 passed, 0 failed
- [x] `cargo test --test integration_test` — 7 passed, 0 failed

Ref: #186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added C# lockfile version resolution that reads `packages.lock.json` files to accurately determine resolved NuGet package versions, eliminating false-positive "update available" warnings for C# projects.

* **Documentation**
  * Updated changelog with entry documenting C# lockfile version resolution capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->