### PR TITLE
fix: use cargo-zigbuild to target GLIBC 2.17 for Linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,18 +47,41 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation toolchain
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-          echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      - name: Install Zig
+        if: contains(matrix.target, 'linux')
+        uses: mlugg/setup-zig@v2
 
-      - name: Build
+      - name: Install cargo-zigbuild
+        if: contains(matrix.target, 'linux')
+        run: cargo install cargo-zigbuild@0.19.8 --locked
+
+      - name: Build (Linux - GLIBC 2.17)
+        if: contains(matrix.target, 'linux')
+        run: |
+          cd dependi-lsp
+          cargo zigbuild --release --target ${{ matrix.target }}.2.17
+
+      - name: Build (macOS / Windows)
+        if: ${{ !contains(matrix.target, 'linux') }}
         run: |
           cd dependi-lsp
           cargo build --release --target ${{ matrix.target }}
+
+      - name: Verify GLIBC compatibility
+        if: contains(matrix.target, 'linux')
+        run: |
+          binary="dependi-lsp/target/${{ matrix.target }}/release/dependi-lsp"
+          max_glibc=$(readelf -V "$binary" 2>/dev/null | grep -oP 'GLIBC_\K[0-9.]+' | sort -V | tail -1)
+          if [ -z "$max_glibc" ]; then
+            echo "::error::Could not determine GLIBC requirement from binary (no GLIBC_ symbols found)"
+            exit 1
+          fi
+          echo "Maximum GLIBC required: $max_glibc"
+          if [ "$(printf '%s\n' "2.17" "$max_glibc" | sort -V | tail -1)" != "2.17" ]; then
+            echo "::error::Binary requires GLIBC $max_glibc, expected <= 2.17"
+            exit 1
+          fi
+          echo "✓ GLIBC compatibility verified: requires <= $max_glibc"
 
       - name: Package (Unix)
         if: matrix.os != 'windows-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix false-positive "update available" reports when using minimal version syntax (e.g., `bon = "3.9"`) by reading resolved versions from `Cargo.lock` ([#184](https://github.com/mpiton/zed-dependi/issues/184))
 - Fix false-positive vulnerability reports by normalizing version operators before OSV.dev queries ([#181](https://github.com/mpiton/zed-dependi/issues/181))
 - Use async I/O for lockfile discovery to avoid blocking the Tokio executor
+- Fix GLIBC compatibility on older Linux systems (Ubuntu 22.04, WSL) by targeting GLIBC 2.17 with cargo-zigbuild ([#198](https://github.com/mpiton/zed-dependi/issues/198))
 
 ## [1.5.0] - 2026-03-16
 


### PR DESCRIPTION
## Summary

- Use `cargo-zigbuild` to build Linux binaries against GLIBC 2.17 instead of the runner's GLIBC (2.39 on `ubuntu-latest`), fixing the extension crash on WSL with Ubuntu 22.04
- Replace `gcc-aarch64-linux-gnu` cross-compilation with Zig, which handles both x86_64 and aarch64 natively
- Add a GLIBC compatibility verification step for all Linux targets that fails CI if the binary requires GLIBC > 2.17
- Pin `cargo-zigbuild` to version 0.19.8 for reproducible builds

### Root Cause

The `dependi-lsp` binary was compiled on `ubuntu-latest` (Ubuntu 24.04, GLIBC 2.39), producing a binary that requires `GLIBC_2.38`. Users on Ubuntu 22.04 WSL (GLIBC 2.35) got:

```
GLIBC_2.38 not found (required by dependi-lsp)
```

### Solution

`cargo-zigbuild` uses Zig as the linker/C compiler, which can target any GLIBC version. By targeting GLIBC 2.17 (CentOS 7+), the binary runs on virtually all Linux distributions in use today.

### CI Safety Net

A new verification step uses `readelf` to check the maximum GLIBC version required by the binary. If any symbol references GLIBC > 2.17, the build fails immediately — preventing future regressions.

Closes #198

## Test plan

- [x] All 488 unit tests pass
- [x] Clippy: 0 warnings
- [x] Fmt: clean
- [ ] CI release workflow builds successfully on tag push (Linux x86_64 + aarch64)
- [ ] Produced binary runs on Ubuntu 22.04 WSL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older Linux systems (e.g., Ubuntu 22.04, WSL) by ensuring binaries target GLIBC 2.17 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->