### PR TITLE
chore: release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-04-07
+
 ### Added
 
 - Add support for PEP 735 `[dependency-groups]` in `pyproject.toml` — versioned dependencies are parsed, `include-group` references and unversioned items are skipped ([#219](https://github.com/mpiton/zed-dependi/pull/219))
@@ -354,7 +356,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory caching for version data
 - Parallel registry requests (5 concurrent)
 
-[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.6.1...HEAD
+[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/mpiton/zed-dependi/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/mpiton/zed-dependi/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/mpiton/zed-dependi/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/mpiton/zed-dependi/compare/v1.4.4...v1.5.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Dependency management extension for the [Zed](https://zed.dev) editor.
 
-**Version:** 1.6.1
+**Version:** 1.7.0
 
 ![Demo](docs/demo.gif)
 

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-lsp"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-lsp"
-version = "1.6.1"
+version = "1.7.0"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/dependi-lsp/fuzz/Cargo.lock
+++ b/dependi-lsp/fuzz/Cargo.lock
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-lsp"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/dependi-zed/Cargo.lock
+++ b/dependi-zed/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-zed"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "hex",
  "sha2",

--- a/dependi-zed/Cargo.toml
+++ b/dependi-zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-zed"
-version = "1.6.1"
+version = "1.7.0"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT"

--- a/dependi-zed/extension.toml
+++ b/dependi-zed/extension.toml
@@ -1,7 +1,7 @@
 id = "dependi"
 name = "Dependi"
 description = "Dependency management for Zed - version hints, updates, and vulnerability detection"
-version = "1.6.1"
+version = "1.7.0"
 schema_version = 1
 authors = ["Mathieu Piton"]
 repository = "https://github.com/mpiton/zed-dependi"


### PR DESCRIPTION
## Summary

Release v1.7.0 with two new Python ecosystem features contributed by the community.

### What's in this release

**Added**
- PEP 735 `[dependency-groups]` support in `pyproject.toml` (#219)
- Hatch environment dependencies parsing in `pyproject.toml` and `hatch.toml` (#220)

**Changed**
- Bump `sha2` from 0.10 to 0.11 in dependi-zed
- Bump GitHub Actions (`configure-pages` v6, `deploy-pages` v5)
- Update all Cargo lockfiles

**Security**
- Bump `requests` 2.32.4 → 2.33.0 in Python fuzz corpus (#213)

### Files changed

- `dependi-lsp/Cargo.toml` — version 1.6.1 → 1.7.0
- `dependi-zed/Cargo.toml` — version 1.6.1 → 1.7.0
- `dependi-zed/extension.toml` — version 1.6.1 → 1.7.0
- `README.md` — version badge
- `CHANGELOG.md` — new [1.7.0] entry
- Lockfiles updated

## Test plan

- [x] `cargo check` passes on both crates
- [x] `cargo test --lib` — 510 passed
- [x] `cargo clippy` — clean
- [x] No remaining `1.6.1` references (except CHANGELOG history)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.7.0 adds Python support for PEP 735 dependency groups and Hatch environment dependencies. It also updates dependencies and actions, including a security bump for `requests`.

- **New Features**
  - Parse PEP 735 `[dependency-groups]` in `pyproject.toml` (versioned deps only; skips `include-group` and unversioned items).
  - Parse Hatch environment dependencies in `pyproject.toml` and `hatch.toml`.

- **Dependencies**
  - Bump `sha2` 0.10 → 0.11 in `dependi-zed`.
  - Update GitHub Actions: `configure-pages` v6, `deploy-pages` v5.
  - Security: bump `requests` 2.32.4 → 2.33.0 in Python fuzz corpus.
  - Apply version `1.7.0` across crates and extension; refresh lockfiles.

<sup>Written for commit 3d89628e817bfbf8a5fd2b38deff01fe7f44b5ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PEP 735 `[dependency-groups]` in `pyproject.toml` files.

* **Chores**
  * Version bumped to 1.7.0 across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->