### PR TITLE
feat(python): add hatch env parsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Dependency management extension for the [Zed](https://zed.dev) editor.
 |----------|------|----------|--------|
 | Rust | `Cargo.toml` | crates.io + alternative registries | ✅ |
 | JavaScript/TypeScript | `package.json` | npm | ✅ |
-| Python | `requirements.txt`, `constraints.txt`, `pyproject.toml` | PyPI | ✅ |
+| Python | `requirements.txt`, `constraints.txt`, `pyproject.toml`, `hatch.toml` | PyPI | ✅ |
 | Go | `go.mod` | proxy.golang.org | ✅ |
 | PHP | `composer.json` | Packagist | ✅ |
 | Dart/Flutter | `pubspec.yaml` | pub.dev | ✅ |
@@ -104,7 +104,7 @@ zed-dependi/
 │   │   │   ├── cargo_lock.rs # Cargo.lock lockfile
 │   │   │   ├── npm.rs     # package.json parser
 │   │   │   ├── npm_lock.rs # package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lock
-│   │   │   ├── python.rs  # requirements.txt, constraints.txt, pyproject.toml
+│   │   │   ├── python.rs  # requirements.txt, constraints.txt, pyproject.toml, hatch.toml
 │   │   │   ├── python_lock.rs # poetry.lock, uv.lock, pdm.lock, Pipfile.lock
 │   │   │   ├── go.rs      # go.mod parser
 │   │   │   ├── go_sum.rs  # go.sum lockfile
@@ -347,7 +347,7 @@ dependi-lsp scan --file <path> [options]
 
 - Rust: `Cargo.toml`
 - JavaScript/TypeScript: `package.json`
-- Python: `requirements.txt`, `constraints.txt`, `pyproject.toml`
+- Python: `requirements.txt`, `constraints.txt`, `pyproject.toml`, `hatch.toml`
 - Go: `go.mod`
 - PHP: `composer.json`
 - Dart/Flutter: `pubspec.yaml`

--- a/dependi-lsp/fuzz/corpus/fuzz_python/hatch.toml
+++ b/dependi-lsp/fuzz/corpus/fuzz_python/hatch.toml
@@ -1,0 +1,13 @@
+[envs.default]
+dependencies = [
+    "mypy>=1.0.0",
+]
+
+[envs.test]
+dependencies = [
+    "pytest>=7.0.0",
+    "coverage>=6.0",
+]
+extra-dependencies = [
+    "baz>=1.0",
+]

--- a/dependi-lsp/fuzz/corpus/fuzz_python/hatch_pyproject_basic.toml
+++ b/dependi-lsp/fuzz/corpus/fuzz_python/hatch_pyproject_basic.toml
@@ -1,0 +1,5 @@
+[tool.hatch.envs.test]
+dependencies = [
+    "pytest>=7.0.0",
+    "coverage>=6.0",
+]

--- a/dependi-lsp/fuzz/corpus/fuzz_python/hatch_pyproject_combined.toml
+++ b/dependi-lsp/fuzz/corpus/fuzz_python/hatch_pyproject_combined.toml
@@ -1,0 +1,22 @@
+[project]
+name = "myapp"
+version = "1.0.0"
+dependencies = [
+    "flask>=2.0.0",
+    "requests~=2.25.0",
+]
+
+[project.optional-dependencies]
+extras = [
+    "redis>=4.0.0",
+]
+
+[tool.hatch.envs.test]
+dependencies = [
+    "pytest>=7.0.0",
+    "coverage[toml]>=6.0",
+]
+
+[tool.hatch.envs.lint]
+dependencies = ["ruff>=0.1.0"]
+extra-dependencies = ["mypy>=1.0.0"]

--- a/dependi-lsp/fuzz/corpus/fuzz_python/hatch_pyproject_extra.toml
+++ b/dependi-lsp/fuzz/corpus/fuzz_python/hatch_pyproject_extra.toml
@@ -1,0 +1,10 @@
+[tool.hatch.envs.default]
+dependencies = [
+    "foo>=1.0",
+    "bar>=2.0",
+]
+
+[tool.hatch.envs.experimental]
+extra-dependencies = [
+    "baz>=1.0",
+]

--- a/dependi-lsp/fuzz/corpus/fuzz_python/pyproject_dependency_groups.toml
+++ b/dependi-lsp/fuzz/corpus/fuzz_python/pyproject_dependency_groups.toml
@@ -1,6 +1,0 @@
-[dependency-groups]
-test = ["pytest>=7.0.0", "coverage>=7.0.0"]
-typing = ["mypy>=1.0.0", "types-requests>=2.0.0"]
-lint = ["ruff>=0.1.0", "black>=23.0.0"]
-typing-test = [{include-group = "typing"}, {include-group = "test"}, "useful-types>=1.0.0"]
-all = [{include-group = "test"}, {include-group = "typing"}, {include-group = "lint"}]

--- a/dependi-lsp/src/file_types.rs
+++ b/dependi-lsp/src/file_types.rs
@@ -60,6 +60,10 @@ impl FileType {
             Some(FileType::Csharp)
         } else if path.ends_with("Gemfile") {
             Some(FileType::Ruby)
+        } else if filename == "hatch.toml" {
+            // Hatch project-level config; the filename is always `hatch.toml`.
+            // Routed to FileType::Python because dependencies resolve via PyPI.
+            Some(FileType::Python)
         } else {
             None
         }
@@ -230,6 +234,22 @@ mod tests {
     fn test_detect_ruby() {
         let uri = Url::parse("file:///project/Gemfile").unwrap();
         assert_eq!(FileType::detect(&uri), Some(FileType::Ruby));
+    }
+
+    #[test]
+    fn test_detect_hatch_toml() {
+        // hatch.toml at project root
+        let uri = Url::parse("file:///project/hatch.toml").unwrap();
+        assert_eq!(FileType::detect(&uri), Some(FileType::Python));
+
+        // hatch.toml nested inside a subdirectory
+        let uri = Url::parse("file:///project/subdir/hatch.toml").unwrap();
+        assert_eq!(FileType::detect(&uri), Some(FileType::Python));
+
+        // A file that merely ends in "hatch.toml" as part of a longer name
+        // is intentionally NOT matched (rsplit behaviour ensures full filename match).
+        let uri = Url::parse("file:///project/not-hatch.toml").unwrap();
+        assert_eq!(FileType::detect(&uri), None);
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/python.rs
+++ b/dependi-lsp/src/parsers/python.rs
@@ -1,4 +1,4 @@
-//! Parser for Python dependency files (requirements.txt, constraints.txt, pyproject.toml)
+//! Parser for Python dependency files (requirements.txt, constraints.txt, pyproject.toml, hatch.toml)
 
 use super::{Dependency, Parser};
 
@@ -14,11 +14,15 @@ impl PythonParser {
 
 impl Parser for PythonParser {
     fn parse(&self, content: &str) -> Vec<Dependency> {
-        // Detect file type based on content
-        // Only parse as TOML if it contains valid pyproject.toml section headers
-        // Use line-anchored detection to avoid false positives like "mypkg[project]==1.2"
+        // Detect file type based on content.
+        // Only parse as TOML if it contains valid pyproject.toml section headers.
+        // Use line-anchored detection to avoid false positives like "mypkg[project]==1.2".
+        // is_pyproject_toml is checked first so that a pyproject.toml that also uses
+        // [tool.hatch.envs.*] is routed through parse_pyproject_toml (which handles both).
         if is_pyproject_toml(content) {
             parse_pyproject_toml(content)
+        } else if is_hatch_toml(content) {
+            parse_hatch_toml(content)
         } else {
             parse_requirements_txt(content)
         }
@@ -46,6 +50,33 @@ fn is_pyproject_toml(content: &str) -> bool {
             && is_valid_section_header(trimmed, "[dependency-groups")
         {
             return true;
+        }
+        // Match [tool.hatch...] section headers (e.g., [tool.hatch.envs.test])
+        if trimmed.starts_with("[tool.hatch") && is_valid_section_header(trimmed, "[tool.hatch") {
+            return true;
+        }
+    }
+    false
+}
+
+/// Detect a standalone hatch.toml file.
+///
+/// The project-level Hatch config is always stored in a file named `hatch.toml`;
+/// the filename cannot be changed. `file_types.rs` therefore gates entry to this
+/// code path via a filename check, making content-based false positives impossible
+/// in practice. Detection requires a top-level `[envs.<NAME>]` section header
+/// with a mandatory dot-separated env name (bare `[envs]` is not a valid hatch section).
+fn is_hatch_toml(content: &str) -> bool {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        // Require "[envs." (dot included) so that a bare "[envs]" is never matched.
+        if trimmed.starts_with("[envs.")
+            && let Some(close) = trimmed.find(']')
+        {
+            let after = trimmed[close + 1..].trim_start();
+            if after.is_empty() || after.starts_with('#') {
+                return true;
+            }
         }
     }
     false
@@ -200,7 +231,7 @@ fn parse_requirement_line(line: &str, line_num: u32, dev: bool) -> Option<Depend
     })
 }
 
-/// Parse pyproject.toml format (PEP 621 + Poetry)
+/// Parse pyproject.toml format (PEP 621 + Poetry + Hatch)
 fn parse_pyproject_toml(content: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
@@ -364,8 +395,89 @@ fn parse_pyproject_toml(content: &str) -> Vec<Dependency> {
             }
         }
     }
+    // Hatch: [tool.hatch.envs.<ENV_NAME>]
+    // Both `dependencies` and `extra-dependencies` are PEP 508 string arrays.
+    // Matrix overrides (e.g. [tool.hatch.envs.test.overrides.matrix.*.dependencies])
+    // use a different inline-table value format and are out of scope.
+    let hatch_envs = dom.get("tool").get("hatch").get("envs");
+    collect_hatch_env_deps(&hatch_envs, content, &mut dependencies);
 
     dependencies
+}
+
+/// Parse a standalone `hatch.toml` file.
+///
+/// The project-level Hatch config is always stored in a file named `hatch.toml`.
+/// In this format the envs table lives at the top level under `envs`
+/// (no `tool.hatch` prefix as in pyproject.toml).
+fn parse_hatch_toml(content: &str) -> Vec<Dependency> {
+    let mut dependencies = Vec::new();
+
+    let parsed = taplo::parser::parse(content);
+    if !parsed.errors.is_empty() {
+        return dependencies;
+    }
+
+    let dom = parsed.into_dom();
+    let envs_node = dom.get("envs");
+    collect_hatch_env_deps(&envs_node, content, &mut dependencies);
+
+    dependencies
+}
+
+/// Collect `dependencies` and `extra-dependencies` from a hatch envs Node.
+///
+/// `envs_node` is the taplo node for the envs table:
+/// - `dom["tool"]["hatch"]["envs"]` when called from `parse_pyproject_toml`
+/// - `dom["envs"]`                  when called from `parse_hatch_toml`
+///
+/// Flags set on every collected dependency:
+/// - `dev = true`       — hatch env deps are extras layered on top of
+///   `[project.dependencies]`; they are always dev/test tooling.
+/// - `optional = false` — they are unconditionally installed when the env is
+///   activated; they are not PEP 508 optional extras (project features/extras).
+///
+/// Context-formatted strings (e.g. `"{root:parent:uri}/pkg"`, `"{env:PKG:default}"`)
+/// contain no PEP 508 version operator, so `parse_pep508_dependency` returns `None`
+/// and they are silently skipped — identical to the treatment of unversioned plain
+/// strings.
+///
+/// Env inheritance (`template` option) is not followed; only deps declared directly
+/// in each env are emitted. This mirrors the treatment of Poetry group inheritance.
+///
+/// The `dependency-groups` key inside a hatch env is a reference to groups already
+/// parsed elsewhere (e.g. from a `[dependency-groups]` table in the same file);
+/// following those references here would produce duplicate entries.
+fn collect_hatch_env_deps(
+    envs_node: &taplo::dom::Node,
+    content: &str,
+    dependencies: &mut Vec<Dependency>,
+) {
+    let Some(envs_table) = envs_node.as_table() else {
+        return;
+    };
+    let env_entries = envs_table.entries().read();
+    for (_env_name, env_value) in env_entries.iter() {
+        for key in ["dependencies", "extra-dependencies"] {
+            let deps_node = env_value.get(key);
+            let Some(deps_array) = deps_node.as_array() else {
+                continue;
+            };
+            let items = deps_array.items().read();
+            for item in items.iter() {
+                let Some(dep_str) = item.as_str() else {
+                    continue;
+                };
+                let dep_str = dep_str.value();
+                if let Some((name, version)) = parse_pep508_dependency(dep_str)
+                    && let Some(mut dep) = find_dependency_position(content, &name, &version, true)
+                {
+                    dep.optional = false; // env deps are required within their env
+                    dependencies.push(dep);
+                }
+            }
+        }
+    }
 }
 
 /// Parse PEP 508 dependency string: "package>=1.0.0" or "package[extra]>=1.0.0"
