### PR TITLE
Track Cargo dep `package` field, and name and version lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `tokio` constraint from 1.50 to 1.52 in `dependi-lsp/Cargo.toml` (lockfile resolves 1.52.1; patch + minor, backwards compatible)
 - Bump `actions/github-script` from v8 to v9 in `contributor-experience.yml` workflow (Octokit v7; inline scripts unaffected — no `require()` or `getOctokit` shadowing)
 - Refresh all Cargo lockfiles (`dependi-lsp`, `dependi-zed`, `dependi-lsp/fuzz`) with latest semver-compatible transitive dependencies
+- Track dependency name and version lines separately
+
+### Fixed
+
+- Respect the `package` field of `Cargo.toml` dependencies
 
 ## [1.7.0] - 2026-04-07
 

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -1386,8 +1386,7 @@ impl LanguageServer for DependiBackend {
             .iter()
             .filter(|dep| {
                 // Only show hints for dependencies in the visible range
-                let line = dep.line;
-                line >= params.range.start.line && line <= params.range.end.line
+                (params.range.start.line..=params.range.end.line).contains(&dep.version_span.line)
             })
             .filter(|dep| {
                 // Skip ignored packages
@@ -1453,9 +1452,8 @@ impl LanguageServer for DependiBackend {
 
         // Find dependency at this position
         let dep = doc.dependencies.iter().find(|d| {
-            d.line == position.line
-                && position.character >= d.name_start
-                && position.character <= d.version_end
+            d.name_span.contains_lsp_position(&position)
+                || d.version_span.contains_lsp_position(&position)
         });
 
         let Some(dep) = dep.cloned() else {
@@ -1483,12 +1481,12 @@ impl LanguageServer for DependiBackend {
             }),
             range: Some(Range {
                 start: Position {
-                    line: dep.line,
-                    character: dep.name_start,
+                    line: dep.name_span.line,
+                    character: dep.name_span.line_start,
                 },
                 end: Position {
-                    line: dep.line,
-                    character: dep.version_end,
+                    line: dep.name_span.line,
+                    character: dep.name_span.line_end,
                 },
             }),
         }))
@@ -1572,17 +1570,22 @@ impl LanguageServer for DependiBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parsers::Dependency;
+    use crate::parsers::{Dependency, Span};
 
     fn make_dep(name: &str, version: &str, resolved: Option<&str>) -> Dependency {
         Dependency {
             name: name.to_string(),
             version: version.to_string(),
-            line: 0,
-            name_start: 0,
-            name_end: name.len() as u32,
-            version_start: name.len() as u32 + 3,
-            version_end: name.len() as u32 + 3 + version.len() as u32,
+            name_span: Span {
+                line: 0,
+                line_start: 0,
+                line_end: name.len() as u32,
+            },
+            version_span: Span {
+                line: 0,
+                line_start: name.len() as u32 + 3,
+                line_end: name.len() as u32 + 3 + version.len() as u32,
+            },
             dev: false,
             optional: false,
             registry: None,

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -1474,6 +1474,11 @@ impl LanguageServer for DependiBackend {
             None => format!("## {dep_name}\n\nCould not fetch package information."),
         };
 
+        let hovered_span = if dep.name_span.contains_lsp_position(&position) {
+            &dep.name_span
+        } else {
+            &dep.version_span
+        };
         Ok(Some(Hover {
             contents: HoverContents::Markup(MarkupContent {
                 kind: MarkupKind::Markdown,
@@ -1481,12 +1486,12 @@ impl LanguageServer for DependiBackend {
             }),
             range: Some(Range {
                 start: Position {
-                    line: dep.name_span.line,
-                    character: dep.name_span.line_start,
+                    line: hovered_span.line,
+                    character: hovered_span.line_start,
                 },
                 end: Position {
-                    line: dep.name_span.line,
-                    character: dep.name_span.line_end,
+                    line: hovered_span.line,
+                    character: hovered_span.line_end,
                 },
             }),
         }))

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -1450,16 +1450,28 @@ impl LanguageServer for DependiBackend {
 
         let file_type = doc.file_type;
 
-        // Find dependency at this position
-        let dep = doc.dependencies.iter().find(|d| {
-            d.name_span.contains_lsp_position(&position)
-                || d.version_span.contains_lsp_position(&position)
-        });
+        enum HoveredSpan {
+            Name,
+            Version,
+        }
 
-        let Some(dep) = dep.cloned() else {
+        // Find dependency at this position
+        let Some((dep, hovered_span)) = doc.dependencies.iter().find_map(|d| {
+            if d.name_span.contains_lsp_position(&position) {
+                Some((d.clone(), HoveredSpan::Name))
+            } else if d.version_span.contains_lsp_position(&position) {
+                Some((d.clone(), HoveredSpan::Version))
+            } else {
+                None
+            }
+        }) else {
             return Ok(None);
         };
         let dep_name = &*dep.name;
+        let hovered_span = match hovered_span {
+            HoveredSpan::Name => dep.name_span,
+            HoveredSpan::Version => dep.version_span,
+        };
 
         // Drop the lock before async call
         drop(doc);
@@ -1474,11 +1486,6 @@ impl LanguageServer for DependiBackend {
             None => format!("## {dep_name}\n\nCould not fetch package information."),
         };
 
-        let hovered_span = if dep.name_span.contains_lsp_position(&position) {
-            &dep.name_span
-        } else {
-            &dep.version_span
-        };
         Ok(Some(Hover {
             contents: HoverContents::Markup(MarkupContent {
                 kind: MarkupKind::Markdown,

--- a/dependi-lsp/src/parsers/cargo.rs
+++ b/dependi-lsp/src/parsers/cargo.rs
@@ -4,6 +4,8 @@ use taplo::dom::Node;
 use taplo::dom::node::{Bool, DomNode, Key, Str};
 use taplo::parser::parse;
 use taplo::rowan::TextRange;
+use taplo::rowan::TextSize;
+use taplo::syntax::SyntaxElement;
 
 use super::{Dependency, Parser, Span};
 
@@ -163,10 +165,9 @@ fn find_dependency_positions(
     version: &Str,
 ) -> Option<TablePositions> {
     let name_range = package
-        .and_then(Str::syntax)
-        .or_else(|| name.syntax())?
-        .text_range();
-    let version_range = version.syntax()?.text_range();
+        .and_then(str_content_range)
+        .or_else(|| name.syntax().map(SyntaxElement::text_range))?;
+    let version_range = str_content_range(version)?;
 
     let name_span = find_range_span(line_ranges, name_range)?;
     let version_span = find_range_span(line_ranges, version_range)?;
@@ -175,6 +176,14 @@ fn find_dependency_positions(
         name_span,
         version_span,
     })
+}
+
+fn str_content_range(s: &Str) -> Option<TextRange> {
+    let quoted_range = s.syntax()?.text_range();
+    Some(TextRange::new(
+        quoted_range.start() + TextSize::from(1),
+        quoted_range.end() - TextSize::from(1),
+    ))
 }
 
 fn find_range_span(haystack: &[TextRange], needle: TextRange) -> Option<Span> {
@@ -235,8 +244,8 @@ serde1 = { package = "serde", version = "1.0.0", features = ["derive"] }
         let deps = parser.parse(content);
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].name, "serde");
-        assert_eq!(deps[0].name_span.line_start, 21);
-        assert_eq!(deps[0].name_span.line_end, 28);
+        assert_eq!(deps[0].name_span.line_start, 22);
+        assert_eq!(deps[0].name_span.line_end, 27);
         assert_eq!(deps[0].version, "1.0.0");
     }
 
@@ -311,8 +320,8 @@ features = ["json"]
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].name, "reqwest");
         assert_eq!(deps[0].name_span.line, 2);
-        assert_eq!(deps[0].name_span.line_start, 10);
-        assert_eq!(deps[0].name_span.line_end, 19);
+        assert_eq!(deps[0].name_span.line_start, 11);
+        assert_eq!(deps[0].name_span.line_end, 18);
         assert_eq!(deps[0].version, "0.12");
     }
 

--- a/dependi-lsp/src/parsers/cargo.rs
+++ b/dependi-lsp/src/parsers/cargo.rs
@@ -1,9 +1,11 @@
 //! Parser for Cargo.toml files using structured TOML parsing
 
-use super::{Dependency, Parser, Span};
-use taplo::dom::Node;
-use taplo::dom::node::{Bool, Str};
+use taplo::dom::node::{Bool, DomNode, Key, Str};
+use taplo::dom::{KeyOrIndex, Node};
 use taplo::parser::parse;
+use taplo::rowan::TextRange;
+
+use super::{Dependency, Parser, Span};
 
 /// Parser for Rust Cargo.toml dependency files
 #[derive(Debug, Default)]
@@ -24,6 +26,17 @@ impl Parser for CargoParser {
             return Vec::new();
         }
 
+        let line_ranges = content
+            .split_inclusive('\n')
+            .map({
+                let mut offset: usize = 0;
+                move |line| {
+                    let range = TextRange::at((offset as u32).into(), (line.len() as u32).into());
+                    offset += line.len();
+                    range
+                }
+            })
+            .collect::<Box<[_]>>();
         let dom = parsed.into_dom();
 
         let mut dependencies = Vec::new();
@@ -39,70 +52,66 @@ impl Parser for CargoParser {
             // Parse regular section dependencies (e.g., [dependencies])
             if let Some(section) = dom.get(section_name).as_table() {
                 let entries = section.entries().read();
-                for (key, value) in entries.iter() {
-                    let name = key.value().to_string();
-                    if let Some(dep) = parse_dependency(&name, value, content, is_dev) {
-                        dependencies.push(dep);
-                    }
-                }
+                let deps = entries.iter().filter_map(|(name, value)| {
+                    parse_dependency(name, value, &line_ranges, is_dev)
+                });
+                dependencies.extend(deps);
             }
 
             // Parse table-style dependencies (e.g., [dependencies.reqwest])
             let pattern = format!("{section_name}.*");
-            if let Ok(keys) = pattern.parse::<taplo::dom::Keys>()
-                && let Ok(matches) = dom.find_all_matches(keys, false)
-            {
-                for (key_path, node) in matches {
-                    // Extract the dependency name from the key path
-                    let key_str = key_path.to_string();
-                    let name = key_str.split('.').next_back().unwrap_or(&key_str);
+            let Ok(matches) = pattern
+                .parse::<taplo::dom::Keys>()
+                .and_then(|keys| dom.find_all_matches(keys, false))
+            else {
+                continue;
+            };
+            let matches = matches.filter_map(|(key_path, node)| {
+                // Extract the dependency name from the key path
+                let name_key = key_path.iter().filter_map(KeyOrIndex::as_key).next_back()?;
 
-                    // For table dependencies, look for the version key
-                    let Some(table) = node.as_table() else {
-                        continue;
-                    };
-                    let Some(version_node) = table.get("version") else {
-                        continue;
-                    };
-                    let Some(version) = version_node.as_str().map(Str::value) else {
-                        continue;
-                    };
+                // For table dependencies, look for the version key
+                let table = node.as_table()?;
+                let version_node = table.get("version")?;
+                let version_str = version_node.as_str()?;
 
-                    let package_node = table.get("package");
-                    let package = package_node.as_ref().and_then(Node::as_str).map(Str::value);
+                let package_node = table.get("package");
+                let package_str = package_node.as_ref().and_then(Node::as_str);
 
-                    let optional = table
-                        .get("optional")
-                        .as_ref()
-                        .and_then(Node::as_bool)
-                        .map(Bool::value)
-                        .unwrap_or(false);
+                let optional = table
+                    .get("optional")
+                    .as_ref()
+                    .and_then(Node::as_bool)
+                    .map(Bool::value)
+                    .unwrap_or(false);
 
-                    let registry_node = table.get("registry");
-                    let registry = registry_node
-                        .as_ref()
-                        .and_then(Node::as_str)
-                        .map(Str::value);
+                let registry_node = table.get("registry");
+                let registry = registry_node
+                    .as_ref()
+                    .and_then(Node::as_str)
+                    .map(Str::value);
 
-                    let Some(TablePositions {
-                        name_span,
-                        version_span,
-                    }) = find_table_dependency_positions(content, name, package, version)
-                    else {
-                        continue;
-                    };
-                    dependencies.push(Dependency {
-                        name: package.unwrap_or(name).to_owned(),
-                        version: version.to_owned(),
-                        name_span,
-                        version_span,
-                        dev: is_dev,
-                        optional,
-                        registry: registry.map(str::to_owned),
-                        resolved_version: None,
-                    });
-                }
-            }
+                let TablePositions {
+                    name_span,
+                    version_span,
+                } = find_dependency_positions(&line_ranges, name_key, package_str, version_str)?;
+
+                Some(Dependency {
+                    name: package_str
+                        .map(Str::value)
+                        .unwrap_or_else(|| name_key.value())
+                        .to_owned(),
+                    version: version_str.value().to_owned(),
+                    name_span,
+                    version_span,
+                    dev: is_dev,
+                    optional,
+                    registry: registry.map(str::to_owned),
+                    resolved_version: None,
+                })
+            });
+
+            dependencies.extend(matches);
         }
 
         // Parse workspace.dependencies section
@@ -111,12 +120,10 @@ impl Parser for CargoParser {
             && let Some(deps_table) = deps_node.as_table()
         {
             let entries = deps_table.entries().read();
-            for (key, value) in entries.iter() {
-                let name = key.value().to_string();
-                if let Some(dep) = parse_dependency(&name, value, content, false) {
-                    dependencies.push(dep);
-                }
-            }
+            let workspace_deps = entries
+                .iter()
+                .filter_map(|(name, value)| parse_dependency(name, value, &line_ranges, false));
+            dependencies.extend(workspace_deps);
         }
 
         dependencies
@@ -124,27 +131,25 @@ impl Parser for CargoParser {
 }
 
 /// Parse a single dependency from a TOML node
-fn parse_dependency(name: &str, node: &Node, content: &str, is_dev: bool) -> Option<Dependency> {
+fn parse_dependency(
+    name: &Key,
+    node: &Node,
+    line_spans: &[TextRange],
+    is_dev: bool,
+) -> Option<Dependency> {
     match node {
-        Node::Str(s) => {
+        Node::Str(version) => {
             // Simple dependency: name = "1.0.0"
-            let version = s.value().to_string();
-            let (line, name_start, name_end, version_start, version_end) =
-                find_simple_dependency_positions(content, name, &version)?;
+            let TablePositions {
+                name_span,
+                version_span,
+            } = find_dependency_positions(line_spans, name, None, version)?;
 
             Some(Dependency {
-                name: name.to_string(),
-                version,
-                name_span: Span {
-                    line,
-                    line_start: name_start,
-                    line_end: name_end,
-                },
-                version_span: Span {
-                    line,
-                    line_start: version_start,
-                    line_end: version_end,
-                },
+                name: name.value().to_owned(),
+                version: version.value().to_owned(),
+                name_span,
+                version_span,
                 dev: is_dev,
                 optional: false,
                 registry: None,
@@ -153,12 +158,11 @@ fn parse_dependency(name: &str, node: &Node, content: &str, is_dev: bool) -> Opt
         }
         Node::Table(table) => {
             let package_node = table.get("package");
-            let package = package_node.as_ref().and_then(Node::as_str).map(Str::value);
+            let package_str = package_node.as_ref().and_then(Node::as_str);
 
             // Inline table: name = { version = "1.0.0", ... }
             let version_node = table.get("version")?;
             let version_str = version_node.as_str()?;
-            let version = version_str.value();
 
             let optional = table
                 .get("optional")
@@ -176,11 +180,14 @@ fn parse_dependency(name: &str, node: &Node, content: &str, is_dev: bool) -> Opt
             let TablePositions {
                 name_span,
                 version_span,
-            } = find_inline_table_positions(content, name, package, version)?;
+            } = find_dependency_positions(line_spans, name, package_str, version_str)?;
 
             Some(Dependency {
-                name: package.unwrap_or(name).to_owned(),
-                version: version.to_owned(),
+                name: package_str
+                    .map(Str::value)
+                    .unwrap_or_else(|| name.value())
+                    .to_owned(),
+                version: version_str.value().to_owned(),
                 name_span,
                 version_span,
                 dev: is_dev,
@@ -193,193 +200,52 @@ fn parse_dependency(name: &str, node: &Node, content: &str, is_dev: bool) -> Opt
     }
 }
 
-/// Find positions for a simple dependency: `name = "version"`
-fn find_simple_dependency_positions(
-    content: &str,
-    name: &str,
-    version: &str,
-) -> Option<(u32, u32, u32, u32, u32)> {
-    for (line_idx, line) in content.lines().enumerate() {
-        // Look for pattern: name = "version" or name = 'version'
-        let trimmed = line.trim();
-        if !trimmed.starts_with(name) {
-            continue;
-        }
-
-        // Check if this line has the exact name followed by =
-        let after_name = trimmed[name.len()..].trim_start();
-        if !after_name.starts_with('=') {
-            continue;
-        }
-
-        // Check for simple string value (not inline table)
-        let after_eq = after_name[1..].trim_start();
-        if after_eq.starts_with('{') {
-            continue; // This is an inline table, skip
-        }
-
-        // Check if version is in this line
-        if !line.contains(version) {
-            continue;
-        }
-
-        // Calculate positions
-        let name_start = line.find(name)? as u32;
-        let name_end = name_start + name.len() as u32;
-
-        // Find version position (inside quotes)
-        let version_start = line.find(version)? as u32;
-        let version_end = version_start + version.len() as u32;
-
-        return Some((
-            line_idx as u32,
-            name_start,
-            name_end,
-            version_start,
-            version_end,
-        ));
-    }
-    None
-}
-
 struct TablePositions {
     name_span: Span,
     version_span: Span,
 }
 
-/// Find positions for an inline table dependency: `name = { version = "1.0.0", ... }`
-fn find_inline_table_positions(
-    content: &str,
-    name: &str,
-    package: Option<&str>,
-    version: &str,
+/// Find positions for a dependency
+/// - simple: `name = "version"`
+/// - inline: `name = { version = "1.0.0", package = "...", ... }`
+/// - table: `[dependencies.name]` with `version = "x.y.z"` & `package = "..."`
+fn find_dependency_positions(
+    line_ranges: &[TextRange],
+    name: &Key,
+    package: Option<&Str>,
+    version: &Str,
 ) -> Option<TablePositions> {
-    for (line_idx, line) in content.lines().enumerate() {
-        let trimmed = line.trim();
-        if !trimmed.starts_with(name) {
-            continue;
-        }
+    const SYNTAX_UNAVAILABLE: &str = "syntax unavailable";
 
-        // Check if this line has the name followed by = and {
-        let after_name = trimmed[name.len()..].trim_start();
-        if !after_name.starts_with('=') {
-            continue;
-        }
+    let name_range = package
+        .map(|s| s.syntax().expect(SYNTAX_UNAVAILABLE))
+        .unwrap_or_else(|| name.syntax().expect(SYNTAX_UNAVAILABLE))
+        .text_range();
+    let version_range = version.syntax().expect(SYNTAX_UNAVAILABLE).text_range();
 
-        let after_eq = after_name[1..].trim_start();
-        if !after_eq.starts_with('{') {
-            continue;
-        }
-
-        // Check if version is in this line
-        if !line.contains(version) {
-            continue;
-        }
-
-        // Calculate positions
-        let (name_start, name_end) = if let Some(package) = package {
-            // Find package position (inside quotes after "package =")
-            let package_start = line.find(&format!("\"{package}\""))? as u32 + 1;
-            let package_end = package_start + package.len() as u32;
-            (package_start, package_end)
-        } else {
-            let name_start = line.find(name)? as u32;
-            let name_end = name_start + name.len() as u32;
-            (name_start, name_end)
-        };
-
-        // Find version position (inside quotes after "version =")
-        let version_start = line.find(version)? as u32;
-        let version_end = version_start + version.len() as u32;
-
-        let line = line_idx as u32;
-
-        return Some(TablePositions {
-            name_span: Span {
-                line,
-                line_start: name_start,
-                line_end: name_end,
-            },
-            version_span: Span {
-                line,
-                line_start: version_start,
-                line_end: version_end,
-            },
-        });
-    }
-    None
-}
-
-/// Find positions for a table dependency: `[dependencies.name]` with `version = "x.y.z"`
-///
-/// For table-style dependencies, the name is in the header `[dependencies.name]`
-/// and the version is on a separate line. We return the version line as the primary
-/// line since that's what gets highlighted, and set name positions to 0 since the
-/// name is on a different line.
-fn find_table_dependency_positions(
-    content: &str,
-    name: &str,
-    package: Option<&str>,
-    version: &str,
-) -> Option<TablePositions> {
-    let mut name_span = None::<Span>;
-    let mut version_span = None::<Span>;
-
-    for (line_idx, line) in content.lines().enumerate() {
-        let trimmed = line.trim();
-
-        // Look for the table header containing the dependency name
-        if trimmed.starts_with('[') && trimmed.ends_with(']') && trimmed.contains(name) {
-            // Check if this is a dependencies table
-            let inner = &trimmed[1..trimmed.len() - 1];
-            if inner.contains("dependencies.") && inner.ends_with(name) {
-                let name_start = line.find(name)? as u32;
-                let name_end = name_start + name.len() as u32;
-                name_span = Some(Span {
-                    line: line_idx as u32,
-                    line_start: name_start,
-                    line_end: name_end,
-                });
-                continue;
-            }
-        }
-
-        // If we found the table, look for version = "x.y.z"
-        if let Some(name_span) = name_span.as_mut() {
-            // Check if we hit a new section
-            if trimmed.starts_with('[') {
-                break;
-            }
-
-            if trimmed.starts_with("version") {
-                let version_start = line.find(version)? as u32;
-                let version_end = version_start + version.len() as u32;
-
-                version_span = Some(Span {
-                    line: line_idx as u32,
-                    line_start: version_start,
-                    line_end: version_end,
-                });
-            }
-
-            if trimmed.starts_with("package") {
-                let package = package?;
-                let package_start = line.find(&format!("\"{package}\""))? as u32 + 1;
-                let package_end = package_start + package.len() as u32;
-
-                *name_span = Span {
-                    line: line_idx as u32,
-                    line_start: package_start,
-                    line_end: package_end,
-                };
-            }
-        }
-    }
+    let name_span = find_range_span(line_ranges, name_range)?;
+    let version_span = find_range_span(line_ranges, version_range)?;
 
     Some(TablePositions {
-        name_span: name_span?,
-        version_span: version_span?,
+        name_span,
+        version_span,
     })
+}
+
+fn find_range_span(haystack: &[TextRange], needle: TextRange) -> Option<Span> {
+    let line_idx = line_range_position(haystack, needle)?;
+    let line_range = haystack[line_idx];
+    Some(Span {
+        line: line_idx as u32,
+        line_start: (needle.start() - line_range.start()).into(),
+        line_end: (needle.end() - line_range.start()).into(),
+    })
+}
+
+fn line_range_position(haystack: &[TextRange], needle: TextRange) -> Option<usize> {
+    haystack
+        .binary_search_by(|line_range| line_range.ordering(needle))
+        .ok()
 }
 
 #[cfg(test)]
@@ -456,7 +322,7 @@ tokio = { version = "1.0", features = ["full"] }
 criterion = "0.5"
 "#;
         let deps = parser.parse(content);
-        assert_eq!(deps.len(), 3);
+        assert_eq!(deps.len(), 3, "{deps:#?}");
 
         let serde = deps.iter().find(|d| d.name == "serde").unwrap();
         assert_eq!(serde.version, "1.0");
@@ -581,7 +447,7 @@ my-crate = { version = "0.1.0", registry = "kellnr" }
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].name, "my-crate");
         assert_eq!(deps[0].version, "0.1.0");
-        assert_eq!(deps[0].registry, Some("kellnr".to_string()));
+        assert_eq!(deps[0].registry.as_deref(), Some("kellnr"));
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/cargo.rs
+++ b/dependi-lsp/src/parsers/cargo.rs
@@ -351,7 +351,7 @@ fn find_table_dependency_positions(
                 break;
             }
 
-            if trimmed.starts_with("version") && line.contains(version) {
+            if trimmed.starts_with("version") {
                 let version_start = line.find(version)? as u32;
                 let version_end = version_start + version.len() as u32;
 
@@ -364,16 +364,14 @@ fn find_table_dependency_positions(
 
             if trimmed.starts_with("package") {
                 let package = package?;
-                if line.contains(package) {
-                    let package_start = line.find(package)? as u32;
-                    let package_end = package_start + package.len() as u32;
+                let package_start = line.find(&format!("\"{package}\""))? as u32 + 1;
+                let package_end = package_start + package.len() as u32;
 
-                    *name_span = Span {
-                        line: line_idx as u32,
-                        line_start: package_start,
-                        line_end: package_end,
-                    };
-                }
+                *name_span = Span {
+                    line: line_idx as u32,
+                    line_start: package_start,
+                    line_end: package_end,
+                };
             }
         }
     }

--- a/dependi-lsp/src/parsers/cargo.rs
+++ b/dependi-lsp/src/parsers/cargo.rs
@@ -1,7 +1,7 @@
 //! Parser for Cargo.toml files using structured TOML parsing
 
+use taplo::dom::Node;
 use taplo::dom::node::{Bool, DomNode, Key, Str};
-use taplo::dom::{KeyOrIndex, Node};
 use taplo::parser::parse;
 use taplo::rowan::TextRange;
 
@@ -50,68 +50,15 @@ impl Parser for CargoParser {
 
         for (section_name, is_dev) in sections {
             // Parse regular section dependencies (e.g., [dependencies])
-            if let Some(section) = dom.get(section_name).as_table() {
-                let entries = section.entries().read();
-                let deps = entries.iter().filter_map(|(name, value)| {
-                    parse_dependency(name, value, &line_ranges, is_dev)
-                });
-                dependencies.extend(deps);
-            }
-
-            // Parse table-style dependencies (e.g., [dependencies.reqwest])
-            let pattern = format!("{section_name}.*");
-            let Ok(matches) = pattern
-                .parse::<taplo::dom::Keys>()
-                .and_then(|keys| dom.find_all_matches(keys, false))
-            else {
+            let section_node = dom.get(section_name);
+            let Some(section) = section_node.as_table() else {
                 continue;
             };
-            let matches = matches.filter_map(|(key_path, node)| {
-                // Extract the dependency name from the key path
-                let name_key = key_path.iter().filter_map(KeyOrIndex::as_key).next_back()?;
-
-                // For table dependencies, look for the version key
-                let table = node.as_table()?;
-                let version_node = table.get("version")?;
-                let version_str = version_node.as_str()?;
-
-                let package_node = table.get("package");
-                let package_str = package_node.as_ref().and_then(Node::as_str);
-
-                let optional = table
-                    .get("optional")
-                    .as_ref()
-                    .and_then(Node::as_bool)
-                    .map(Bool::value)
-                    .unwrap_or(false);
-
-                let registry_node = table.get("registry");
-                let registry = registry_node
-                    .as_ref()
-                    .and_then(Node::as_str)
-                    .map(Str::value);
-
-                let TablePositions {
-                    name_span,
-                    version_span,
-                } = find_dependency_positions(&line_ranges, name_key, package_str, version_str)?;
-
-                Some(Dependency {
-                    name: package_str
-                        .map(Str::value)
-                        .unwrap_or_else(|| name_key.value())
-                        .to_owned(),
-                    version: version_str.value().to_owned(),
-                    name_span,
-                    version_span,
-                    dev: is_dev,
-                    optional,
-                    registry: registry.map(str::to_owned),
-                    resolved_version: None,
-                })
-            });
-
-            dependencies.extend(matches);
+            let entries = section.entries().read();
+            let deps = entries
+                .iter()
+                .filter_map(|(name, value)| parse_dependency(name, value, &line_ranges, is_dev));
+            dependencies.extend(deps);
         }
 
         // Parse workspace.dependencies section
@@ -288,7 +235,8 @@ serde1 = { package = "serde", version = "1.0.0", features = ["derive"] }
         let deps = parser.parse(content);
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].name, "serde");
-        assert_eq!(deps[0].name_span.line_start, 22);
+        assert_eq!(deps[0].name_span.line_start, 21);
+        assert_eq!(deps[0].name_span.line_end, 28);
         assert_eq!(deps[0].version, "1.0.0");
     }
 
@@ -363,7 +311,8 @@ features = ["json"]
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].name, "reqwest");
         assert_eq!(deps[0].name_span.line, 2);
-        assert_eq!(deps[0].name_span.line_start, 11);
+        assert_eq!(deps[0].name_span.line_start, 10);
+        assert_eq!(deps[0].name_span.line_end, 19);
         assert_eq!(deps[0].version, "0.12");
     }
 

--- a/dependi-lsp/src/parsers/cargo.rs
+++ b/dependi-lsp/src/parsers/cargo.rs
@@ -215,13 +215,11 @@ fn find_dependency_positions(
     package: Option<&Str>,
     version: &Str,
 ) -> Option<TablePositions> {
-    const SYNTAX_UNAVAILABLE: &str = "syntax unavailable";
-
     let name_range = package
-        .map(|s| s.syntax().expect(SYNTAX_UNAVAILABLE))
-        .unwrap_or_else(|| name.syntax().expect(SYNTAX_UNAVAILABLE))
+        .and_then(Str::syntax)
+        .or_else(|| name.syntax())?
         .text_range();
-    let version_range = version.syntax().expect(SYNTAX_UNAVAILABLE).text_range();
+    let version_range = version.syntax()?.text_range();
 
     let name_span = find_range_span(line_ranges, name_range)?;
     let version_span = find_range_span(line_ranges, version_range)?;

--- a/dependi-lsp/src/parsers/cargo.rs
+++ b/dependi-lsp/src/parsers/cargo.rs
@@ -1,7 +1,8 @@
 //! Parser for Cargo.toml files using structured TOML parsing
 
-use super::{Dependency, Parser};
+use super::{Dependency, Parser, Span};
 use taplo::dom::Node;
+use taplo::dom::node::{Bool, Str};
 use taplo::parser::parse;
 
 /// Parser for Rust Cargo.toml dependency files
@@ -54,44 +55,52 @@ impl Parser for CargoParser {
                 for (key_path, node) in matches {
                     // Extract the dependency name from the key path
                     let key_str = key_path.to_string();
-                    let name = key_str
-                        .split('.')
-                        .next_back()
-                        .unwrap_or(&key_str)
-                        .to_string();
+                    let name = key_str.split('.').next_back().unwrap_or(&key_str);
 
                     // For table dependencies, look for the version key
-                    if let Some(table) = node.as_table()
-                        && let Some(version_node) = table.get("version")
-                        && let Some(version_str) = version_node.as_str()
-                    {
-                        let version = version_str.value().to_string();
-                        let optional = table
-                            .get("optional")
-                            .and_then(|n| n.as_bool().map(|b| b.value()))
-                            .unwrap_or(false);
-                        let registry = table
-                            .get("registry")
-                            .and_then(|n| n.as_str().map(|s| s.value().to_string()));
+                    let Some(table) = node.as_table() else {
+                        continue;
+                    };
+                    let Some(version_node) = table.get("version") else {
+                        continue;
+                    };
+                    let Some(version) = version_node.as_str().map(Str::value) else {
+                        continue;
+                    };
 
-                        if let Some((line, name_start, name_end, version_start, version_end)) =
-                            find_table_dependency_positions(content, &name, &version)
-                        {
-                            dependencies.push(Dependency {
-                                name,
-                                version,
-                                line,
-                                name_start,
-                                name_end,
-                                version_start,
-                                version_end,
-                                dev: is_dev,
-                                optional,
-                                registry,
-                                resolved_version: None,
-                            });
-                        }
-                    }
+                    let package_node = table.get("package");
+                    let package = package_node.as_ref().and_then(Node::as_str).map(Str::value);
+
+                    let optional = table
+                        .get("optional")
+                        .as_ref()
+                        .and_then(Node::as_bool)
+                        .map(Bool::value)
+                        .unwrap_or(false);
+
+                    let registry_node = table.get("registry");
+                    let registry = registry_node
+                        .as_ref()
+                        .and_then(Node::as_str)
+                        .map(Str::value);
+
+                    let Some(TablePositions {
+                        name_span,
+                        version_span,
+                    }) = find_table_dependency_positions(content, name, package, version)
+                    else {
+                        continue;
+                    };
+                    dependencies.push(Dependency {
+                        name: package.unwrap_or(name).to_owned(),
+                        version: version.to_owned(),
+                        name_span,
+                        version_span,
+                        dev: is_dev,
+                        optional,
+                        registry: registry.map(str::to_owned),
+                        resolved_version: None,
+                    });
                 }
             }
         }
@@ -126,11 +135,16 @@ fn parse_dependency(name: &str, node: &Node, content: &str, is_dev: bool) -> Opt
             Some(Dependency {
                 name: name.to_string(),
                 version,
-                line,
-                name_start,
-                name_end,
-                version_start,
-                version_end,
+                name_span: Span {
+                    line,
+                    line_start: name_start,
+                    line_end: name_end,
+                },
+                version_span: Span {
+                    line,
+                    line_start: version_start,
+                    line_end: version_end,
+                },
                 dev: is_dev,
                 optional: false,
                 registry: None,
@@ -138,31 +152,37 @@ fn parse_dependency(name: &str, node: &Node, content: &str, is_dev: bool) -> Opt
             })
         }
         Node::Table(table) => {
+            let package_node = table.get("package");
+            let package = package_node.as_ref().and_then(Node::as_str).map(Str::value);
+
             // Inline table: name = { version = "1.0.0", ... }
             let version_node = table.get("version")?;
             let version_str = version_node.as_str()?;
-            let version = version_str.value().to_string();
+            let version = version_str.value();
 
             let optional = table
                 .get("optional")
-                .and_then(|n| n.as_bool().map(|b| b.value()))
+                .as_ref()
+                .and_then(Node::as_bool)
+                .map(Bool::value)
                 .unwrap_or(false);
 
             let registry = table
                 .get("registry")
-                .and_then(|n| n.as_str().map(|s| s.value().to_string()));
+                .as_ref()
+                .and_then(Node::as_str)
+                .map(|s| s.value().to_owned());
 
-            let (line, name_start, name_end, version_start, version_end) =
-                find_inline_table_positions(content, name, &version)?;
+            let TablePositions {
+                name_span,
+                version_span,
+            } = find_inline_table_positions(content, name, package, version)?;
 
             Some(Dependency {
-                name: name.to_string(),
-                version,
-                line,
-                name_start,
-                name_end,
-                version_start,
-                version_end,
+                name: package.unwrap_or(name).to_owned(),
+                version: version.to_owned(),
+                name_span,
+                version_span,
                 dev: is_dev,
                 optional,
                 registry,
@@ -222,12 +242,18 @@ fn find_simple_dependency_positions(
     None
 }
 
+struct TablePositions {
+    name_span: Span,
+    version_span: Span,
+}
+
 /// Find positions for an inline table dependency: `name = { version = "1.0.0", ... }`
 fn find_inline_table_positions(
     content: &str,
     name: &str,
+    package: Option<&str>,
     version: &str,
-) -> Option<(u32, u32, u32, u32, u32)> {
+) -> Option<TablePositions> {
     for (line_idx, line) in content.lines().enumerate() {
         let trimmed = line.trim();
         if !trimmed.starts_with(name) {
@@ -251,20 +277,35 @@ fn find_inline_table_positions(
         }
 
         // Calculate positions
-        let name_start = line.find(name)? as u32;
-        let name_end = name_start + name.len() as u32;
+        let (name_start, name_end) = if let Some(package) = package {
+            // Find package position (inside quotes after "package =")
+            let package_start = line.find(&format!("\"{package}\""))? as u32 + 1;
+            let package_end = package_start + package.len() as u32;
+            (package_start, package_end)
+        } else {
+            let name_start = line.find(name)? as u32;
+            let name_end = name_start + name.len() as u32;
+            (name_start, name_end)
+        };
 
         // Find version position (inside quotes after "version =")
         let version_start = line.find(version)? as u32;
         let version_end = version_start + version.len() as u32;
 
-        return Some((
-            line_idx as u32,
-            name_start,
-            name_end,
-            version_start,
-            version_end,
-        ));
+        let line = line_idx as u32;
+
+        return Some(TablePositions {
+            name_span: Span {
+                line,
+                line_start: name_start,
+                line_end: name_end,
+            },
+            version_span: Span {
+                line,
+                line_start: version_start,
+                line_end: version_end,
+            },
+        });
     }
     None
 }
@@ -278,9 +319,11 @@ fn find_inline_table_positions(
 fn find_table_dependency_positions(
     content: &str,
     name: &str,
+    package: Option<&str>,
     version: &str,
-) -> Option<(u32, u32, u32, u32, u32)> {
-    let mut found_table = false;
+) -> Option<TablePositions> {
+    let mut name_span = None::<Span>;
+    let mut version_span = None::<Span>;
 
     for (line_idx, line) in content.lines().enumerate() {
         let trimmed = line.trim();
@@ -290,13 +333,19 @@ fn find_table_dependency_positions(
             // Check if this is a dependencies table
             let inner = &trimmed[1..trimmed.len() - 1];
             if inner.contains("dependencies.") && inner.ends_with(name) {
-                found_table = true;
+                let name_start = line.find(name)? as u32;
+                let name_end = name_start + name.len() as u32;
+                name_span = Some(Span {
+                    line: line_idx as u32,
+                    line_start: name_start,
+                    line_end: name_end,
+                });
                 continue;
             }
         }
 
         // If we found the table, look for version = "x.y.z"
-        if found_table {
+        if let Some(name_span) = name_span.as_mut() {
             // Check if we hit a new section
             if trimmed.starts_with('[') {
                 break;
@@ -306,13 +355,33 @@ fn find_table_dependency_positions(
                 let version_start = line.find(version)? as u32;
                 let version_end = version_start + version.len() as u32;
 
-                // For table dependencies, name is in header (different line)
-                // Set name positions to 0 since we can only return one line number
-                return Some((line_idx as u32, 0, 0, version_start, version_end));
+                version_span = Some(Span {
+                    line: line_idx as u32,
+                    line_start: version_start,
+                    line_end: version_end,
+                });
+            }
+
+            if trimmed.starts_with("package") {
+                let package = package?;
+                if line.contains(package) {
+                    let package_start = line.find(package)? as u32;
+                    let package_end = package_start + package.len() as u32;
+
+                    *name_span = Span {
+                        line: line_idx as u32,
+                        line_start: package_start,
+                        line_end: package_end,
+                    };
+                }
             }
         }
     }
-    None
+
+    Some(TablePositions {
+        name_span: name_span?,
+        version_span: version_span?,
+    })
 }
 
 #[cfg(test)]
@@ -343,6 +412,21 @@ serde = { version = "1.0.0", features = ["derive"] }
         let deps = parser.parse(content);
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].name, "serde");
+        assert_eq!(deps[0].name_span.line_start, 0);
+        assert_eq!(deps[0].version, "1.0.0");
+    }
+
+    #[test]
+    fn test_inline_table_alias_dependency() {
+        let parser = CargoParser::new();
+        let content = r#"
+[dependencies]
+serde1 = { package = "serde", version = "1.0.0", features = ["derive"] }
+"#;
+        let deps = parser.parse(content);
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].name, "serde");
+        assert_eq!(deps[0].name_span.line_start, 22);
         assert_eq!(deps[0].version, "1.0.0");
     }
 
@@ -400,6 +484,24 @@ features = ["json"]
         let deps = parser.parse(content);
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].name, "reqwest");
+        assert_eq!(deps[0].name_span.line, 1);
+        assert_eq!(deps[0].version, "0.12");
+    }
+
+    #[test]
+    fn test_table_alias_dependency() {
+        let parser = CargoParser::new();
+        let content = r#"
+[dependencies.reqwest1]
+package = "reqwest"
+version = "0.12"
+features = ["json"]
+"#;
+        let deps = parser.parse(content);
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].name, "reqwest");
+        assert_eq!(deps[0].name_span.line, 2);
+        assert_eq!(deps[0].name_span.line_start, 11);
         assert_eq!(deps[0].version, "0.12");
     }
 

--- a/dependi-lsp/src/parsers/csharp.rs
+++ b/dependi-lsp/src/parsers/csharp.rs
@@ -1,6 +1,6 @@
 //! Parser for C# .csproj files (NuGet PackageReference format)
 
-use super::{Dependency, Parser};
+use super::{Dependency, Parser, Span};
 
 /// Parser for C# .csproj files
 #[derive(Debug, Default)]
@@ -71,11 +71,16 @@ fn parse_package_reference(line: &str, line_num: u32) -> Option<Dependency> {
     Some(Dependency {
         name: name.to_string(),
         version,
-        line: line_num,
-        name_start,
-        name_end,
-        version_start,
-        version_end,
+        name_span: Span {
+            line: line_num,
+            line_start: name_start,
+            line_end: name_end,
+        },
+        version_span: Span {
+            line: line_num,
+            line_start: version_start,
+            line_end: version_end,
+        },
         dev: false, // NuGet doesn't have explicit dev dependencies in .csproj
         optional: false,
         registry: None,
@@ -143,7 +148,7 @@ mod tests {
 
         assert_eq!(deps.len(), 1);
         let dep = &deps[0];
-        assert!(dep.version_start > dep.name_end);
+        assert!(dep.version_span.line_start > dep.name_span.line_end);
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/dart.rs
+++ b/dependi-lsp/src/parsers/dart.rs
@@ -1,6 +1,6 @@
 //! Parser for Dart/Flutter pubspec.yaml files
 
-use super::{Dependency, Parser};
+use super::{Dependency, Parser, Span};
 
 /// Parser for Dart pubspec.yaml dependency files
 #[derive(Debug, Default)]
@@ -159,11 +159,16 @@ fn parse_dart_dependency_line(line: &str, line_num: u32, dev: bool) -> Option<De
     Some(Dependency {
         name: name.to_string(),
         version,
-        line: line_num,
-        name_start,
-        name_end,
-        version_start,
-        version_end,
+        name_span: Span {
+            line: line_num,
+            line_start: name_start,
+            line_end: name_end,
+        },
+        version_span: Span {
+            line: line_num,
+            line_start: version_start,
+            line_end: version_end,
+        },
         dev,
         optional: false,
         registry: None,
@@ -279,7 +284,7 @@ dependencies:
         assert_eq!(deps.len(), 1);
         let http = &deps[0];
         assert_eq!(http.name, "http");
-        assert!(http.version_start > http.name_end);
+        assert!(http.version_span.line_start > http.name_span.line_end);
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/go.rs
+++ b/dependi-lsp/src/parsers/go.rs
@@ -2,7 +2,7 @@
 //!
 //! Optimized for performance with pre-allocation and reduced string searches.
 
-use super::{Dependency, Parser};
+use super::{Dependency, Parser, Span};
 
 /// Parser for Go go.mod dependency files
 #[derive(Debug, Default)]
@@ -129,11 +129,16 @@ fn parse_require_with_positions(
     Some(Dependency {
         name: module_path.to_string(),
         version: version.to_string(),
-        line: line_num,
-        name_start,
-        name_end,
-        version_start,
-        version_end,
+        name_span: Span {
+            line: line_num,
+            line_start: name_start,
+            line_end: name_end,
+        },
+        version_span: Span {
+            line: line_num,
+            line_start: version_start,
+            line_end: version_end,
+        },
         dev: false,
         optional: is_indirect,
         registry: None,
@@ -230,10 +235,12 @@ require github.com/pkg/c v3.0.0
         assert_eq!(deps.len(), 1);
 
         let dep = &deps[0];
-        assert_eq!(dep.name_start, 8);
-        assert_eq!(dep.name_end, 29);
-        assert_eq!(dep.version_start, 30);
-        assert_eq!(dep.version_end, 36);
+        assert_eq!(dep.name_span.line, 0);
+        assert_eq!(dep.name_span.line_start, 8);
+        assert_eq!(dep.name_span.line_end, 29);
+        assert_eq!(dep.version_span.line, 0);
+        assert_eq!(dep.version_span.line_start, 30);
+        assert_eq!(dep.version_span.line_end, 36);
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -1,6 +1,7 @@
 //! Parsers for dependency files (Cargo.toml, package.json, etc.)
 
 use serde::{Deserialize, Serialize};
+use tower_lsp::lsp_types;
 
 /// Represents a dependency extracted from a manifest file
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -9,16 +10,10 @@ pub struct Dependency {
     pub name: String,
     /// Version specifier (e.g., "1.0.0", "^1.0", ">=1,<2")
     pub version: String,
-    /// Line number in the file (0-indexed)
-    pub line: u32,
-    /// Column where the package name starts
-    pub name_start: u32,
-    /// Column where the package name ends
-    pub name_end: u32,
-    /// Column where the version string starts
-    pub version_start: u32,
-    /// Column where the version string ends
-    pub version_end: u32,
+    /// Package name span
+    pub name_span: Span,
+    /// Version string span
+    pub version_span: Span,
     /// Whether this is a dev dependency
     pub dev: bool,
     /// Whether this dependency is optional
@@ -28,6 +23,23 @@ pub struct Dependency {
     /// Resolved version from the lock file (e.g., Cargo.lock), if available
     #[serde(default)]
     pub resolved_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Span {
+    /// Line number in the file (0-indexed)
+    pub line: u32,
+    /// Column where the value starts
+    pub line_start: u32,
+    /// Column where the value ends
+    pub line_end: u32,
+}
+
+impl Span {
+    pub fn contains_lsp_position(&self, position: &lsp_types::Position) -> bool {
+        self.line == position.line
+            && (self.line_start..=self.line_end).contains(&position.character)
+    }
 }
 
 impl Dependency {

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -37,8 +37,7 @@ pub struct Span {
 
 impl Span {
     pub fn contains_lsp_position(&self, position: &lsp_types::Position) -> bool {
-        self.line == position.line
-            && (self.line_start..=self.line_end).contains(&position.character)
+        self.line == position.line && (self.line_start..self.line_end).contains(&position.character)
     }
 }
 

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -25,7 +25,7 @@ pub struct Dependency {
     pub resolved_version: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Span {
     /// Line number in the file (0-indexed)
     pub line: u32,

--- a/dependi-lsp/src/parsers/npm.rs
+++ b/dependi-lsp/src/parsers/npm.rs
@@ -2,7 +2,7 @@
 //!
 //! Uses serde_json for fast parsing with position tracking via byte offset calculation.
 
-use super::{Dependency, Parser};
+use super::{Dependency, Parser, Span};
 use serde_json::Value;
 
 /// Parser for npm package.json dependency files
@@ -179,11 +179,16 @@ fn find_dependency_position(
                 return Some(Dependency {
                     name: name.to_string(),
                     version: version.to_string(),
-                    line,
-                    name_start: name_start_col,
-                    name_end: name_end_col,
-                    version_start: version_start_col,
-                    version_end: version_end_col,
+                    name_span: Span {
+                        line,
+                        line_start: name_start_col,
+                        line_end: name_end_col,
+                    },
+                    version_span: Span {
+                        line: version_line,
+                        line_start: version_start_col,
+                        line_end: version_end_col,
+                    },
                     dev,
                     optional,
                     registry: None,
@@ -337,10 +342,11 @@ mod tests {
 
         let react = &deps[0];
         assert_eq!(react.name, "react");
-        assert_eq!(react.line, 2); // 0-indexed, so line 3 is index 2
+        assert_eq!(react.name_span.line, 2); // 0-indexed, so line 3 is index 2
+        assert_eq!(react.version_span.line, 2); // 0-indexed, so line 3 is index 2
         // Verify positions are within reasonable bounds
-        assert!(react.name_start < react.name_end);
-        assert!(react.version_start < react.version_end);
+        assert!(react.name_span.line_start < react.name_span.line_end);
+        assert!(react.version_span.line_start < react.version_span.line_end);
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/php.rs
+++ b/dependi-lsp/src/parsers/php.rs
@@ -2,7 +2,7 @@
 //!
 //! Uses serde_json for fast parsing with position tracking via byte offset calculation.
 
-use super::{Dependency, Parser};
+use super::{Dependency, Parser, Span};
 use serde_json::Value;
 
 /// Parser for PHP composer.json dependency files
@@ -148,11 +148,16 @@ fn find_dependency_position(
                 return Some(Dependency {
                     name: name.to_string(),
                     version: version.to_string(),
-                    line,
-                    name_start: name_start_col,
-                    name_end: name_end_col,
-                    version_start: version_start_col,
-                    version_end: version_end_col,
+                    name_span: Span {
+                        line,
+                        line_start: name_start_col,
+                        line_end: name_end_col,
+                    },
+                    version_span: Span {
+                        line: version_line,
+                        line_start: version_start_col,
+                        line_end: version_end_col,
+                    },
                     dev,
                     optional: false,
                     registry: None,

--- a/dependi-lsp/src/parsers/python.rs
+++ b/dependi-lsp/src/parsers/python.rs
@@ -1,6 +1,6 @@
 //! Parser for Python dependency files (requirements.txt, constraints.txt, pyproject.toml, hatch.toml)
 
-use super::{Dependency, Parser};
+use super::{Dependency, Parser, Span};
 
 /// Parser for Python dependency files
 #[derive(Debug, Default)]
@@ -219,11 +219,16 @@ fn parse_requirement_line(line: &str, line_num: u32, dev: bool) -> Option<Depend
     Some(Dependency {
         name: name.to_string(),
         version,
-        line: line_num,
-        name_start,
-        name_end,
-        version_start,
-        version_end,
+        name_span: Span {
+            line: line_num,
+            line_start: name_start,
+            line_end: name_end,
+        },
+        version_span: Span {
+            line: line_num,
+            line_start: version_start,
+            line_end: version_end,
+        },
         dev,
         optional: false,
         registry: None,
@@ -579,11 +584,16 @@ fn find_dependency_position(
                 return Some(Dependency {
                     name: name.to_string(),
                     version: version.to_string(),
-                    line: line_num,
-                    name_start,
-                    name_end,
-                    version_start,
-                    version_end,
+                    name_span: Span {
+                        line: line_num,
+                        line_start: name_start,
+                        line_end: name_end,
+                    },
+                    version_span: Span {
+                        line: line_num,
+                        line_start: version_start,
+                        line_end: version_end,
+                    },
                     dev,
                     optional,
                     registry: None,
@@ -622,11 +632,16 @@ fn find_poetry_dependency_position(
                 return Some(Dependency {
                     name: name.to_string(),
                     version: version.to_string(),
-                    line: line_num,
-                    name_start,
-                    name_end,
-                    version_start,
-                    version_end,
+                    name_span: Span {
+                        line: line_num,
+                        line_start: name_start,
+                        line_end: name_end,
+                    },
+                    version_span: Span {
+                        line: line_num,
+                        line_start: version_start,
+                        line_end: version_end,
+                    },
                     dev,
                     optional: false,
                     registry: None,
@@ -765,11 +780,13 @@ pytest = "^7.0.0"
 
         let dep = &deps[0];
         assert_eq!(dep.version, "==2.0.0");
-        assert_eq!(dep.name_start, 0);
-        assert_eq!(dep.name_end, 5);
+        assert_eq!(dep.name_span.line, 0);
+        assert_eq!(dep.name_span.line_start, 0);
+        assert_eq!(dep.name_span.line_end, 5);
         // version_start now includes the operator "=="
-        assert_eq!(dep.version_start, 5);
-        assert_eq!(dep.version_end, 12);
+        assert_eq!(dep.version_span.line, 0);
+        assert_eq!(dep.version_span.line_start, 5);
+        assert_eq!(dep.version_span.line_end, 12);
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/ruby.rs
+++ b/dependi-lsp/src/parsers/ruby.rs
@@ -7,7 +7,7 @@
 //! - gem declarations with version constraints
 //! - group blocks for development dependencies
 
-use super::{Dependency, Parser};
+use super::{Dependency, Parser, Span};
 
 /// Parser for Ruby Gemfile dependency files
 #[derive(Debug, Default)]
@@ -93,11 +93,16 @@ fn parse_gem_declaration(line: &str, line_num: u32, dev: bool) -> Option<Depende
     Some(Dependency {
         name,
         version,
-        line: line_num,
-        name_start,
-        name_end,
-        version_start,
-        version_end,
+        name_span: Span {
+            line: line_num,
+            line_start: name_start,
+            line_end: name_end,
+        },
+        version_span: Span {
+            line: line_num,
+            line_start: version_start,
+            line_end: version_end,
+        },
         dev,
         optional: false,
         registry: None,
@@ -361,16 +366,18 @@ gem "pg", "~> 1.4"
         let dep = &deps[0];
 
         // Verify positions are valid
-        assert!(dep.name_start < dep.name_end);
-        assert!(dep.version_start < dep.version_end);
-        assert!(dep.name_end < dep.version_start);
+        assert!(dep.name_span.line_start < dep.name_span.line_end);
+        assert!(dep.version_span.line_start < dep.version_span.line_end);
+        assert!(dep.name_span.line_end < dep.version_span.line_start);
 
         // Verify name position
-        let name_slice = &content[dep.name_start as usize..dep.name_end as usize];
+        let name_slice =
+            &content[dep.name_span.line_start as usize..dep.name_span.line_end as usize];
         assert_eq!(name_slice, "rails");
 
         // Verify version position
-        let version_slice = &content[dep.version_start as usize..dep.version_end as usize];
+        let version_slice =
+            &content[dep.version_span.line_start as usize..dep.version_span.line_end as usize];
         assert_eq!(version_slice, "~> 7.0");
     }
 

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -98,7 +98,7 @@ pub fn create_code_actions(
 ) -> Vec<CodeActionOrCommand> {
     let mut actions: Vec<CodeActionOrCommand> = dependencies
         .iter()
-        .filter(|dep| dep.line >= range.start.line && dep.line <= range.end.line)
+        .filter(|dep| (range.start.line..=range.end.line).contains(&dep.version_span.line))
         .filter_map(|dep| create_update_action(dep, cache, uri, file_type, &cache_key_fn))
         .collect();
 
@@ -140,12 +140,12 @@ fn create_update_action(
             let edit = TextEdit {
                 range: Range {
                     start: Position {
-                        line: dep.line,
-                        character: dep.version_start,
+                        line: dep.version_span.line,
+                        character: dep.version_span.line_start,
                     },
                     end: Position {
-                        line: dep.line,
-                        character: dep.version_end,
+                        line: dep.version_span.line,
+                        character: dep.version_span.line_end,
                     },
                 },
                 new_text,
@@ -214,12 +214,12 @@ fn create_update_all_action(
             TextEdit {
                 range: Range {
                     start: Position {
-                        line: dep.line,
-                        character: dep.version_start,
+                        line: dep.version_span.line,
+                        character: dep.version_span.line_start,
                     },
                     end: Position {
-                        line: dep.line,
-                        character: dep.version_end,
+                        line: dep.version_span.line,
+                        character: dep.version_span.line_end,
                     },
                 },
                 new_text,
@@ -306,17 +306,23 @@ fn format_version_for_dep(
 mod tests {
     use super::*;
     use crate::cache::{MemoryCache, WriteCache};
+    use crate::parsers::Span;
     use crate::registries::VersionInfo;
 
     fn create_test_dependency(name: &str, version: &str, line: u32) -> Dependency {
         Dependency {
             name: name.to_string(),
             version: version.to_string(),
-            line,
-            name_start: 0,
-            name_end: name.len() as u32,
-            version_start: name.len() as u32 + 4,
-            version_end: name.len() as u32 + 4 + version.len() as u32,
+            name_span: Span {
+                line,
+                line_start: 0,
+                line_end: name.len() as u32,
+            },
+            version_span: Span {
+                line,
+                line_start: name.len() as u32 + 4,
+                line_end: name.len() as u32 + 4 + version.len() as u32,
+            },
             dev: false,
             optional: false,
             registry: None,

--- a/dependi-lsp/src/providers/completion.rs
+++ b/dependi-lsp/src/providers/completion.rs
@@ -79,11 +79,9 @@ pub fn get_completions(
     cache_key_fn: impl Fn(&str) -> String,
 ) -> Option<Vec<CompletionItem>> {
     // Find if we're inside a version field
-    let dep = dependencies.iter().find(|d| {
-        d.version_span.line == position.line
-            && position.character >= d.version_span.line_start
-            && position.character <= d.version_span.line_end
-    })?;
+    let dep = dependencies
+        .iter()
+        .find(|d| d.version_span.contains_lsp_position(&position))?;
 
     let cache_key = cache_key_fn(&dep.name);
     let version_info = cache.get(&cache_key)?;

--- a/dependi-lsp/src/providers/completion.rs
+++ b/dependi-lsp/src/providers/completion.rs
@@ -80,9 +80,9 @@ pub fn get_completions(
 ) -> Option<Vec<CompletionItem>> {
     // Find if we're inside a version field
     let dep = dependencies.iter().find(|d| {
-        d.line == position.line
-            && position.character >= d.version_start
-            && position.character <= d.version_end
+        d.version_span.line == position.line
+            && position.character >= d.version_span.line_start
+            && position.character <= d.version_span.line_end
     })?;
 
     let cache_key = cache_key_fn(&dep.name);
@@ -160,6 +160,7 @@ pub fn get_completions(
 mod tests {
     use super::*;
     use crate::cache::{MemoryCache, WriteCache};
+    use crate::parsers::Span;
     use crate::registries::VersionInfo;
     use chrono::Duration;
     use hashbrown::HashMap;
@@ -168,11 +169,16 @@ mod tests {
         Dependency {
             name: name.to_string(),
             version: version.to_string(),
-            line,
-            name_start: 0,
-            name_end: name.len() as u32,
-            version_start: name.len() as u32 + 4,
-            version_end: name.len() as u32 + 4 + version.len() as u32,
+            name_span: Span {
+                line,
+                line_start: 0,
+                line_end: name.len() as u32,
+            },
+            version_span: Span {
+                line,
+                line_start: name.len() as u32 + 4,
+                line_end: name.len() as u32 + 4 + version.len() as u32,
+            },
             dev: false,
             optional: false,
             registry: None,

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -98,12 +98,12 @@ fn create_outdated_diagnostic(
         VersionStatus::UpdateAvailable(new_version) => Some(Diagnostic {
             range: Range {
                 start: Position {
-                    line: dep.line,
-                    character: dep.version_start,
+                    line: dep.version_span.line,
+                    character: dep.version_span.line_start,
                 },
                 end: Position {
-                    line: dep.line,
-                    character: dep.version_end,
+                    line: dep.version_span.line,
+                    character: dep.version_span.line_end,
                 },
             },
             severity: Some(DiagnosticSeverity::HINT),
@@ -127,12 +127,12 @@ fn create_local_dependency_diagnostic(dep: &Dependency) -> Diagnostic {
     Diagnostic {
         range: Range {
             start: Position {
-                line: dep.line,
-                character: dep.version_start,
+                line: dep.version_span.line,
+                character: dep.version_span.line_start,
             },
             end: Position {
-                line: dep.line,
-                character: dep.version_end,
+                line: dep.version_span.line,
+                character: dep.version_span.line_end,
             },
         },
         severity: Some(DiagnosticSeverity::HINT),
@@ -188,12 +188,12 @@ fn create_deprecation_diagnostic(dep: &Dependency, version_info: &VersionInfo) -
     Diagnostic {
         range: Range {
             start: Position {
-                line: dep.line,
-                character: dep.version_start,
+                line: dep.version_span.line,
+                character: dep.version_span.line_start,
             },
             end: Position {
-                line: dep.line,
-                character: dep.version_end,
+                line: dep.version_span.line,
+                character: dep.version_span.line_end,
             },
         },
         severity: Some(DiagnosticSeverity::WARNING),
@@ -292,12 +292,12 @@ fn create_yanked_diagnostic(
     Diagnostic {
         range: Range {
             start: Position {
-                line: dep.line,
-                character: dep.version_start,
+                line: dep.version_span.line,
+                character: dep.version_span.line_start,
             },
             end: Position {
-                line: dep.line,
-                character: dep.version_end,
+                line: dep.version_span.line,
+                character: dep.version_span.line_end,
             },
         },
         severity: Some(DiagnosticSeverity::WARNING),
@@ -369,12 +369,12 @@ fn create_vulnerability_summary_diagnostic(
     Diagnostic {
         range: Range {
             start: Position {
-                line: dep.line,
-                character: dep.version_start,
+                line: dep.version_span.line,
+                character: dep.version_span.line_start,
             },
             end: Position {
-                line: dep.line,
-                character: dep.version_end,
+                line: dep.version_span.line,
+                character: dep.version_span.line_end,
             },
         },
         severity: Some(diagnostic_severity),
@@ -397,17 +397,23 @@ mod tests {
     use super::*;
     use crate::cache::{MemoryCache, WriteCache};
     use crate::file_types::FileType;
+    use crate::parsers::Span;
     use crate::registries::VersionInfo;
 
     fn create_test_dependency(name: &str, version: &str, line: u32) -> Dependency {
         Dependency {
             name: name.to_string(),
             version: version.to_string(),
-            line,
-            name_start: 0,
-            name_end: name.len() as u32,
-            version_start: name.len() as u32 + 4,
-            version_end: name.len() as u32 + 4 + version.len() as u32,
+            name_span: Span {
+                line,
+                line_start: 0,
+                line_end: name.len() as u32,
+            },
+            version_span: Span {
+                line,
+                line_start: name.len() as u32 + 4,
+                line_end: name.len() as u32 + 4 + version.len() as u32,
+            },
             dev: false,
             optional: false,
             registry: None,

--- a/dependi-lsp/src/providers/document_links.rs
+++ b/dependi-lsp/src/providers/document_links.rs
@@ -28,12 +28,12 @@ pub fn create_document_links(deps: &[Dependency], file_type: &FileType) -> Vec<D
             Some(DocumentLink {
                 range: Range {
                     start: Position {
-                        line: dep.line,
-                        character: dep.name_start,
+                        line: dep.name_span.line,
+                        character: dep.name_span.line_start,
                     },
                     end: Position {
-                        line: dep.line,
-                        character: dep.name_end,
+                        line: dep.name_span.line,
+                        character: dep.name_span.line_end,
                     },
                 },
                 target: Some(url),
@@ -46,17 +46,24 @@ pub fn create_document_links(deps: &[Dependency], file_type: &FileType) -> Vec<D
 
 #[cfg(test)]
 mod tests {
+    use crate::parsers::Span;
+
     use super::*;
 
     fn make_dep(name: &str, line: u32, name_start: u32, name_end: u32) -> Dependency {
         Dependency {
             name: name.to_string(),
             version: "1.0.0".to_string(),
-            line,
-            name_start,
-            name_end,
-            version_start: name_end + 2,
-            version_end: name_end + 7,
+            name_span: Span {
+                line,
+                line_start: name_start,
+                line_end: name_end,
+            },
+            version_span: Span {
+                line,
+                line_start: name_end + 2,
+                line_end: name_end + 7,
+            },
             dev: false,
             optional: false,
             registry: None,

--- a/dependi-lsp/src/providers/inlay_hints.rs
+++ b/dependi-lsp/src/providers/inlay_hints.rs
@@ -47,8 +47,8 @@ pub fn create_inlay_hint(
 
     InlayHint {
         position: Position {
-            line: dep.line,
-            character: dep.version_end + 1,
+            line: dep.version_span.line,
+            character: dep.version_span.line_end + 1,
         },
         label: InlayHintLabel::String(format!(" {label}")),
         kind: Some(InlayHintKind::PARAMETER),
@@ -519,6 +519,7 @@ pub fn normalize_version(version: &str) -> String {
 mod tests {
     use super::*;
     use crate::file_types::FileType;
+    use crate::parsers::Span;
     use crate::registries::Vulnerability;
 
     fn make_version_info(latest: &str) -> VersionInfo {
@@ -532,11 +533,16 @@ mod tests {
         Dependency {
             name: name.to_string(),
             version: version.to_string(),
-            line: 5,
-            name_start: 0,
-            name_end: name.len() as u32,
-            version_start: name.len() as u32 + 4,
-            version_end: name.len() as u32 + 4 + version.len() as u32,
+            name_span: Span {
+                line: 5,
+                line_start: 0,
+                line_end: name.len() as u32,
+            },
+            version_span: Span {
+                line: 5,
+                line_start: name.len() as u32 + 4,
+                line_end: name.len() as u32 + 4 + version.len() as u32,
+            },
             dev: false,
             optional: false,
             registry: None,
@@ -1210,11 +1216,16 @@ mod tests {
         Dependency {
             name: name.to_string(),
             version: version.to_string(),
-            line: 5,
-            name_start: 0,
-            name_end: name.len() as u32,
-            version_start: name.len() as u32 + 4,
-            version_end: name.len() as u32 + 4 + version.len() as u32,
+            name_span: Span {
+                line: 5,
+                line_start: 0,
+                line_end: name.len() as u32,
+            },
+            version_span: Span {
+                line: 5,
+                line_start: name.len() as u32 + 4,
+                line_end: name.len() as u32 + 4 + version.len() as u32,
+            },
             dev: false,
             optional: false,
             registry: None,

--- a/dependi-lsp/tests/fuzz_regression.rs
+++ b/dependi-lsp/tests/fuzz_regression.rs
@@ -9,36 +9,45 @@ fn validate_deps(deps: &[dependi_lsp::parsers::Dependency], content: &str, parse
     let lines: Vec<&str> = content.lines().collect();
     let lines_len = lines.len();
     for dep in deps {
-        let dep_line = dep.line;
+        let dep_name_line = dep.name_span.line;
         assert!(
-            (dep_line as usize) < lines_len,
-            "{parser_name}: dep.line {dep_line} >= lines.len() {lines_len}"
+            (dep_name_line as usize) < lines_len,
+            "{parser_name}: dep.name_span.line {dep_name_line} >= lines.len() {lines_len}"
         );
 
-        let line = lines[dep.line as usize];
-        let line_len = line.len() as u32;
+        let name_line = lines[dep_name_line as usize];
+        let name_line_len = name_line.len() as u32;
 
         let dep_name = &*dep.name;
-        let dep_name_start = dep.name_start;
-        let dep_name_end = dep.name_end;
+        let dep_name_start = dep.name_span.line_start;
+        let dep_name_end = dep.name_span.line_end;
         assert!(
             dep_name_start <= dep_name_end,
             "{parser_name}: name_start {dep_name_start} > name_end {dep_name_end}"
         );
         assert!(
-            dep_name_end <= line_len,
-            "{parser_name}: name_end {dep_name_end} > line_len {line_len} for dep {dep_name} on line '{line}'"
+            dep_name_end <= name_line_len,
+            "{parser_name}: name_end {dep_name_end} > line_len {name_line_len} for dep {dep_name} on line '{name_line}'"
         );
 
-        let dep_version_start = dep.version_start;
-        let dep_version_end = dep.version_end;
+        let dep_version_line = dep.version_span.line;
+        assert!(
+            (dep_version_line as usize) < lines_len,
+            "{parser_name}: dep.version_span.line {dep_version_line} >= lines.len() {lines_len}"
+        );
+
+        let version_line = lines[dep_version_line as usize];
+        let version_line_len = version_line.len() as u32;
+
+        let dep_version_start = dep.version_span.line_start;
+        let dep_version_end = dep.version_span.line_end;
         assert!(
             dep_version_start <= dep_version_end,
             "{parser_name}: version_start {dep_version_start} > version_end {dep_version_end}"
         );
         assert!(
-            dep_version_end <= line_len,
-            "{parser_name}: version_end {dep_version_end} > line_len {line_len} for dep {dep_name} on line '{line}'"
+            dep_version_end <= version_line_len,
+            "{parser_name}: version_end {dep_version_end} > line_len {version_line_len} for dep {dep_name} on line '{version_line}'"
         );
     }
 }

--- a/dependi-lsp/tests/integration_test.rs
+++ b/dependi-lsp/tests/integration_test.rs
@@ -163,17 +163,22 @@ fn test_cache_integration() {
 /// Test inlay hint generation with various scenarios
 #[test]
 fn test_inlay_hint_generation() {
-    use dependi_lsp::parsers::Dependency;
+    use dependi_lsp::parsers::{Dependency, Span};
 
     // Up-to-date dependency
     let dep_up_to_date = Dependency {
         name: "serde".to_string(),
         version: "1.0.200".to_string(),
-        line: 5,
-        name_start: 0,
-        name_end: 5,
-        version_start: 9,
-        version_end: 18,
+        name_span: Span {
+            line: 5,
+            line_start: 0,
+            line_end: 5,
+        },
+        version_span: Span {
+            line: 5,
+            line_start: 9,
+            line_end: 18,
+        },
         dev: false,
         optional: false,
         registry: None,
@@ -197,11 +202,16 @@ fn test_inlay_hint_generation() {
     let dep_outdated = Dependency {
         name: "tokio".to_string(),
         version: "1.0.0".to_string(),
-        line: 6,
-        name_start: 0,
-        name_end: 5,
-        version_start: 9,
-        version_end: 16,
+        name_span: Span {
+            line: 6,
+            line_start: 0,
+            line_end: 5,
+        },
+        version_span: Span {
+            line: 6,
+            line_start: 9,
+            line_end: 16,
+        },
         dev: false,
         optional: false,
         registry: None,
@@ -323,9 +333,11 @@ tokio = { version = "1.35" }
 
     // serde should be on line 1 (0-indexed)
     let serde = deps.iter().find(|d| d.name == "serde").unwrap();
-    assert_eq!(serde.line, 1);
+    assert_eq!(serde.name_span.line, 1);
+    assert_eq!(serde.version_span.line, 1);
 
     // tokio should be on line 2
     let tokio = deps.iter().find(|d| d.name == "tokio").unwrap();
-    assert_eq!(tokio.line, 2);
+    assert_eq!(tokio.name_span.line, 2);
+    assert_eq!(tokio.version_span.line, 2);
 }


### PR DESCRIPTION
## Summary

<!-- Briefly describe your changes -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Related Issue

<!-- Link to the issue this PR addresses -->
Closes #249

## Changes Made

<!-- List the key changes in this PR -->
- Track the `package` field of a Cargo dependency entry
- Name and version lines are tracked separately

## Testing

<!-- Describe how you tested your changes -->
- [x] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo fmt --check` passes
- [ ] Tested manually in Zed

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated documentation if needed
- [x] I have added tests for new functionality
- [x] All new and existing tests pass

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Cargo alias dependencies via the `package` field and switches all parsers/providers to precise, quote‑free `name_span`/`version_span`, with separate lines for name and version. Improves hover, links, hints, completions, and edits, fixes duplicate Cargo entries, and avoids panics when syntax is missing.

- **New Features**
  - Use the quoted `package` value as the name for Cargo aliases (inline tables and `[dependencies.*]`).
  - Derive exact `name_span`/`version_span` from parser syntax (no quotes), tracking name/version lines separately.

- **Bug Fixes**
  - Hovers, completions, actions, diagnostics, inlay hints, and document links use `Span::contains_lsp_position` and the hovered span for accurate ranges.
  - Filter hints/actions by the version line for correct visibility; prevent duplicate Cargo entries and handle missing syntax safely.

<sup>Written for commit 0e8edc7044054a802bbbbfe92ed4a7dffac453fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved position tracking to use precise span-based locations, improving accuracy of name/version detection across all parsers and tooling.
* **Bug Fix**
  * Hover, inlay hints, completions, diagnostics, document links, and code actions now highlight and target the exact name or version region, fixing incorrect ranges.
* **Changed**
  * Cargo parsing now respects the package field for aliased dependencies; changelog updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->