### PR TITLE
refactor: drop unused Serialize/Deserialize derives on Dependency/Span

### DIFF
--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -1,10 +1,9 @@
 //! Parsers for dependency files (Cargo.toml, package.json, etc.)
 
-use serde::{Deserialize, Serialize};
 use tower_lsp::lsp_types;
 
 /// Represents a dependency extracted from a manifest file
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Dependency {
     /// Package name
     pub name: String,
@@ -21,11 +20,10 @@ pub struct Dependency {
     /// Custom registry name (Cargo only, e.g., "kellnr")
     pub registry: Option<String>,
     /// Resolved version from the lock file (e.g., Cargo.lock), if available
-    #[serde(default)]
     pub resolved_version: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy)]
 pub struct Span {
     /// Line number in the file (0-indexed)
     pub line: u32,


### PR DESCRIPTION
## Summary

- Drop `Serialize, Deserialize` from `Dependency` and `Span` derives in `dependi-lsp/src/parsers/mod.rs`
- Drop the `use serde::{Deserialize, Serialize};` import (no other type in the file needs it)
- Drop `#[serde(default)]` on `resolved_version` (no longer deserialized)

The SQLite cache persists `VersionInfo` — not `Dependency` — and the JSON/Markdown reports use their own `VulnerabilityReportEntry` / `VulnerabilitySummary` types, so these derives were dead weight.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings` (No issues found)
- [x] `cargo test --lib` (540 passed, 1 ignored)
- [x] `cargo test --test integration_test` (8 passed)
- [x] `cargo fmt --all -- --check`

Closes #253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal data handling by removing external serialization dependencies, improving code efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unused `serde` derives in `dependi-lsp/src/parsers/mod.rs` to trim dead code. No behavior change; `Dependency` and `Span` are not serialized.

- **Refactors**
  - Dropped `Serialize`/`Deserialize` derives from `Dependency` and `Span`.
  - Removed `#[serde(default)]` on `resolved_version`.
  - Removed `use serde::{Deserialize, Serialize};`.

<sup>Written for commit 8159340b97701b017cc7244726f6b6c304d2dbbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