@@ -712,13 +824,26 @@ flask>=2.0.0
             "[dependency-groups] # comment\ntest = []"
         ));
         assert!(is_pyproject_toml("  [dependency-groups]  \ntest = []"));
+        // Valid [tool.hatch] patterns
+        assert!(is_pyproject_toml(
+            "[tool.hatch.envs.test]\ndependencies = []"
+        ));
+        assert!(is_pyproject_toml(
+            "[tool.hatch.envs.default]\ndependencies = []"
+        ));
+        assert!(is_pyproject_toml("[tool.hatch] # comment\nversion = {}"));
+        assert!(is_pyproject_toml(
+            "[tool.hatch.envs.test.scripts]\ntest = \"pytest\""
+        ));
 
         // Invalid patterns (should not trigger TOML parsing)
         assert!(!is_pyproject_toml("mypkg[project]==1.2"));
         assert!(!is_pyproject_toml("pkg[tool.poetry]>=1.0"));
+        assert!(!is_pyproject_toml("pkg[tool.hatch]>=1.0"));
         assert!(!is_pyproject_toml("[projects]\nname = \"test\"")); // not [project]
         assert!(!is_pyproject_toml("[projectx]\nname = \"test\"")); // not [project] or [project.*]
         assert!(!is_pyproject_toml("[tool.poetryextra]\nname = \"test\"")); // not [tool.poetry...]
+        assert!(!is_pyproject_toml("[tool.hatchextra]\nname = \"test\"")); // not [tool.hatch...]
         assert!(!is_pyproject_toml("flask>=2.0.0\nrequests>=2.25.0"));
         assert!(!is_pyproject_toml("[dependency-groupsx]\ntest = []")); // not [dependency-groups]
     }
@@ -768,5 +893,267 @@ unversioned = ["bare-package"]
 
         // bare-package has no version operator → must not appear
         assert!(!deps.iter().any(|d| d.name == "bare-package"));
+    }
+
+    #[test]
+    fn test_is_hatch_toml_detection() {
+        // Valid: top-level [envs.<name>] section
+        assert!(is_hatch_toml("[envs.test]\ndependencies = []"));
+        assert!(is_hatch_toml("[envs.default]\ndependencies = []"));
+        // Sub-tables of an env are also valid triggers
+        assert!(is_hatch_toml("[envs.test.scripts]\ntest = \"pytest\""));
+        // Inline comment after closing bracket
+        assert!(is_hatch_toml(
+            "[envs.test] # my test env\ndependencies = []"
+        ));
+        // Leading whitespace on header line
+        assert!(is_hatch_toml("  [envs.test]  \ndependencies = []"));
+
+        // Invalid: bare [envs] without a name
+        assert!(!is_hatch_toml("[envs]\ndependencies = []"));
+        // Invalid: different top-level key
+        assert!(!is_hatch_toml("[envsx.test]\ndependencies = []"));
+        // Invalid: content that would be pyproject.toml
+        assert!(!is_hatch_toml("[project]\nname = \"test\""));
+        // Invalid: requirements.txt style
+        assert!(!is_hatch_toml("flask>=2.0.0\nrequests>=2.25.0"));
+        // Invalid: env name is part of a value, not a section header
+        assert!(!is_hatch_toml("template = \"[envs.default]\""));
+    }
+
+    #[test]
+    fn test_pyproject_hatch_deps() {
+        // Basic [tool.hatch.envs.*] with dependencies
+        let parser = PythonParser::new();
+        let content = r#"
+[project]
+name = "myproject"
+version = "1.0.0"
+
+[tool.hatch.envs.test]
+dependencies = [
+    "pytest>=7.0.0",
+    "coverage>=6.0",
+]
+"#;
+        let deps = parser.parse(content);
+        assert_eq!(deps.len(), 2);
+
+        let pytest = deps.iter().find(|d| d.name == "pytest").unwrap();
+        assert_eq!(pytest.version, ">=7.0.0");
+        assert!(pytest.dev);
+        assert!(!pytest.optional);
+
+        let coverage = deps.iter().find(|d| d.name == "coverage").unwrap();
+        assert_eq!(coverage.version, ">=6.0");
+        assert!(coverage.dev);
+        assert!(!coverage.optional);
+    }
+
+    #[test]
+    fn test_pyproject_hatch_extra_deps() {
+        // extra-dependencies in a hatch env
+        let parser = PythonParser::new();
+        let content = r#"
+[project]
+name = "myproject"
+
+[tool.hatch.envs.default]
+dependencies = [
+    "foo>=1.0",
+]
+
+[tool.hatch.envs.experimental]
+extra-dependencies = [
+    "baz>=2.0",
+]
+"#;
+        let deps = parser.parse(content);
+        assert_eq!(deps.len(), 2);
+
+        let foo = deps.iter().find(|d| d.name == "foo").unwrap();
+        assert_eq!(foo.version, ">=1.0");
+        assert!(foo.dev);
+        assert!(!foo.optional);
+
+        let baz = deps.iter().find(|d| d.name == "baz").unwrap();
+        assert_eq!(baz.version, ">=2.0");
+        assert!(baz.dev);
+        assert!(!baz.optional);
+    }
+
+    #[test]
+    fn test_pyproject_hatch_multiple_envs() {
+        // Several named envs each contributing deps; all dev=true, optional=false
+        let parser = PythonParser::new();
+        let content = r#"
+[project]
+name = "myproject"
+
+[tool.hatch.envs.default]
+dependencies = ["requests>=2.28.0"]
+
+[tool.hatch.envs.test]
+dependencies = [
+    "pytest>=7.0.0",
+    "coverage[toml]>=6.0",
+]
+
+[tool.hatch.envs.lint]
+dependencies = [
+    "ruff>=0.1.0",
+    "mypy>=1.0.0",
+]
+extra-dependencies = [
+    "types-requests>=2.28.0",
+]
+"#;
+        let deps = parser.parse(content);
+        assert_eq!(deps.len(), 6);
+        assert!(deps.iter().all(|d| d.dev));
+        assert!(deps.iter().all(|d| !d.optional));
+
+        assert!(deps.iter().any(|d| d.name == "requests"));
+        assert!(deps.iter().any(|d| d.name == "pytest"));
+        assert!(deps.iter().any(|d| d.name == "coverage"));
+        assert!(deps.iter().any(|d| d.name == "ruff"));
+        assert!(deps.iter().any(|d| d.name == "mypy"));
+        assert!(deps.iter().any(|d| d.name == "types-requests"));
+    }
+
+    #[test]
+    fn test_pyproject_hatch_no_version() {
+        // Bare package name without a version operator is silently dropped
+        let parser = PythonParser::new();
+        let content = r#"
+[tool.hatch.envs.test]
+dependencies = [
+    "bare-package",
+    "pytest>=7.0.0",
+]
+"#;
+        let deps = parser.parse(content);
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].name, "pytest");
+        assert!(!deps.iter().any(|d| d.name == "bare-package"));
+    }
+
+    #[test]
+    fn test_pyproject_hatch_context_formatted() {
+        // Context-formatted strings (hatch-specific, no PEP 508 version operator) are
+        // silently skipped.  A versioned dep on the same env is still collected.
+        let parser = PythonParser::new();
+        let content = r#"
+[tool.hatch.envs.test]
+dependencies = [
+    "example-project @ {root:parent:parent:uri}/example-project",
+    "pytest>=7.0.0",
+]
+"#;
+        let deps = parser.parse(content);
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].name, "pytest");
+    }
+
+    #[test]
+    fn test_pyproject_hatch_combined_pep621() {
+        // pyproject.toml with [project.dependencies] (dev=false) and
+        // [tool.hatch.envs.*] (dev=true, optional=false) in the same file.
+        let parser = PythonParser::new();
+        let content = r#"
+[project]
+name = "myproject"
+dependencies = [
+    "flask>=2.0.0",
+    "requests~=2.25.0",
+]
+
+[project.optional-dependencies]
+extras = [
+    "redis>=4.0.0",
+]
+
+[tool.hatch.envs.test]
+dependencies = [
+    "pytest>=7.0.0",
+    "coverage>=6.0",
+]
+"#;
+        let deps = parser.parse(content);
+        assert_eq!(deps.len(), 5);
+
+        // Project deps: dev=false, optional=false
+        let flask = deps.iter().find(|d| d.name == "flask").unwrap();
+        assert!(!flask.dev);
+        assert!(!flask.optional);
+
+        let requests = deps.iter().find(|d| d.name == "requests").unwrap();
+        assert!(!requests.dev);
+        assert!(!requests.optional);
+
+        // Optional dep: dev=true, optional=true
+        let redis = deps.iter().find(|d| d.name == "redis").unwrap();
+        assert!(redis.dev);
+        assert!(redis.optional);
+
+        // Hatch env deps: dev=true, optional=false
+        let pytest = deps.iter().find(|d| d.name == "pytest").unwrap();
+        assert!(pytest.dev);
+        assert!(!pytest.optional);
+
+        let coverage = deps.iter().find(|d| d.name == "coverage").unwrap();
+        assert!(coverage.dev);
+        assert!(!coverage.optional);
+    }
+
+    #[test]
+    fn test_hatch_toml_basic() {
+        // Standalone hatch.toml — envs at top level under [envs.*]
+        let parser = PythonParser::new();
+        let content = r#"
+[envs.default]
+dependencies = [
+    "mypy>=1.0.0",
+]
+
+[envs.test]
+dependencies = [
+    "pytest>=7.0.0",
+    "coverage>=6.0",
+]
+"#;
+        let deps = parser.parse(content);
+        assert_eq!(deps.len(), 3);
+        assert!(deps.iter().all(|d| d.dev));
+        assert!(deps.iter().all(|d| !d.optional));
+
+        assert!(deps.iter().any(|d| d.name == "mypy"));
+        assert!(deps.iter().any(|d| d.name == "pytest"));
+        assert!(deps.iter().any(|d| d.name == "coverage"));
+    }
+
+    #[test]
+    fn test_hatch_toml_extra_deps() {
+        // extra-dependencies in standalone hatch.toml
+        let parser = PythonParser::new();
+        let content = r#"
+[envs.default]
+dependencies = [
+    "foo>=1.0",
+    "bar>=2.0",
+]
+
+[envs.experimental]
+extra-dependencies = [
+    "baz>=3.0",
+]
+"#;
+        let deps = parser.parse(content);
+        assert_eq!(deps.len(), 3);
+        assert!(deps.iter().any(|d| d.name == "foo"));
+        assert!(deps.iter().any(|d| d.name == "bar"));
+        assert!(deps.iter().any(|d| d.name == "baz"));
+        assert!(deps.iter().all(|d| d.dev));
+        assert!(deps.iter().all(|d| !d.optional));
     }
 }

--- a/dependi-lsp/src/parsers/python.rs
+++ b/dependi-lsp/src/parsers/python.rs
@@ -256,7 +256,8 @@ fn parse_pyproject_toml(content: &str) -> Vec<Dependency> {
                 if let Some(dep_str) = item.as_str() {
                     let dep_str = dep_str.value();
                     if let Some((name, version)) = parse_pep508_dependency(dep_str)
-                        && let Some(dep) = find_dependency_position(content, &name, &version, false)
+                        && let Some(dep) =
+                            find_dependency_position(content, &name, &version, false, false)
                     {
                         dependencies.push(dep);
                     }
@@ -276,7 +277,7 @@ fn parse_pyproject_toml(content: &str) -> Vec<Dependency> {
                             let dep_str = dep_str.value();
                             if let Some((name, version)) = parse_pep508_dependency(dep_str)
                                 && let Some(dep) =
-                                    find_dependency_position(content, &name, &version, true)
+                                    find_dependency_position(content, &name, &version, true, true)
                             {
                                 dependencies.push(dep);
                             }
@@ -385,7 +386,7 @@ fn parse_pyproject_toml(content: &str) -> Vec<Dependency> {
                         let dep_str = dep_str.value();
                         if let Some((name, version)) = parse_pep508_dependency(dep_str)
                             && let Some(dep) =
-                                find_dependency_position(content, &name, &version, false)
+                                find_dependency_position(content, &name, &version, false, false)
                         {
                             dependencies.push(dep);
                         }
@@ -470,9 +471,9 @@ fn collect_hatch_env_deps(
                 };
                 let dep_str = dep_str.value();
                 if let Some((name, version)) = parse_pep508_dependency(dep_str)
-                    && let Some(mut dep) = find_dependency_position(content, &name, &version, true)
+                    && let Some(dep) =
+                        find_dependency_position(content, &name, &version, true, false)
                 {
-                    dep.optional = false; // env deps are required within their env
                     dependencies.push(dep);
                 }
             }
@@ -558,6 +559,7 @@ fn find_dependency_position(
     name: &str,
     version: &str,
     dev: bool,
+    optional: bool,
 ) -> Option<Dependency> {
     for (line_idx, line) in content.lines().enumerate() {
         // Look for the dependency string in an array
@@ -583,7 +585,7 @@ fn find_dependency_position(
                     version_start,
                     version_end,
                     dev,
-                    optional: dev, // optional-dependencies are optional
+                    optional,
                     registry: None,
                     resolved_version: None,
                 });

--- a/dependi-lsp/tests/fuzz_regression.rs
+++ b/dependi-lsp/tests/fuzz_regression.rs
@@ -205,3 +205,149 @@ unversioned = ["bare-package"]
         }
     }
 }
+
+#[test]
+fn test_hatch_fuzz_pyproject() {
+    // Exercises collect_hatch_env_deps via parse_pyproject_toml:
+    // [tool.hatch.envs.*] with `dependencies` and `extra-dependencies`.
+    let parser = PythonParser::new();
+
+    // --- Valid case: multiple envs with both dep keys ---
+    let valid = r#"
+[project]
+name = "mypkg"
+version = "1.0.0"
+
+[tool.hatch.envs.default]
+dependencies = [
+    "mypy>=1.0.0",
+]
+
+[tool.hatch.envs.test]
+dependencies = [
+    "pytest>=7.0.0",
+    "coverage>=6.0",
+]
+extra-dependencies = [
+    "baz>=1.0",
+]
+"#;
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| parser.parse(valid)));
+    let deps = result.expect("should not panic on valid hatch pyproject.toml");
+    // default: 1, test: 2, extra: 1 = 4 hatch deps (plus any [project.dependencies])
+    assert_eq!(deps.len(), 4, "expected 4 hatch env deps");
+    // All hatch env deps: dev=true, optional=false
+    for dep in &deps {
+        assert!(dep.dev, "hatch env dep should be dev=true");
+        assert!(!dep.optional, "hatch env dep should be optional=false");
+    }
+    validate_deps(&deps, valid, "Python/hatch-pyproject");
+
+    // --- Edge cases: must not panic and must satisfy position invariants ---
+    let edge_cases: &[&str] = &[
+        // truncated array — no closing bracket
+        "[tool.hatch.envs.test]\ndependencies = [",
+        // empty deps array
+        "[tool.hatch.envs.test]\ndependencies = []",
+        // empty envs table
+        "[tool.hatch.envs]\n",
+        // no envs at all
+        "[tool.hatch]\n",
+        // extra-dependencies key only
+        "[tool.hatch.envs.lint]\nextra-dependencies = [\"ruff>=0.4\"]",
+        // context-formatted string — no PEP 508 version, must be silently skipped
+        "[tool.hatch.envs.test]\ndependencies = [\"{root:parent:uri}/local-pkg\"]",
+        // mixed: one context-formatted, one real dep
+        "[tool.hatch.envs.test]\ndependencies = [\"{env:MY_PKG:default}\", \"pytest>=7.0\"]",
+        // unversioned string — skipped
+        "[tool.hatch.envs.test]\ndependencies = [\"bare-package\"]",
+        // invalid PEP 508 specifier — no valid operator
+        "[tool.hatch.envs.test]\ndependencies = [\">=>==>>\"]",
+        // control characters inside string value
+        "[tool.hatch.envs.test]\ndependencies = [\"\x00\x01pytest>=7.0\"]",
+        // malformed TOML (unclosed string) — must not panic
+        "[tool.hatch.envs.test]\ndependencies = [\"pytest>=7.0",
+        // combined: [project.dependencies] + hatch envs
+        "[project]\nname = \"p\"\n\n[project.dependencies]\n# none\n\n[tool.hatch.envs.test]\ndependencies = [\"pytest>=7.0.0\"]\n",
+    ];
+
+    for content in edge_cases {
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| parser.parse(content)));
+        match result {
+            Ok(deps) => validate_deps(&deps, content, "Python/hatch-pyproject"),
+            Err(_) => panic!("Python parser panicked on hatch pyproject input:\n{content:?}"),
+        }
+    }
+}
+
+#[test]
+fn test_hatch_fuzz_standalone() {
+    // Exercises collect_hatch_env_deps via parse_hatch_toml:
+    // standalone hatch.toml uses [envs.*] (no [tool.hatch] wrapper).
+    let parser = PythonParser::new();
+
+    // --- Valid case ---
+    let valid = r#"
+[envs.default]
+dependencies = [
+    "mypy>=1.0.0",
+]
+
+[envs.test]
+dependencies = [
+    "pytest>=7.0.0",
+    "coverage>=6.0",
+]
+extra-dependencies = [
+    "baz>=1.0",
+]
+"#;
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| parser.parse(valid)));
+    let deps = result.expect("should not panic on valid standalone hatch.toml");
+    assert_eq!(
+        deps.len(),
+        4,
+        "expected 4 hatch env deps from standalone hatch.toml"
+    );
+    for dep in &deps {
+        assert!(dep.dev, "hatch env dep should be dev=true");
+        assert!(!dep.optional, "hatch env dep should be optional=false");
+    }
+    validate_deps(&deps, valid, "Python/hatch-standalone");
+
+    // --- Edge cases: must not panic and must satisfy position invariants ---
+    let edge_cases: &[&str] = &[
+        // truncated array
+        "[envs.test]\ndependencies = [",
+        // empty deps array
+        "[envs.test]\ndependencies = []",
+        // empty envs table
+        "[envs]\n",
+        // no envs key
+        "[build]\nrequires = [\"hatchling\"]\n",
+        // extra-dependencies only
+        "[envs.lint]\nextra-dependencies = [\"ruff>=0.4\"]",
+        // context-formatted string — silently skipped
+        "[envs.test]\ndependencies = [\"{root:parent:uri}/pkg\"]",
+        // mixed valid + context-formatted
+        "[envs.test]\ndependencies = [\"{env:PKG:default}\", \"coverage>=6.0\"]",
+        // unversioned bare name
+        "[envs.test]\ndependencies = [\"bare-package\"]",
+        // invalid PEP 508
+        "[envs.test]\ndependencies = [\">>>>=invalid\"]",
+        // control characters
+        "[envs.test]\ndependencies = [\"\x00\x01ruff>=0.4\"]",
+        // malformed TOML
+        "[envs.test]\ndependencies = [\"pytest>=7.0",
+        // multiple envs, one empty
+        "[envs.a]\ndependencies = []\n[envs.b]\ndependencies = [\"pytest>=7.0.0\"]\n",
+    ];
+
+    for content in edge_cases {
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| parser.parse(content)));
+        match result {
+            Ok(deps) => validate_deps(&deps, content, "Python/hatch-standalone"),
+            Err(_) => panic!("Python parser panicked on standalone hatch.toml input:\n{content:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extract dependencies and extra-dependencies from hatch envs in both hatch.toml and pyproject.toml

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issue

No issue.

## Changes Made

- Add support to check hatch environments dependencies and extra-dependencies list in both `pyproject.toml` and `hatch.toml` files

## Testing

<!-- Describe how you tested your changes -->
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] Tested manually in Zed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality
- [x] All new and existing tests pass

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
<img width="1317" height="864" alt="image" src="https://github.com/user-attachments/assets/b2e75460-d2c2-4e7a-a28d-1bc9ef1ac227" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add parsing for Hatch env dependencies in both `pyproject.toml` and `hatch.toml` so dev tooling is surfaced in Python projects. Detect `hatch.toml` as Python, extend TOML detection for `[tool.hatch.*]`, and add tests/docs.

- **New Features**
  - Parse `[tool.hatch.envs.*]` in `pyproject.toml` and `[envs.*]` in `hatch.toml`; collect `dependencies` and `extra-dependencies`.
  - Skip unversioned or context-formatted entries; ignore matrix override formats.
  - Detect `hatch.toml` as Python; extend pyproject detection for `[tool.hatch.*]`; update README; add unit and fuzz regression tests for both formats.

- **Bug Fixes**
  - Mark all Hatch env deps as `optional=false` (previously set incorrectly); keep `dev=true`.

<sup>Written for commit ea1fa0a239ed3f0d3f0f701c30a0408274bf84f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Hatch environment files for Python dependency detection, so Hatch-managed dependencies are recognized alongside existing Python config formats.

* **Documentation**
  * Updated supported file types/docs to list Hatch files as a recognized Python dependency configuration.

* **Tests**
  * Added regression/fuzz tests and sample Hatch configuration examples to improve parser robustness and safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->