### PR TITLE
feat: scan lockfiles for transitive vulnerability detection (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,29 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for debugging or when only the manifest should be inspected.
 - `VersionInfo.transitive_vulnerabilities: Vec<TransitiveVuln>` and new public
   `TransitiveVuln` type in `registries` for consumers of the public API.
-
-### Fixed
-
-- `dependi-lsp scan` now uses `effective_version()` (the resolved lockfile
-  version when available) instead of the declared version specifier when
-  querying OSV — previously the CLI queried using the specifier string (e.g.
-  `^1.0`), which caused false negatives.
-
-### Security
-
-- Lockfile reads are now capped at 50 MiB to prevent out-of-memory on hostile
-  or corrupted inputs (both in CLI and LSP backend).
-
 - Support for Java/Maven projects (pom.xml):
   - Parse direct dependencies with `${properties}` substitution
   - Scope awareness (`test`/`provided` marked as dev dependencies)
   - Fetch versions and metadata from Maven Central (`maven-metadata.xml` + best-effort POM)
   - Vulnerability scanning via OSV.dev (Maven ecosystem)
-
-### Security
-
-- Bump transitive `rand` from 0.9.2 to 0.9.4 via `cargo update` to address [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) / [GHSA-cq8v-f236-94qc](https://github.com/rust-random/rand/security/advisories/GHSA-cq8v-f236-94qc) — unsoundness when the `log` and `thread_rng` features are combined with a custom logger that calls `rand::rng()` during a reseed cycle
-- Bump transitive `rustls-webpki` from 0.103.10 to 0.103.12 via `cargo update` to address [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098.html) / [GHSA-965h-392x-2mh5](https://github.com/rustls/webpki/security/advisories/GHSA-965h-392x-2mh5) (URI name constraints ignored) and [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099.html) / [GHSA-xgp8-3hg3-c2mh](https://github.com/rustls/webpki/security/advisories/GHSA-xgp8-3hg3-c2mh) (wildcard DNS name constraints bypass)
 
 ### Changed
 
@@ -64,7 +46,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `dependi-lsp scan` now uses `effective_version()` (the resolved lockfile
+  version when available) instead of the declared version specifier when
+  querying OSV — previously the CLI queried using the specifier string (e.g.
+  `^1.0`), which caused false negatives.
 - Respect the `package` field of `Cargo.toml` dependencies
+
+### Security
+
+- Lockfile reads are now capped at 50 MiB to prevent out-of-memory on hostile
+  or corrupted inputs (both in CLI and LSP backend).
+- Bump transitive `rand` from 0.9.2 to 0.9.4 via `cargo update` to address [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) / [GHSA-cq8v-f236-94qc](https://github.com/rust-random/rand/security/advisories/GHSA-cq8v-f236-94qc) — unsoundness when the `log` and `thread_rng` features are combined with a custom logger that calls `rand::rng()` during a reseed cycle
+- Bump transitive `rustls-webpki` from 0.103.10 to 0.103.12 via `cargo update` to address [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098.html) / [GHSA-965h-392x-2mh5](https://github.com/rustls/webpki/security/advisories/GHSA-965h-392x-2mh5) (URI name constraints ignored) and [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099.html) / [GHSA-xgp8-3hg3-c2mh](https://github.com/rustls/webpki/security/advisories/GHSA-xgp8-3hg3-c2mh) (wildcard DNS name constraints bypass)
 
 ## [1.7.0] - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Lockfile-based vulnerability scanning in the `dependi-lsp scan` CLI and in
   the LSP editor: when a manifest has an adjacent lockfile (`Cargo.lock`,
-  `package-lock.json`, `pnpm-lock.yaml` v6/v9, `yarn.lock` v1, `poetry.lock`,
+  `package-lock.json` (v2/v3 flat format; v1 legacy format not supported), `pnpm-lock.yaml` v6/v9, `yarn.lock` v1, `poetry.lock`,
   `uv.lock`, `Pipfile.lock`, `composer.lock`, `Gemfile.lock`), the scanner now
   uses the exact resolved versions **and** walks the full dependency graph to
   check transitive dependencies via OSV.dev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Lockfile-based vulnerability scanning in the `dependi-lsp scan` CLI and in
+  the LSP editor: when a manifest has an adjacent lockfile (`Cargo.lock`,
+  `package-lock.json`, `pnpm-lock.yaml` v6/v9, `yarn.lock` v1, `poetry.lock`,
+  `uv.lock`, `Pipfile.lock`, `composer.lock`, `Gemfile.lock`), the scanner now
+  uses the exact resolved versions **and** walks the full dependency graph to
+  check transitive dependencies via OSV.dev.
+- Transitive vulnerabilities are attributed to the direct dependency that
+  introduces them (`npm audit` style) and surfaced in:
+  - CLI reports (`summary`, `markdown`, `json`) under a distinct
+    `Transitive dependencies` section, each entry tagged with the direct
+    parent via `via_direct`.
+  - LSP diagnostics on the direct dependency line, with the message
+    summarizing up to 3 transitive CVEs (`N transitive CVE(s): pkg@ver (CVE-ID), ...`)
+    and escalating severity when a transitive CVE is more critical than the
+    direct ones.
+  - LSP hover content, with a dedicated `Transitive vulnerabilities` section
+    listing each CVE with severity, package@version, description, and link.
+- `--no-use-lockfile` flag on `dependi-lsp scan` to disable lockfile detection
+  for debugging or when only the manifest should be inspected.
+- `VersionInfo.transitive_vulnerabilities: Vec<TransitiveVuln>` and new public
+  `TransitiveVuln` type in `registries` for consumers of the public API.
+
+### Fixed
+
+- `dependi-lsp scan` now uses `effective_version()` (the resolved lockfile
+  version when available) instead of the declared version specifier when
+  querying OSV — previously the CLI queried using the specifier string (e.g.
+  `^1.0`), which caused false negatives.
+
+### Security
+
+- Lockfile reads are now capped at 50 MiB to prevent out-of-memory on hostile
+  or corrupted inputs (both in CLI and LSP backend).
+
 - Support for Java/Maven projects (pom.xml):
   - Parse direct dependencies with `${properties}` substitution
   - Scope awareness (`test`/`provided` marked as dev dependencies)

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -120,6 +120,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +489,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "dependi-lsp"
 version = "1.7.0"
 dependencies = [
@@ -499,12 +527,14 @@ dependencies = [
  "serde_json",
  "serial_test",
  "taplo",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml",
  "tower-lsp",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]
@@ -587,6 +617,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -750,6 +786,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +859,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +904,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,9 +919,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1182,6 +1251,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,6 +1376,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1762,6 +1847,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2146,6 +2244,19 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tracing",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3009,6 +3120,29 @@ name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -41,6 +41,8 @@ quick-xml = "0.38"
 [dev-dependencies]
 serial_test = "3"
 criterion = { version = "0.8.2", features = ["html_reports"] }
+wiremock = "0.6"
+tempfile = "3"
 
 [[bench]]
 name = "benchmarks"

--- a/dependi-lsp/benches/benchmarks.rs
+++ b/dependi-lsp/benches/benchmarks.rs
@@ -365,6 +365,7 @@ fn create_version_info() -> VersionInfo {
         yanked: false,
         yanked_versions: vec!["0.1.0".to_string(), "0.2.0".to_string()],
         release_dates: Default::default(),
+        transitive_vulnerabilities: vec![],
     }
 }
 

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -202,9 +202,19 @@ impl ProcessingContext {
                             }
                         }
                     };
+                    // Build first-wins version map: for ecosystems without canonical
+                    // multi-version disambiguation, the first entry for a given name wins.
+                    // This matches the pre-graph HashMap-based behavior for these ecosystems.
+                    let mut version_map: hashbrown::HashMap<String, String> =
+                        hashbrown::HashMap::new();
+                    for p in &graph.packages {
+                        version_map
+                            .entry_ref(&p.name)
+                            .or_insert_with(|| p.version.clone());
+                    }
                     for dep in &mut dependencies {
-                        if let Some(p) = graph.packages.iter().find(|p| p.name == dep.name) {
-                            dep.resolved_version = Some(p.version.clone());
+                        if let Some(v) = version_map.get(&dep.name) {
+                            dep.resolved_version = Some(v.clone());
                         }
                     }
                     tracing::debug!(
@@ -267,11 +277,21 @@ impl ProcessingContext {
                                 }
                             }
                         };
+                        // Build first-wins version map (graph keys are already normalized).
+                        // For ecosystems without canonical multi-version disambiguation, the first
+                        // entry for a given name wins — matches pre-graph HashMap behavior.
+                        let mut version_map: hashbrown::HashMap<String, String> =
+                            hashbrown::HashMap::new();
+                        for p in &graph.packages {
+                            version_map
+                                .entry_ref(&p.name)
+                                .or_insert_with(|| p.version.clone());
+                        }
                         for dep in &mut dependencies {
                             let normalized =
                                 crate::parsers::python_lock::normalize_python_name(&dep.name);
-                            if let Some(p) = graph.packages.iter().find(|p| p.name == normalized) {
-                                dep.resolved_version = Some(p.version.clone());
+                            if let Some(v) = version_map.get(&normalized) {
+                                dep.resolved_version = Some(v.clone());
                             }
                         }
                         tracing::debug!(
@@ -362,11 +382,21 @@ impl ProcessingContext {
                 Ok(lock_content) => {
                     let graph =
                         crate::parsers::composer_lock::parse_composer_lock_graph(&lock_content);
+                    // Build first-wins version map (graph keys are already normalized).
+                    // For ecosystems without canonical multi-version disambiguation, the first
+                    // entry for a given name wins — matches pre-graph HashMap behavior.
+                    let mut version_map: hashbrown::HashMap<String, String> =
+                        hashbrown::HashMap::new();
+                    for p in &graph.packages {
+                        version_map
+                            .entry_ref(&p.name)
+                            .or_insert_with(|| p.version.clone());
+                    }
                     for dep in &mut dependencies {
                         let normalized =
                             crate::parsers::composer_lock::normalize_composer_name(&dep.name);
-                        if let Some(p) = graph.packages.iter().find(|p| p.name == normalized) {
-                            dep.resolved_version = Some(p.version.clone());
+                        if let Some(v) = version_map.get(&normalized) {
+                            dep.resolved_version = Some(v.clone());
                         }
                     }
                     tracing::debug!(
@@ -499,11 +529,21 @@ impl ProcessingContext {
                 Ok(lock_content) => {
                     let graph =
                         crate::parsers::gemfile_lock::parse_gemfile_lock_graph(&lock_content);
+                    // Build first-wins version map (graph keys are already normalized).
+                    // For ecosystems without canonical multi-version disambiguation, the first
+                    // entry for a given name wins — matches pre-graph HashMap behavior.
+                    let mut version_map: hashbrown::HashMap<String, String> =
+                        hashbrown::HashMap::new();
+                    for p in &graph.packages {
+                        version_map
+                            .entry_ref(&p.name)
+                            .or_insert_with(|| p.version.clone());
+                    }
                     for dep in &mut dependencies {
                         let normalized =
                             crate::parsers::gemfile_lock::normalize_gem_name(&dep.name);
-                        if let Some(p) = graph.packages.iter().find(|p| p.name == normalized) {
-                            dep.resolved_version = Some(p.version.clone());
+                        if let Some(v) = version_map.get(&normalized) {
+                            dep.resolved_version = Some(v.clone());
                         }
                     }
                     tracing::debug!(
@@ -634,6 +674,7 @@ impl ProcessingContext {
                 dependencies: dependencies.clone(),
                 file_type,
                 lockfile_graph: lockfile_graph.clone(),
+                transitive_vulns_by_direct: hashbrown::HashMap::new(),
             },
         );
 
@@ -666,6 +707,13 @@ impl ProcessingContext {
                 .iter()
                 .map(|dep| (dep.name.clone(), dep_cache_key(dep, file_type)))
                 .collect();
+            // Transitive vulns are not yet available at this point (background task hasn't run).
+            // They will be populated in DocumentState.transitive_vulns_by_direct once the
+            // background vulnerability fetch completes.
+            let empty_transitives: hashbrown::HashMap<
+                String,
+                Vec<crate::registries::TransitiveVuln>,
+            > = hashbrown::HashMap::new();
             let diagnostics = create_diagnostics(
                 &dependencies,
                 &self.version_cache,
@@ -677,6 +725,7 @@ impl ProcessingContext {
                 },
                 severity_filter,
                 file_type,
+                &empty_transitives,
             );
 
             self.client
@@ -697,7 +746,8 @@ impl ProcessingContext {
             let osv_client_clone = Arc::clone(&self.osv_client);
             let vuln_cache_clone = Arc::clone(&self.vuln_cache);
             let client_clone = self.client.clone();
-            let lockfile_graph_clone = lockfile_graph.clone();
+            let documents_clone = Arc::clone(&self.documents);
+            let uri_clone = uri.clone();
 
             tokio::spawn(async move {
                 DependiBackend::fetch_vulnerabilities_background(
@@ -707,12 +757,24 @@ impl ProcessingContext {
                     osv_client_clone,
                     vuln_cache_clone,
                     client_clone,
-                    lockfile_graph_clone,
+                    VulnBgContext {
+                        documents: documents_clone,
+                        uri: uri_clone,
+                        lockfile_graph,
+                    },
                 )
                 .await;
             });
         }
     }
+}
+
+/// Context passed to the background vulnerability fetch task so it can write
+/// per-document transitive attribution after the OSV query completes.
+struct VulnBgContext {
+    documents: Arc<DashMap<Url, DocumentState>>,
+    uri: Url,
+    lockfile_graph: Option<std::sync::Arc<crate::parsers::lockfile_graph::LockfileGraph>>,
 }
 
 pub struct DependiBackend {
@@ -935,7 +997,7 @@ impl DependiBackend {
         osv_client: Arc<OsvClient>,
         vuln_cache: Arc<VulnerabilityCache>,
         client: Client,
-        lockfile_graph: Option<std::sync::Arc<crate::parsers::lockfile_graph::LockfileGraph>>,
+        bg_ctx: VulnBgContext,
     ) {
         use crate::vulnerabilities::cache::VulnCacheKey;
 
@@ -947,9 +1009,19 @@ impl DependiBackend {
             .map(|dep| (dep.name.clone(), dep_cache_key(dep, file_type)))
             .collect();
 
-        // Collect transitive packages from the lockfile graph
-        let direct_names: Vec<String> = dependencies.iter().map(|d| d.name.clone()).collect();
-        let transitives: Vec<crate::parsers::lockfile_graph::LockfilePackage> = lockfile_graph
+        // Collect transitive packages from the lockfile graph.
+        // Names are canonicalized to match the lockfile graph keys (Python/PHP/Ruby normalize).
+        let direct_names: Vec<String> = dependencies
+            .iter()
+            .map(|d| match file_type {
+                FileType::Python => crate::parsers::python_lock::normalize_python_name(&d.name),
+                FileType::Php => crate::parsers::composer_lock::normalize_composer_name(&d.name),
+                FileType::Ruby => crate::parsers::gemfile_lock::normalize_gem_name(&d.name),
+                _ => d.name.clone(),
+            })
+            .collect();
+        let transitives: Vec<crate::parsers::lockfile_graph::LockfilePackage> = bg_ctx
+            .lockfile_graph
             .as_deref()
             .map(|g| {
                 g.transitives_only(&direct_names)
@@ -1058,12 +1130,20 @@ impl DependiBackend {
                     }
                 }
 
-                // Attach transitive vulnerabilities to the first direct parent that reaches them.
+                // Attribute transitive vulnerabilities to ALL direct parents that reach them.
+                // Stored per-document (not in global version_cache) to avoid cross-workspace
+                // contamination: transitive attribution depends on this document's lockfile graph.
                 // transitive_query_pkgs is the filtered list (cached ones were skipped above).
-                if let Some(graph) = lockfile_graph.as_deref() {
+                if let Some(graph) = bg_ctx.lockfile_graph.as_deref() {
                     use crate::registries::TransitiveVuln;
 
                     let inverse = graph.reverse_index(&direct_names);
+
+                    // Build per-document transitive attribution map.
+                    let mut transitive_vulns_by_direct: hashbrown::HashMap<
+                        String,
+                        Vec<TransitiveVuln>,
+                    > = hashbrown::HashMap::new();
 
                     for (tpkg, result) in
                         transitive_query_pkgs.iter().zip(transitive_results.iter())
@@ -1077,40 +1157,65 @@ impl DependiBackend {
                         if result.vulnerabilities.is_empty() {
                             continue;
                         }
-                        // Find the first direct dep that transitively reaches this package
-                        let first_parent =
-                            inverse.get(&tpkg.name).and_then(|parents| parents.first());
 
-                        if let Some(dep_name) = first_parent {
-                            let cache_key = cache_key_map
-                                .get(dep_name)
-                                .cloned()
-                                .unwrap_or_else(|| file_type.cache_key(dep_name));
-                            if let Some(mut info) = cache.get(&cache_key) {
-                                for v in &result.vulnerabilities {
-                                    let new_tv = TransitiveVuln {
+                        // Attribute to ALL direct parents that transitively reach this package.
+                        let parents = inverse.get(&tpkg.name).cloned().unwrap_or_default();
+
+                        if parents.is_empty() {
+                            // No known parent — attribute to "(unknown)" so we don't drop the finding.
+                            for v in &result.vulnerabilities {
+                                transitive_vulns_by_direct
+                                    .entry_ref("(unknown)")
+                                    .or_default()
+                                    .push(TransitiveVuln {
                                         package_name: tpkg.name.clone(),
                                         package_version: tpkg.version.clone(),
                                         vulnerability: v.clone(),
-                                    };
-                                    if !info.transitive_vulnerabilities.iter().any(|existing| {
-                                        existing.package_name == new_tv.package_name
-                                            && existing.package_version == new_tv.package_version
-                                            && existing.vulnerability.id == new_tv.vulnerability.id
-                                    }) {
-                                        info.transitive_vulnerabilities.push(new_tv);
-                                    }
+                                    });
+                            }
+                        } else {
+                            for parent in &parents {
+                                for v in &result.vulnerabilities {
+                                    transitive_vulns_by_direct
+                                        .entry_ref(parent.as_str())
+                                        .or_default()
+                                        .push(TransitiveVuln {
+                                            package_name: tpkg.name.clone(),
+                                            package_version: tpkg.version.clone(),
+                                            vulnerability: v.clone(),
+                                        });
                                 }
                                 tracing::debug!(
-                                    "Background: Attached {} transitive vulns from {}@{} to direct dep {}",
+                                    "Background: Attributed {} transitive vulns from {}@{} to direct dep {}",
                                     result.vulnerabilities.len(),
                                     tpkg.name,
                                     tpkg.version,
-                                    dep_name
+                                    parent
                                 );
-                                cache.insert(cache_key, info);
                             }
                         }
+                    }
+
+                    // Dedup within each parent bucket.
+                    for bucket in transitive_vulns_by_direct.values_mut() {
+                        bucket.sort_by(|a, b| {
+                            (&a.package_name, &a.package_version, &a.vulnerability.id).cmp(&(
+                                &b.package_name,
+                                &b.package_version,
+                                &b.vulnerability.id,
+                            ))
+                        });
+                        bucket.dedup_by(|a, b| {
+                            a.package_name == b.package_name
+                                && a.package_version == b.package_version
+                                && a.vulnerability.id == b.vulnerability.id
+                        });
+                    }
+
+                    // Write per-document transitive findings into the DocumentState so they are
+                    // isolated from other workspaces that share the same global version_cache.
+                    if let Some(mut doc) = bg_ctx.documents.get_mut(&bg_ctx.uri) {
+                        doc.transitive_vulns_by_direct = transitive_vulns_by_direct;
                     }
                 }
 
@@ -1253,6 +1358,7 @@ fn format_hover_content(
     dep: &crate::parsers::Dependency,
     file_type: FileType,
     info: &VersionInfo,
+    doc_transitive_vulns: &[crate::registries::TransitiveVuln],
 ) -> String {
     let dep_name = &*dep.name;
     let dep_version = dep.effective_version();
@@ -1324,10 +1430,11 @@ fn format_hover_content(
             }
         }
 
-        // Add transitive vulnerability information if present
-        if !info.transitive_vulnerabilities.is_empty() {
+        // Add transitive vulnerability information if present.
+        // Uses per-document attribution (not global version_cache) to avoid cross-workspace leaks.
+        if !doc_transitive_vulns.is_empty() {
             writeln!(f, "\n## Transitive vulnerabilities")?;
-            for t in &info.transitive_vulnerabilities {
+            for t in doc_transitive_vulns {
                 let link = match &t.vulnerability.url {
                     Some(u) => format!("[{}]({u})", t.vulnerability.id),
                     None => t.vulnerability.id.clone(),
@@ -1746,6 +1853,13 @@ impl LanguageServer for DependiBackend {
             HoveredSpan::Version => dep.version_span,
         };
 
+        // Snapshot per-document transitive vulns for this dependency before dropping the lock.
+        let doc_transitive_vulns: Vec<crate::registries::TransitiveVuln> = doc
+            .transitive_vulns_by_direct
+            .get(dep_name)
+            .cloned()
+            .unwrap_or_default();
+
         // Drop the lock before async call
         drop(doc);
 
@@ -1755,7 +1869,7 @@ impl LanguageServer for DependiBackend {
             .await;
 
         let content = match version_info {
-            Some(info) => format_hover_content(&dep, file_type, &info),
+            Some(info) => format_hover_content(&dep, file_type, &info, &doc_transitive_vulns),
             None => format!("## {dep_name}\n\nCould not fetch package information."),
         };
 
@@ -1886,7 +2000,7 @@ mod tests {
             ..Default::default()
         };
 
-        let content = format_hover_content(&dep, FileType::Cargo, &info);
+        let content = format_hover_content(&dep, FileType::Cargo, &info, &[]);
 
         // Must show the resolved version, not the manifest specifier
         assert!(
@@ -1907,7 +2021,7 @@ mod tests {
             ..Default::default()
         };
 
-        let content = format_hover_content(&dep, FileType::Cargo, &info);
+        let content = format_hover_content(&dep, FileType::Cargo, &info, &[]);
 
         assert!(
             content.contains("**Current:** 1.35.0"),
@@ -1930,7 +2044,7 @@ mod tests {
         info.release_dates
             .insert("1.0.200".to_string(), release_date);
 
-        let content = format_hover_content(&dep, FileType::Cargo, &info);
+        let content = format_hover_content(&dep, FileType::Cargo, &info, &[]);
 
         // The release date should be found (keyed by effective_version "1.0.200")
         assert!(
@@ -1946,19 +2060,19 @@ mod tests {
         let dep = make_dep("react", "^18.0", Some("18.2.0"));
         let info = VersionInfo {
             latest: Some("18.2.0".to_string()),
-            transitive_vulnerabilities: vec![TransitiveVuln {
-                package_name: "scheduler".to_string(),
-                package_version: "1.2.3".to_string(),
-                vulnerability: Vulnerability {
-                    id: "CVE-1".to_string(),
-                    severity: VulnerabilitySeverity::High,
-                    description: "desc".to_string(),
-                    url: None,
-                },
-            }],
             ..Default::default()
         };
-        let content = format_hover_content(&dep, FileType::Npm, &info);
+        let transitive_vulns = vec![TransitiveVuln {
+            package_name: "scheduler".to_string(),
+            package_version: "1.2.3".to_string(),
+            vulnerability: Vulnerability {
+                id: "CVE-1".to_string(),
+                severity: VulnerabilitySeverity::High,
+                description: "desc".to_string(),
+                url: None,
+            },
+        }];
+        let content = format_hover_content(&dep, FileType::Npm, &info, &transitive_vulns);
         assert!(
             content.contains("Transitive vulnerabilities"),
             "Hover should contain transitive section, got:\n{content}"

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -119,7 +119,9 @@ impl ProcessingContext {
         let mut dependencies = self.parse_document(uri, content);
 
         // lockfile_graph is populated by the ecosystem-specific blocks below.
-        let mut lockfile_graph: Option<std::sync::Arc<crate::parsers::lockfile_graph::LockfileGraph>> = None;
+        let mut lockfile_graph: Option<
+            std::sync::Arc<crate::parsers::lockfile_graph::LockfileGraph>,
+        > = None;
 
         // Resolve versions from Cargo.lock for Cargo dependencies
         if file_type == FileType::Cargo
@@ -127,7 +129,7 @@ impl ProcessingContext {
             && let Some(lock_path) =
                 crate::parsers::cargo_lock::find_cargo_lock(&cargo_toml_path).await
         {
-            match tokio::fs::read_to_string(&lock_path).await {
+            match crate::parsers::lockfile_graph::read_lockfile_capped(&lock_path).await {
                 Ok(lock_content) => {
                     let graph = crate::parsers::cargo_lock::parse_cargo_lock_graph(&lock_content);
                     for dep in &mut dependencies {
@@ -161,7 +163,7 @@ impl ProcessingContext {
             && let Some((lock_path, npm_lockfile_type)) =
                 crate::parsers::npm_lock::find_npm_lockfile(&package_json_path).await
         {
-            match tokio::fs::read_to_string(&lock_path).await {
+            match crate::parsers::lockfile_graph::read_lockfile_capped(&lock_path).await {
                 Ok(lock_content) => {
                     use crate::parsers::npm_lock::NpmLockfileType;
                     let graph = match npm_lockfile_type {
@@ -225,7 +227,7 @@ impl ProcessingContext {
             if let Some((lock_path, py_lockfile_type)) =
                 crate::parsers::python_lock::find_python_lockfile(&manifest_path, preferred).await
             {
-                match tokio::fs::read_to_string(&lock_path).await {
+                match crate::parsers::lockfile_graph::read_lockfile_capped(&lock_path).await {
                     Ok(lock_content) => {
                         use crate::parsers::python_lock::PythonLockfileType;
                         let graph = match py_lockfile_type {
@@ -240,10 +242,11 @@ impl ProcessingContext {
                             }
                             PythonLockfileType::PdmLock => {
                                 // No graph parser for PDM — build minimal graph from HashMap
-                                let lock_versions = crate::parsers::python_lock::parse_python_lockfile(
-                                    &lock_content,
-                                    py_lockfile_type,
-                                );
+                                let lock_versions =
+                                    crate::parsers::python_lock::parse_python_lockfile(
+                                        &lock_content,
+                                        py_lockfile_type,
+                                    );
                                 crate::parsers::lockfile_graph::LockfileGraph {
                                     packages: lock_versions
                                         .iter()
@@ -262,9 +265,7 @@ impl ProcessingContext {
                         for dep in &mut dependencies {
                             let normalized =
                                 crate::parsers::python_lock::normalize_python_name(&dep.name);
-                            if let Some(p) =
-                                graph.packages.iter().find(|p| p.name == normalized)
-                            {
+                            if let Some(p) = graph.packages.iter().find(|p| p.name == normalized) {
                                 dep.resolved_version = Some(p.version.clone());
                             }
                         }
@@ -295,7 +296,7 @@ impl ProcessingContext {
             && let Ok(go_mod_path) = uri.to_file_path()
             && let Some(lock_path) = crate::parsers::go_sum::find_go_sum(&go_mod_path).await
         {
-            match tokio::fs::read_to_string(&lock_path).await {
+            match crate::parsers::lockfile_graph::read_lockfile_capped(&lock_path).await {
                 Ok(lock_content) => {
                     let lock_versions = crate::parsers::go_sum::parse_go_sum(&lock_content);
                     let mut minimal_packages = Vec::new();
@@ -316,12 +317,14 @@ impl ProcessingContext {
                     // Build minimal graph (no edge data available from go.sum)
                     for (name, versions) in &lock_versions {
                         for version in versions {
-                            minimal_packages.push(crate::parsers::lockfile_graph::LockfilePackage {
-                                name: name.clone(),
-                                version: version.clone(),
-                                dependencies: Vec::new(),
-                                is_root: false,
-                            });
+                            minimal_packages.push(
+                                crate::parsers::lockfile_graph::LockfilePackage {
+                                    name: name.clone(),
+                                    version: version.clone(),
+                                    dependencies: Vec::new(),
+                                    is_root: false,
+                                },
+                            );
                         }
                     }
                     tracing::debug!(
@@ -350,7 +353,7 @@ impl ProcessingContext {
             && let Some(lock_path) =
                 crate::parsers::composer_lock::find_composer_lock(&composer_json_path).await
         {
-            match tokio::fs::read_to_string(&lock_path).await {
+            match crate::parsers::lockfile_graph::read_lockfile_capped(&lock_path).await {
                 Ok(lock_content) => {
                     let graph =
                         crate::parsers::composer_lock::parse_composer_lock_graph(&lock_content);
@@ -387,7 +390,7 @@ impl ProcessingContext {
             && let Some(lock_path) =
                 crate::parsers::pubspec_lock::find_pubspec_lock(&pubspec_yaml_path).await
         {
-            match tokio::fs::read_to_string(&lock_path).await {
+            match crate::parsers::lockfile_graph::read_lockfile_capped(&lock_path).await {
                 Ok(lock_content) => {
                     let lock_versions =
                         crate::parsers::pubspec_lock::parse_pubspec_lock(&lock_content);
@@ -436,7 +439,7 @@ impl ProcessingContext {
             && let Some(lock_path) =
                 crate::parsers::packages_lock_json::find_packages_lock(&csproj_path).await
         {
-            match tokio::fs::read_to_string(&lock_path).await {
+            match crate::parsers::lockfile_graph::read_lockfile_capped(&lock_path).await {
                 Ok(lock_content) => {
                     let lock_versions =
                         crate::parsers::packages_lock_json::parse_packages_lock(&lock_content);
@@ -487,7 +490,7 @@ impl ProcessingContext {
             && let Some(lock_path) =
                 crate::parsers::gemfile_lock::find_gemfile_lock(&gemfile_path).await
         {
-            match tokio::fs::read_to_string(&lock_path).await {
+            match crate::parsers::lockfile_graph::read_lockfile_capped(&lock_path).await {
                 Ok(lock_content) => {
                     let graph =
                         crate::parsers::gemfile_lock::parse_gemfile_lock_graph(&lock_content);
@@ -943,7 +946,12 @@ impl DependiBackend {
         let direct_names: Vec<String> = dependencies.iter().map(|d| d.name.clone()).collect();
         let transitives: Vec<crate::parsers::lockfile_graph::LockfilePackage> = lockfile_graph
             .as_deref()
-            .map(|g| g.transitives_only(&direct_names).into_iter().cloned().collect())
+            .map(|g| {
+                g.transitives_only(&direct_names)
+                    .into_iter()
+                    .cloned()
+                    .collect()
+            })
             .unwrap_or_default();
 
         // Build queries for direct packages not in vulnerability cache
@@ -995,7 +1003,10 @@ impl DependiBackend {
                 let (direct_results, transitive_results) = results.split_at(direct_count);
 
                 // Update vulnerability cache and version_cache with direct results
-                for (query, result) in all_queries[..direct_count].iter().zip(direct_results.iter()) {
+                for (query, result) in all_queries[..direct_count]
+                    .iter()
+                    .zip(direct_results.iter())
+                {
                     // Mark this package as queried in vuln_cache
                     let vuln_key =
                         VulnCacheKey::new(ecosystem, &query.package_name, &query.version);
@@ -1037,24 +1048,21 @@ impl DependiBackend {
                 if let Some(graph) = lockfile_graph.as_deref() {
                     use crate::registries::TransitiveVuln;
 
+                    let inverse = graph.reverse_index(&direct_names);
+
                     for (tpkg, result) in transitives.iter().zip(transitive_results.iter()) {
                         if result.vulnerabilities.is_empty() {
                             continue;
                         }
                         // Find the first direct dep that transitively reaches this package
-                        for dep in &dependencies {
-                            let reaches = graph
-                                .transitive_deps_of(&dep.name)
-                                .iter()
-                                .any(|p| p.name == tpkg.name);
-                            if !reaches {
-                                continue;
-                            }
+                        let first_parent =
+                            inverse.get(&tpkg.name).and_then(|parents| parents.first());
 
+                        if let Some(dep_name) = first_parent {
                             let cache_key = cache_key_map
-                                .get(&dep.name)
+                                .get(dep_name)
                                 .cloned()
-                                .unwrap_or_else(|| file_type.cache_key(&dep.name));
+                                .unwrap_or_else(|| file_type.cache_key(dep_name));
                             if let Some(mut info) = cache.get(&cache_key) {
                                 for v in &result.vulnerabilities {
                                     let new_tv = TransitiveVuln {
@@ -1075,12 +1083,10 @@ impl DependiBackend {
                                     result.vulnerabilities.len(),
                                     tpkg.name,
                                     tpkg.version,
-                                    dep.name
+                                    dep_name
                                 );
                                 cache.insert(cache_key, info);
                             }
-                            // Attach to first matching direct parent only (npm audit style)
-                            break;
                         }
                     }
                 }

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -1196,6 +1196,17 @@ impl DependiBackend {
                             VulnCacheKey::new(ecosystem, &tpkg.name, &normalized_version);
                         vuln_cache.insert(vuln_key);
 
+                        // Always store vuln data (even empty) so the cached-attribution loop
+                        // below can find a transitive_vuln_data entry for every vuln_cache hit.
+                        let vuln_data_key = VulnCacheKey::new(
+                            ecosystem,
+                            &tpkg.name,
+                            &normalize_version_for_osv(&tpkg.version),
+                        );
+                        bg_ctx
+                            .transitive_vuln_data
+                            .insert(vuln_data_key, result.vulnerabilities.clone());
+
                         if result.vulnerabilities.is_empty() {
                             continue;
                         }
@@ -1241,19 +1252,6 @@ impl DependiBackend {
                                     raw_parent
                                 );
                             }
-                        }
-
-                        // Also store per-(ecosystem, name, version) so cached re-attribution can
-                        // retrieve the vuln list on subsequent document opens (FIX C).
-                        if !result.vulnerabilities.is_empty() {
-                            let vuln_data_key = VulnCacheKey::new(
-                                ecosystem,
-                                &tpkg.name,
-                                &normalize_version_for_osv(&tpkg.version),
-                            );
-                            bg_ctx
-                                .transitive_vuln_data
-                                .insert(vuln_data_key, result.vulnerabilities.clone());
                         }
                     }
 
@@ -1309,6 +1307,12 @@ impl DependiBackend {
                                     );
                                 }
                             }
+                        } else {
+                            tracing::debug!(
+                                "vuln_cache hit without transitive_vuln_data for {}@{} — skipping attribution",
+                                tpkg.name,
+                                tpkg.version
+                            );
                         }
                     }
 

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -1023,8 +1023,7 @@ impl DependiBackend {
                 for (dep, result) in direct_query_deps.iter().zip(direct_results.iter()) {
                     let normalized_version = normalize_version_for_osv(dep.effective_version());
                     // Mark this package as queried in vuln_cache
-                    let vuln_key =
-                        VulnCacheKey::new(ecosystem, &dep.name, &normalized_version);
+                    let vuln_key = VulnCacheKey::new(ecosystem, &dep.name, &normalized_version);
                     vuln_cache.insert(vuln_key);
 
                     // Store vulnerabilities and deprecated status in version_cache

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -52,6 +52,17 @@ use crate::{
     reports::fmt_markdown_report,
 };
 
+/// Extract the `[package].name` field from a Cargo.toml manifest.
+/// Used to pass the root package name to `parse_cargo_lock` for multi-version disambiguation.
+fn cargo_root_package_name(manifest_content: &str) -> Option<String> {
+    let value: toml::Value = toml::from_str(manifest_content).ok()?;
+    value
+        .get("package")?
+        .get("name")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
 /// Compute cache key for a dependency, including registry for Cargo alternative registries.
 ///
 /// For Cargo deps with `registry = "name"`, the key is `crates:{registry}:{name}` to avoid
@@ -93,6 +104,10 @@ struct ProcessingContext {
     maven_central: Arc<tokio::sync::RwLock<MavenCentralRegistry>>,
     osv_client: Arc<OsvClient>,
     vuln_cache: Arc<VulnerabilityCache>,
+    /// Per-(ecosystem, name, version) transitive vuln data shared across document processing runs.
+    transitive_vuln_data: Arc<
+        DashMap<crate::vulnerabilities::cache::VulnCacheKey, Vec<crate::registries::Vulnerability>>,
+    >,
 }
 
 impl ProcessingContext {
@@ -134,8 +149,11 @@ impl ProcessingContext {
                     // Use parse_cargo_lock (HashMap) for resolution: it correctly
                     // disambiguates multi-version crates via the root package's dep list.
                     // parse_cargo_lock_graph is kept for the transitive walk below.
-                    let version_map =
-                        crate::parsers::cargo_lock::parse_cargo_lock(&lock_content, None);
+                    let root_name = cargo_root_package_name(content);
+                    let version_map = crate::parsers::cargo_lock::parse_cargo_lock(
+                        &lock_content,
+                        root_name.as_deref(),
+                    );
                     for dep in &mut dependencies {
                         if let Some(v) = version_map.get(&dep.name) {
                             dep.resolved_version = Some(v.clone());
@@ -745,6 +763,7 @@ impl ProcessingContext {
             let cache_clone = Arc::clone(&self.version_cache);
             let osv_client_clone = Arc::clone(&self.osv_client);
             let vuln_cache_clone = Arc::clone(&self.vuln_cache);
+            let transitive_vuln_data_clone = Arc::clone(&self.transitive_vuln_data);
             let client_clone = self.client.clone();
             let documents_clone = Arc::clone(&self.documents);
             let uri_clone = uri.clone();
@@ -761,6 +780,7 @@ impl ProcessingContext {
                         documents: documents_clone,
                         uri: uri_clone,
                         lockfile_graph,
+                        transitive_vuln_data: transitive_vuln_data_clone,
                     },
                 )
                 .await;
@@ -775,6 +795,11 @@ struct VulnBgContext {
     documents: Arc<DashMap<Url, DocumentState>>,
     uri: Url,
     lockfile_graph: Option<std::sync::Arc<crate::parsers::lockfile_graph::LockfileGraph>>,
+    /// Per-(ecosystem, name, version) transitive vuln data. Populated by the fresh-query loop
+    /// and read by the cached-query loop so re-attribution works on subsequent document opens.
+    transitive_vuln_data: Arc<
+        DashMap<crate::vulnerabilities::cache::VulnCacheKey, Vec<crate::registries::Vulnerability>>,
+    >,
 }
 
 pub struct DependiBackend {
@@ -815,6 +840,12 @@ pub struct DependiBackend {
     /// Vulnerability scanning
     osv_client: Arc<OsvClient>,
     vuln_cache: Arc<VulnerabilityCache>,
+    /// Per-(ecosystem, name, version) transitive vuln data.
+    /// Populated during fresh OSV queries for transitive packages; read on cached re-attribution
+    /// so subsequent document opens can still attribute transitives to their direct parents.
+    transitive_vuln_data: Arc<
+        DashMap<crate::vulnerabilities::cache::VulnCacheKey, Vec<crate::registries::Vulnerability>>,
+    >,
     /// Debounce tasks for did_change notifications (per-URI)
     /// Maps URI -> (generation, JoinHandle) for safe cleanup with racing tasks
     debounce_tasks: Arc<DashMap<Url, (u64, tokio::task::JoinHandle<()>)>>,
@@ -889,6 +920,7 @@ impl DependiBackend {
             token_manager,
             osv_client: Arc::new(OsvClient::default()),
             vuln_cache: Arc::new(VulnerabilityCache::new()),
+            transitive_vuln_data: Arc::new(DashMap::new()),
             debounce_tasks: Arc::new(DashMap::new()),
             debounce_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             pending_changes: Arc::new(DashMap::new()),
@@ -922,6 +954,7 @@ impl DependiBackend {
             maven_central: Arc::clone(&self.maven_central),
             osv_client: Arc::clone(&self.osv_client),
             vuln_cache: Arc::clone(&self.vuln_cache),
+            transitive_vuln_data: Arc::clone(&self.transitive_vuln_data),
         }
     }
 
@@ -1011,15 +1044,25 @@ impl DependiBackend {
 
         // Collect transitive packages from the lockfile graph.
         // Names are canonicalized to match the lockfile graph keys (Python/PHP/Ruby normalize).
-        let direct_names: Vec<String> = dependencies
-            .iter()
-            .map(|d| match file_type {
-                FileType::Python => crate::parsers::python_lock::normalize_python_name(&d.name),
-                FileType::Php => crate::parsers::composer_lock::normalize_composer_name(&d.name),
-                FileType::Ruby => crate::parsers::gemfile_lock::normalize_gem_name(&d.name),
-                _ => d.name.clone(),
-            })
-            .collect();
+        // Also build a reverse map so that normalized parent names from reverse_index can be
+        // translated back to the raw manifest name used as keys in diagnostics/hover lookups.
+        let (direct_names, normalized_to_raw): (Vec<String>, HashMap<String, String>) = {
+            let mut names = Vec::with_capacity(dependencies.len());
+            let mut map: HashMap<String, String> = HashMap::new();
+            for d in dependencies.iter() {
+                let canonical = match file_type {
+                    FileType::Python => crate::parsers::python_lock::normalize_python_name(&d.name),
+                    FileType::Php => {
+                        crate::parsers::composer_lock::normalize_composer_name(&d.name)
+                    }
+                    FileType::Ruby => crate::parsers::gemfile_lock::normalize_gem_name(&d.name),
+                    _ => d.name.clone(),
+                };
+                names.push(canonical.clone());
+                map.insert(canonical, d.name.clone());
+            }
+            (names, map)
+        };
         let transitives: Vec<crate::parsers::lockfile_graph::LockfilePackage> = bg_ctx
             .lockfile_graph
             .as_deref()
@@ -1174,9 +1217,15 @@ impl DependiBackend {
                             }
                         } else {
                             for parent in &parents {
+                                // Translate normalized parent name back to the raw manifest name
+                                // so that diagnostics/hover lookups using dep.name succeed.
+                                let raw_parent = normalized_to_raw
+                                    .get(parent.as_str())
+                                    .cloned()
+                                    .unwrap_or_else(|| parent.clone());
                                 for v in &result.vulnerabilities {
                                     transitive_vulns_by_direct
-                                        .entry_ref(parent.as_str())
+                                        .entry_ref(raw_parent.as_str())
                                         .or_default()
                                         .push(TransitiveVuln {
                                             package_name: tpkg.name.clone(),
@@ -1189,25 +1238,42 @@ impl DependiBackend {
                                     result.vulnerabilities.len(),
                                     tpkg.name,
                                     tpkg.version,
-                                    parent
+                                    raw_parent
                                 );
                             }
+                        }
+
+                        // Also store per-(ecosystem, name, version) so cached re-attribution can
+                        // retrieve the vuln list on subsequent document opens (FIX C).
+                        if !result.vulnerabilities.is_empty() {
+                            let vuln_data_key = VulnCacheKey::new(
+                                ecosystem,
+                                &tpkg.name,
+                                &normalize_version_for_osv(&tpkg.version),
+                            );
+                            bg_ctx
+                                .transitive_vuln_data
+                                .insert(vuln_data_key, result.vulnerabilities.clone());
                         }
                     }
 
                     // Attribute transitive vulns for packages already in vuln_cache.
-                    // Their vuln data lives in version_cache under the ecosystem-prefixed key.
-                    // This ensures re-processing a document never drops transitive attribution
-                    // just because the OSV query was skipped.
+                    // Vuln data for transitives is stored in transitive_vuln_data (not
+                    // version_cache, which only holds direct-dep data). This ensures
+                    // re-processing a document never drops transitive attribution just because
+                    // the OSV query was skipped on the second run (FIX C).
                     for tpkg in &transitive_cached_pkgs {
-                        let cache_key = file_type.cache_key(&tpkg.name);
-                        if let Some(info) = cache.get(&cache_key) {
-                            if info.vulnerabilities.is_empty() {
+                        let normalized_version = normalize_version_for_osv(&tpkg.version);
+                        let vuln_data_key =
+                            VulnCacheKey::new(ecosystem, &tpkg.name, &normalized_version);
+                        if let Some(vulns) = bg_ctx.transitive_vuln_data.get(&vuln_data_key) {
+                            let vulns: Vec<_> = vulns.clone();
+                            if vulns.is_empty() {
                                 continue;
                             }
                             let parents = inverse.get(&tpkg.name).cloned().unwrap_or_default();
                             if parents.is_empty() {
-                                for v in &info.vulnerabilities {
+                                for v in &vulns {
                                     transitive_vulns_by_direct
                                         .entry_ref("(unknown)")
                                         .or_default()
@@ -1219,9 +1285,14 @@ impl DependiBackend {
                                 }
                             } else {
                                 for parent in &parents {
-                                    for v in &info.vulnerabilities {
+                                    // Translate normalized parent name back to raw manifest name.
+                                    let raw_parent = normalized_to_raw
+                                        .get(parent.as_str())
+                                        .cloned()
+                                        .unwrap_or_else(|| parent.clone());
+                                    for v in &vulns {
                                         transitive_vulns_by_direct
-                                            .entry_ref(parent.as_str())
+                                            .entry_ref(raw_parent.as_str())
                                             .or_default()
                                             .push(TransitiveVuln {
                                                 package_name: tpkg.name.clone(),
@@ -1231,10 +1302,10 @@ impl DependiBackend {
                                     }
                                     tracing::debug!(
                                         "Background: Re-attributed (cached) {} transitive vulns from {}@{} to direct dep {}",
-                                        info.vulnerabilities.len(),
+                                        vulns.len(),
                                         tpkg.name,
                                         tpkg.version,
-                                        parent
+                                        raw_parent
                                     );
                                 }
                             }

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -1050,13 +1050,17 @@ impl DependiBackend {
         }
 
         // Build queries for transitive packages not in vulnerability cache.
+        // Cached transitives are tracked separately so we can still attribute their vulns.
         let mut transitive_queries: Vec<VulnerabilityQuery> = Vec::new();
         let mut transitive_query_pkgs: Vec<&crate::parsers::lockfile_graph::LockfilePackage> =
+            Vec::new();
+        let mut transitive_cached_pkgs: Vec<&crate::parsers::lockfile_graph::LockfilePackage> =
             Vec::new();
         for t in transitives.iter() {
             let normalized_version = normalize_version_for_osv(&t.version);
             let vuln_key = VulnCacheKey::new(ecosystem, &t.name, &normalized_version);
             if vuln_cache.contains(&vuln_key) {
+                transitive_cached_pkgs.push(t);
                 continue;
             }
             transitive_queries.push(VulnerabilityQuery {
@@ -1070,11 +1074,6 @@ impl DependiBackend {
         let direct_count = direct_queries.len();
         let mut all_queries = direct_queries;
         all_queries.extend(transitive_queries);
-
-        if all_queries.is_empty() {
-            tracing::debug!("Background: All vulnerability info cached, skipping OSV query");
-            return;
-        }
 
         tracing::info!(
             "Background: Querying OSV.dev for {} packages ({} direct, {} transitive)",
@@ -1192,6 +1191,52 @@ impl DependiBackend {
                                     tpkg.version,
                                     parent
                                 );
+                            }
+                        }
+                    }
+
+                    // Attribute transitive vulns for packages already in vuln_cache.
+                    // Their vuln data lives in version_cache under the ecosystem-prefixed key.
+                    // This ensures re-processing a document never drops transitive attribution
+                    // just because the OSV query was skipped.
+                    for tpkg in &transitive_cached_pkgs {
+                        let cache_key = file_type.cache_key(&tpkg.name);
+                        if let Some(info) = cache.get(&cache_key) {
+                            if info.vulnerabilities.is_empty() {
+                                continue;
+                            }
+                            let parents = inverse.get(&tpkg.name).cloned().unwrap_or_default();
+                            if parents.is_empty() {
+                                for v in &info.vulnerabilities {
+                                    transitive_vulns_by_direct
+                                        .entry_ref("(unknown)")
+                                        .or_default()
+                                        .push(TransitiveVuln {
+                                            package_name: tpkg.name.clone(),
+                                            package_version: tpkg.version.clone(),
+                                            vulnerability: v.clone(),
+                                        });
+                                }
+                            } else {
+                                for parent in &parents {
+                                    for v in &info.vulnerabilities {
+                                        transitive_vulns_by_direct
+                                            .entry_ref(parent.as_str())
+                                            .or_default()
+                                            .push(TransitiveVuln {
+                                                package_name: tpkg.name.clone(),
+                                                package_version: tpkg.version.clone(),
+                                                vulnerability: v.clone(),
+                                            });
+                                    }
+                                    tracing::debug!(
+                                        "Background: Re-attributed (cached) {} transitive vulns from {}@{} to direct dep {}",
+                                        info.vulnerabilities.len(),
+                                        tpkg.name,
+                                        tpkg.version,
+                                        parent
+                                    );
+                                }
                             }
                         }
                     }

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -131,10 +131,14 @@ impl ProcessingContext {
         {
             match crate::parsers::lockfile_graph::read_lockfile_capped(&lock_path).await {
                 Ok(lock_content) => {
-                    let graph = crate::parsers::cargo_lock::parse_cargo_lock_graph(&lock_content);
+                    // Use parse_cargo_lock (HashMap) for resolution: it correctly
+                    // disambiguates multi-version crates via the root package's dep list.
+                    // parse_cargo_lock_graph is kept for the transitive walk below.
+                    let version_map =
+                        crate::parsers::cargo_lock::parse_cargo_lock(&lock_content, None);
                     for dep in &mut dependencies {
-                        if let Some(p) = graph.packages.iter().find(|p| p.name == dep.name) {
-                            dep.resolved_version = Some(p.version.clone());
+                        if let Some(v) = version_map.get(&dep.name) {
+                            dep.resolved_version = Some(v.clone());
                         }
                     }
                     tracing::debug!(
@@ -145,6 +149,7 @@ impl ProcessingContext {
                             .count(),
                         lock_path.display()
                     );
+                    let graph = crate::parsers::cargo_lock::parse_cargo_lock_graph(&lock_content);
                     lockfile_graph = Some(std::sync::Arc::new(graph));
                 }
                 Err(e) => {
@@ -954,30 +959,41 @@ impl DependiBackend {
             })
             .unwrap_or_default();
 
-        // Build queries for direct packages not in vulnerability cache
-        let direct_queries: Vec<VulnerabilityQuery> = dependencies
-            .iter()
-            .filter(|dep| {
-                let normalized_version = normalize_version_for_osv(dep.effective_version());
-                let vuln_key = VulnCacheKey::new(ecosystem, &dep.name, &normalized_version);
-                !vuln_cache.contains(&vuln_key)
-            })
-            .map(|dep| VulnerabilityQuery {
+        // Build queries for direct packages not in vulnerability cache.
+        // Track the filtered subset so we can correlate results back.
+        let mut direct_queries: Vec<VulnerabilityQuery> = Vec::new();
+        let mut direct_query_deps: Vec<&crate::parsers::Dependency> = Vec::new();
+        for dep in dependencies.iter() {
+            let normalized_version = normalize_version_for_osv(dep.effective_version());
+            let vuln_key = VulnCacheKey::new(ecosystem, &dep.name, &normalized_version);
+            if vuln_cache.contains(&vuln_key) {
+                continue;
+            }
+            direct_queries.push(VulnerabilityQuery {
                 ecosystem,
                 package_name: dep.name.clone(),
-                version: normalize_version_for_osv(dep.effective_version()),
-            })
-            .collect();
+                version: normalized_version,
+            });
+            direct_query_deps.push(dep);
+        }
 
-        // Build queries for transitive packages
-        let transitive_queries: Vec<VulnerabilityQuery> = transitives
-            .iter()
-            .map(|t| VulnerabilityQuery {
+        // Build queries for transitive packages not in vulnerability cache.
+        let mut transitive_queries: Vec<VulnerabilityQuery> = Vec::new();
+        let mut transitive_query_pkgs: Vec<&crate::parsers::lockfile_graph::LockfilePackage> =
+            Vec::new();
+        for t in transitives.iter() {
+            let normalized_version = normalize_version_for_osv(&t.version);
+            let vuln_key = VulnCacheKey::new(ecosystem, &t.name, &normalized_version);
+            if vuln_cache.contains(&vuln_key) {
+                continue;
+            }
+            transitive_queries.push(VulnerabilityQuery {
                 ecosystem,
                 package_name: t.name.clone(),
-                version: normalize_version_for_osv(&t.version),
-            })
-            .collect();
+                version: normalized_version,
+            });
+            transitive_query_pkgs.push(t);
+        }
 
         let direct_count = direct_queries.len();
         let mut all_queries = direct_queries;
@@ -992,7 +1008,7 @@ impl DependiBackend {
             "Background: Querying OSV.dev for {} packages ({} direct, {} transitive)",
             all_queries.len(),
             direct_count,
-            transitives.len()
+            transitive_query_pkgs.len()
         );
 
         // Batch query OSV.dev
@@ -1002,35 +1018,34 @@ impl DependiBackend {
 
                 let (direct_results, transitive_results) = results.split_at(direct_count);
 
-                // Update vulnerability cache and version_cache with direct results
-                for (query, result) in all_queries[..direct_count]
-                    .iter()
-                    .zip(direct_results.iter())
-                {
+                // Update vulnerability cache and version_cache with direct results.
+                // direct_query_deps is the filtered list (cached ones were skipped above).
+                for (dep, result) in direct_query_deps.iter().zip(direct_results.iter()) {
+                    let normalized_version = normalize_version_for_osv(dep.effective_version());
                     // Mark this package as queried in vuln_cache
                     let vuln_key =
-                        VulnCacheKey::new(ecosystem, &query.package_name, &query.version);
+                        VulnCacheKey::new(ecosystem, &dep.name, &normalized_version);
                     vuln_cache.insert(vuln_key);
 
                     // Store vulnerabilities and deprecated status in version_cache
                     let cache_key = cache_key_map
-                        .get(&query.package_name)
+                        .get(&dep.name)
                         .cloned()
-                        .unwrap_or_else(|| file_type.cache_key(&query.package_name));
+                        .unwrap_or_else(|| file_type.cache_key(&dep.name));
                     if let Some(mut info) = cache.get(&cache_key) {
                         info.vulnerabilities = result.vulnerabilities.clone();
                         info.deprecated = result.deprecated;
                         if result.deprecated {
                             tracing::info!(
                                 "Background: Package {} {} is deprecated (unmaintained)",
-                                query.package_name,
-                                query.version
+                                dep.name,
+                                normalized_version
                             );
                         }
                         tracing::debug!(
                             "Background: Updated {} {} with {} vulnerabilities, deprecated={}",
-                            query.package_name,
-                            query.version,
+                            dep.name,
+                            normalized_version,
                             result.vulnerabilities.len(),
                             result.deprecated
                         );
@@ -1039,18 +1054,27 @@ impl DependiBackend {
                     } else {
                         tracing::warn!(
                             "Background: Could not update vulnerabilities for {}: not found in version cache",
-                            query.package_name
+                            dep.name
                         );
                     }
                 }
 
-                // Attach transitive vulnerabilities to the first direct parent that reaches them
+                // Attach transitive vulnerabilities to the first direct parent that reaches them.
+                // transitive_query_pkgs is the filtered list (cached ones were skipped above).
                 if let Some(graph) = lockfile_graph.as_deref() {
                     use crate::registries::TransitiveVuln;
 
                     let inverse = graph.reverse_index(&direct_names);
 
-                    for (tpkg, result) in transitives.iter().zip(transitive_results.iter()) {
+                    for (tpkg, result) in
+                        transitive_query_pkgs.iter().zip(transitive_results.iter())
+                    {
+                        // Mark this transitive package as queried in vuln_cache
+                        let normalized_version = normalize_version_for_osv(&tpkg.version);
+                        let vuln_key =
+                            VulnCacheKey::new(ecosystem, &tpkg.name, &normalized_version);
+                        vuln_cache.insert(vuln_key);
+
                         if result.vulnerabilities.is_empty() {
                             continue;
                         }

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -1196,16 +1196,16 @@ impl DependiBackend {
                             VulnCacheKey::new(ecosystem, &tpkg.name, &normalized_version);
                         vuln_cache.insert(vuln_key);
 
-                        // Always store vuln data (even empty) so the cached-attribution loop
-                        // below can find a transitive_vuln_data entry for every vuln_cache hit.
                         let vuln_data_key = VulnCacheKey::new(
                             ecosystem,
                             &tpkg.name,
                             &normalize_version_for_osv(&tpkg.version),
                         );
-                        bg_ctx
-                            .transitive_vuln_data
-                            .insert(vuln_data_key, result.vulnerabilities.clone());
+                        if !result.vulnerabilities.is_empty() {
+                            bg_ctx
+                                .transitive_vuln_data
+                                .insert(vuln_data_key, result.vulnerabilities.clone());
+                        }
 
                         if result.vulnerabilities.is_empty() {
                             continue;
@@ -1266,9 +1266,7 @@ impl DependiBackend {
                             VulnCacheKey::new(ecosystem, &tpkg.name, &normalized_version);
                         if let Some(vulns) = bg_ctx.transitive_vuln_data.get(&vuln_data_key) {
                             let vulns: Vec<_> = vulns.clone();
-                            if vulns.is_empty() {
-                                continue;
-                            }
+                            // No else: absence means no vulns, nothing to do.
                             let parents = inverse.get(&tpkg.name).cloned().unwrap_or_default();
                             if parents.is_empty() {
                                 for v in &vulns {

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -118,6 +118,9 @@ impl ProcessingContext {
 
         let mut dependencies = self.parse_document(uri, content);
 
+        // lockfile_graph is populated by the ecosystem-specific blocks below.
+        let mut lockfile_graph: Option<std::sync::Arc<crate::parsers::lockfile_graph::LockfileGraph>> = None;
+
         // Resolve versions from Cargo.lock for Cargo dependencies
         if file_type == FileType::Cargo
             && let Ok(cargo_toml_path) = uri.to_file_path()
@@ -126,24 +129,10 @@ impl ProcessingContext {
         {
             match tokio::fs::read_to_string(&lock_path).await {
                 Ok(lock_content) => {
-                    let root_package = match toml::from_str::<toml::Value>(content) {
-                        Ok(v) => v
-                            .get("package")
-                            .and_then(|p| p.get("name"))
-                            .and_then(|n| n.as_str())
-                            .map(String::from),
-                        Err(e) => {
-                            tracing::debug!("Could not parse Cargo.toml for package name: {e}");
-                            None
-                        }
-                    };
-                    let lock_versions = crate::parsers::cargo_lock::parse_cargo_lock(
-                        &lock_content,
-                        root_package.as_deref(),
-                    );
+                    let graph = crate::parsers::cargo_lock::parse_cargo_lock_graph(&lock_content);
                     for dep in &mut dependencies {
-                        if let Some(resolved) = lock_versions.get(&dep.name) {
-                            dep.resolved_version = Some(resolved.clone());
+                        if let Some(p) = graph.packages.iter().find(|p| p.name == dep.name) {
+                            dep.resolved_version = Some(p.version.clone());
                         }
                     }
                     tracing::debug!(
@@ -154,6 +143,7 @@ impl ProcessingContext {
                             .count(),
                         lock_path.display()
                     );
+                    lockfile_graph = Some(std::sync::Arc::new(graph));
                 }
                 Err(e) => {
                     tracing::debug!(
@@ -168,16 +158,46 @@ impl ProcessingContext {
         // Resolve versions from lockfile for npm dependencies
         if file_type == FileType::Npm
             && let Ok(package_json_path) = uri.to_file_path()
-            && let Some((lock_path, lockfile_type)) =
+            && let Some((lock_path, npm_lockfile_type)) =
                 crate::parsers::npm_lock::find_npm_lockfile(&package_json_path).await
         {
             match tokio::fs::read_to_string(&lock_path).await {
                 Ok(lock_content) => {
-                    let lock_versions =
-                        crate::parsers::npm_lock::parse_npm_lockfile(&lock_content, lockfile_type);
+                    use crate::parsers::npm_lock::NpmLockfileType;
+                    let graph = match npm_lockfile_type {
+                        NpmLockfileType::PackageLock => {
+                            crate::parsers::npm_lock::parse_package_lock_graph(&lock_content)
+                        }
+                        NpmLockfileType::PnpmLock => {
+                            crate::parsers::npm_lock::parse_pnpm_lock_graph(&lock_content)
+                        }
+                        NpmLockfileType::YarnLock => {
+                            crate::parsers::npm_lock::parse_yarn_lock_graph(&lock_content)
+                        }
+                        NpmLockfileType::BunLock => {
+                            // No graph parser for Bun — fall back to HashMap path
+                            let lock_versions = crate::parsers::npm_lock::parse_npm_lockfile(
+                                &lock_content,
+                                npm_lockfile_type,
+                            );
+                            crate::parsers::lockfile_graph::LockfileGraph {
+                                packages: lock_versions
+                                    .iter()
+                                    .map(|(name, version)| {
+                                        crate::parsers::lockfile_graph::LockfilePackage {
+                                            name: name.clone(),
+                                            version: version.clone(),
+                                            dependencies: Vec::new(),
+                                            is_root: false,
+                                        }
+                                    })
+                                    .collect(),
+                            }
+                        }
+                    };
                     for dep in &mut dependencies {
-                        if let Some(resolved) = lock_versions.get(&dep.name) {
-                            dep.resolved_version = Some(resolved.clone());
+                        if let Some(p) = graph.packages.iter().find(|p| p.name == dep.name) {
+                            dep.resolved_version = Some(p.version.clone());
                         }
                     }
                     tracing::debug!(
@@ -187,8 +207,9 @@ impl ProcessingContext {
                             .filter(|d| d.resolved_version.is_some())
                             .count(),
                         lock_path.display(),
-                        lockfile_type,
+                        npm_lockfile_type,
                     );
+                    lockfile_graph = Some(std::sync::Arc::new(graph));
                 }
                 Err(e) => {
                     tracing::debug!("Could not read lockfile at {}: {}", lock_path.display(), e);
@@ -201,20 +222,50 @@ impl ProcessingContext {
             && let Ok(manifest_path) = uri.to_file_path()
         {
             let preferred = crate::parsers::python_lock::detect_python_tool(content);
-            if let Some((lock_path, lockfile_type)) =
+            if let Some((lock_path, py_lockfile_type)) =
                 crate::parsers::python_lock::find_python_lockfile(&manifest_path, preferred).await
             {
                 match tokio::fs::read_to_string(&lock_path).await {
                     Ok(lock_content) => {
-                        let lock_versions = crate::parsers::python_lock::parse_python_lockfile(
-                            &lock_content,
-                            lockfile_type,
-                        );
+                        use crate::parsers::python_lock::PythonLockfileType;
+                        let graph = match py_lockfile_type {
+                            PythonLockfileType::PoetryLock => {
+                                crate::parsers::python_lock::parse_poetry_lock_graph(&lock_content)
+                            }
+                            PythonLockfileType::UvLock => {
+                                crate::parsers::python_lock::parse_uv_lock_graph(&lock_content)
+                            }
+                            PythonLockfileType::PipfileLock => {
+                                crate::parsers::python_lock::parse_pipfile_lock_graph(&lock_content)
+                            }
+                            PythonLockfileType::PdmLock => {
+                                // No graph parser for PDM — build minimal graph from HashMap
+                                let lock_versions = crate::parsers::python_lock::parse_python_lockfile(
+                                    &lock_content,
+                                    py_lockfile_type,
+                                );
+                                crate::parsers::lockfile_graph::LockfileGraph {
+                                    packages: lock_versions
+                                        .iter()
+                                        .map(|(name, version)| {
+                                            crate::parsers::lockfile_graph::LockfilePackage {
+                                                name: name.clone(),
+                                                version: version.clone(),
+                                                dependencies: Vec::new(),
+                                                is_root: false,
+                                            }
+                                        })
+                                        .collect(),
+                                }
+                            }
+                        };
                         for dep in &mut dependencies {
                             let normalized =
                                 crate::parsers::python_lock::normalize_python_name(&dep.name);
-                            if let Some(resolved) = lock_versions.get(&normalized) {
-                                dep.resolved_version = Some(resolved.clone());
+                            if let Some(p) =
+                                graph.packages.iter().find(|p| p.name == normalized)
+                            {
+                                dep.resolved_version = Some(p.version.clone());
                             }
                         }
                         tracing::debug!(
@@ -224,8 +275,9 @@ impl ProcessingContext {
                                 .filter(|d| d.resolved_version.is_some())
                                 .count(),
                             lock_path.display(),
-                            lockfile_type,
+                            py_lockfile_type,
                         );
+                        lockfile_graph = Some(std::sync::Arc::new(graph));
                     }
                     Err(e) => {
                         tracing::debug!(
@@ -246,6 +298,7 @@ impl ProcessingContext {
             match tokio::fs::read_to_string(&lock_path).await {
                 Ok(lock_content) => {
                     let lock_versions = crate::parsers::go_sum::parse_go_sum(&lock_content);
+                    let mut minimal_packages = Vec::new();
                     for dep in &mut dependencies {
                         if let Some(versions) = lock_versions.get(&dep.name) {
                             // Prefer dep.version when it appears among the
@@ -260,6 +313,17 @@ impl ProcessingContext {
                             }
                         }
                     }
+                    // Build minimal graph (no edge data available from go.sum)
+                    for (name, versions) in &lock_versions {
+                        for version in versions {
+                            minimal_packages.push(crate::parsers::lockfile_graph::LockfilePackage {
+                                name: name.clone(),
+                                version: version.clone(),
+                                dependencies: Vec::new(),
+                                is_root: false,
+                            });
+                        }
+                    }
                     tracing::debug!(
                         "Resolved {} versions from {}",
                         dependencies
@@ -268,6 +332,11 @@ impl ProcessingContext {
                             .count(),
                         lock_path.display()
                     );
+                    lockfile_graph = Some(std::sync::Arc::new(
+                        crate::parsers::lockfile_graph::LockfileGraph {
+                            packages: minimal_packages,
+                        },
+                    ));
                 }
                 Err(e) => {
                     tracing::debug!("Could not read go.sum at {}: {}", lock_path.display(), e);
@@ -283,13 +352,13 @@ impl ProcessingContext {
         {
             match tokio::fs::read_to_string(&lock_path).await {
                 Ok(lock_content) => {
-                    let lock_versions =
-                        crate::parsers::composer_lock::parse_composer_lock(&lock_content);
+                    let graph =
+                        crate::parsers::composer_lock::parse_composer_lock_graph(&lock_content);
                     for dep in &mut dependencies {
                         let normalized =
                             crate::parsers::composer_lock::normalize_composer_name(&dep.name);
-                        if let Some(resolved) = lock_versions.get(&normalized) {
-                            dep.resolved_version = Some(resolved.clone());
+                        if let Some(p) = graph.packages.iter().find(|p| p.name == normalized) {
+                            dep.resolved_version = Some(p.version.clone());
                         }
                     }
                     tracing::debug!(
@@ -300,6 +369,7 @@ impl ProcessingContext {
                             .count(),
                         lock_path.display()
                     );
+                    lockfile_graph = Some(std::sync::Arc::new(graph));
                 }
                 Err(e) => {
                     tracing::debug!(
@@ -334,6 +404,22 @@ impl ProcessingContext {
                             .count(),
                         lock_path.display()
                     );
+                    // No graph parser for Dart — build minimal graph from HashMap
+                    lockfile_graph = Some(std::sync::Arc::new(
+                        crate::parsers::lockfile_graph::LockfileGraph {
+                            packages: lock_versions
+                                .into_iter()
+                                .map(|(name, version)| {
+                                    crate::parsers::lockfile_graph::LockfilePackage {
+                                        name,
+                                        version,
+                                        dependencies: Vec::new(),
+                                        is_root: false,
+                                    }
+                                })
+                                .collect(),
+                        },
+                    ));
                 }
                 Err(e) => {
                     tracing::debug!(
@@ -369,6 +455,22 @@ impl ProcessingContext {
                             .count(),
                         lock_path.display()
                     );
+                    // No graph parser for C# — build minimal graph from HashMap
+                    lockfile_graph = Some(std::sync::Arc::new(
+                        crate::parsers::lockfile_graph::LockfileGraph {
+                            packages: lock_versions
+                                .into_iter()
+                                .map(|(name, version)| {
+                                    crate::parsers::lockfile_graph::LockfilePackage {
+                                        name,
+                                        version,
+                                        dependencies: Vec::new(),
+                                        is_root: false,
+                                    }
+                                })
+                                .collect(),
+                        },
+                    ));
                 }
                 Err(e) => {
                     tracing::debug!(
@@ -387,13 +489,13 @@ impl ProcessingContext {
         {
             match tokio::fs::read_to_string(&lock_path).await {
                 Ok(lock_content) => {
-                    let lock_versions =
-                        crate::parsers::gemfile_lock::parse_gemfile_lock(&lock_content);
+                    let graph =
+                        crate::parsers::gemfile_lock::parse_gemfile_lock_graph(&lock_content);
                     for dep in &mut dependencies {
                         let normalized =
                             crate::parsers::gemfile_lock::normalize_gem_name(&dep.name);
-                        if let Some(resolved) = lock_versions.get(&normalized) {
-                            dep.resolved_version = Some(resolved.clone());
+                        if let Some(p) = graph.packages.iter().find(|p| p.name == normalized) {
+                            dep.resolved_version = Some(p.version.clone());
                         }
                     }
                     tracing::debug!(
@@ -404,6 +506,7 @@ impl ProcessingContext {
                             .count(),
                         lock_path.display()
                     );
+                    lockfile_graph = Some(std::sync::Arc::new(graph));
                 }
                 Err(e) => {
                     tracing::debug!(
@@ -522,6 +625,7 @@ impl ProcessingContext {
             DocumentState {
                 dependencies: dependencies.clone(),
                 file_type,
+                lockfile_graph: lockfile_graph.clone(),
             },
         );
 
@@ -585,6 +689,7 @@ impl ProcessingContext {
             let osv_client_clone = Arc::clone(&self.osv_client);
             let vuln_cache_clone = Arc::clone(&self.vuln_cache);
             let client_clone = self.client.clone();
+            let lockfile_graph_clone = lockfile_graph.clone();
 
             tokio::spawn(async move {
                 DependiBackend::fetch_vulnerabilities_background(
@@ -594,6 +699,7 @@ impl ProcessingContext {
                     osv_client_clone,
                     vuln_cache_clone,
                     client_clone,
+                    lockfile_graph_clone,
                 )
                 .await;
             });
@@ -821,6 +927,7 @@ impl DependiBackend {
         osv_client: Arc<OsvClient>,
         vuln_cache: Arc<VulnerabilityCache>,
         client: Client,
+        lockfile_graph: Option<std::sync::Arc<crate::parsers::lockfile_graph::LockfileGraph>>,
     ) {
         use crate::vulnerabilities::cache::VulnCacheKey;
 
@@ -832,8 +939,15 @@ impl DependiBackend {
             .map(|dep| (dep.name.clone(), dep_cache_key(dep, file_type)))
             .collect();
 
-        // Build queries for packages not in vulnerability cache
-        let queries: Vec<VulnerabilityQuery> = dependencies
+        // Collect transitive packages from the lockfile graph
+        let direct_names: Vec<String> = dependencies.iter().map(|d| d.name.clone()).collect();
+        let transitives: Vec<crate::parsers::lockfile_graph::LockfilePackage> = lockfile_graph
+            .as_deref()
+            .map(|g| g.transitives_only(&direct_names).into_iter().cloned().collect())
+            .unwrap_or_default();
+
+        // Build queries for direct packages not in vulnerability cache
+        let direct_queries: Vec<VulnerabilityQuery> = dependencies
             .iter()
             .filter(|dep| {
                 let normalized_version = normalize_version_for_osv(dep.effective_version());
@@ -847,23 +961,41 @@ impl DependiBackend {
             })
             .collect();
 
-        if queries.is_empty() {
+        // Build queries for transitive packages
+        let transitive_queries: Vec<VulnerabilityQuery> = transitives
+            .iter()
+            .map(|t| VulnerabilityQuery {
+                ecosystem,
+                package_name: t.name.clone(),
+                version: normalize_version_for_osv(&t.version),
+            })
+            .collect();
+
+        let direct_count = direct_queries.len();
+        let mut all_queries = direct_queries;
+        all_queries.extend(transitive_queries);
+
+        if all_queries.is_empty() {
             tracing::debug!("Background: All vulnerability info cached, skipping OSV query");
             return;
         }
 
         tracing::info!(
-            "Background: Querying OSV.dev for {} packages",
-            queries.len()
+            "Background: Querying OSV.dev for {} packages ({} direct, {} transitive)",
+            all_queries.len(),
+            direct_count,
+            transitives.len()
         );
 
         // Batch query OSV.dev
-        match osv_client.query_batch(&queries).await {
+        match osv_client.query_batch(&all_queries).await {
             Ok(results) => {
                 let mut updated_count = 0;
 
-                // Update vulnerability cache and version_cache with results
-                for (query, result) in queries.iter().zip(results.iter()) {
+                let (direct_results, transitive_results) = results.split_at(direct_count);
+
+                // Update vulnerability cache and version_cache with direct results
+                for (query, result) in all_queries[..direct_count].iter().zip(direct_results.iter()) {
                     // Mark this package as queried in vuln_cache
                     let vuln_key =
                         VulnCacheKey::new(ecosystem, &query.package_name, &query.version);
@@ -900,6 +1032,59 @@ impl DependiBackend {
                         );
                     }
                 }
+
+                // Attach transitive vulnerabilities to the first direct parent that reaches them
+                if let Some(graph) = lockfile_graph.as_deref() {
+                    use crate::registries::TransitiveVuln;
+
+                    for (tpkg, result) in transitives.iter().zip(transitive_results.iter()) {
+                        if result.vulnerabilities.is_empty() {
+                            continue;
+                        }
+                        // Find the first direct dep that transitively reaches this package
+                        for dep in &dependencies {
+                            let reaches = graph
+                                .transitive_deps_of(&dep.name)
+                                .iter()
+                                .any(|p| p.name == tpkg.name);
+                            if !reaches {
+                                continue;
+                            }
+
+                            let cache_key = cache_key_map
+                                .get(&dep.name)
+                                .cloned()
+                                .unwrap_or_else(|| file_type.cache_key(&dep.name));
+                            if let Some(mut info) = cache.get(&cache_key) {
+                                for v in &result.vulnerabilities {
+                                    let new_tv = TransitiveVuln {
+                                        package_name: tpkg.name.clone(),
+                                        package_version: tpkg.version.clone(),
+                                        vulnerability: v.clone(),
+                                    };
+                                    if !info.transitive_vulnerabilities.iter().any(|existing| {
+                                        existing.package_name == new_tv.package_name
+                                            && existing.package_version == new_tv.package_version
+                                            && existing.vulnerability.id == new_tv.vulnerability.id
+                                    }) {
+                                        info.transitive_vulnerabilities.push(new_tv);
+                                    }
+                                }
+                                tracing::debug!(
+                                    "Background: Attached {} transitive vulns from {}@{} to direct dep {}",
+                                    result.vulnerabilities.len(),
+                                    tpkg.name,
+                                    tpkg.version,
+                                    dep.name
+                                );
+                                cache.insert(cache_key, info);
+                            }
+                            // Attach to first matching direct parent only (npm audit style)
+                            break;
+                        }
+                    }
+                }
+
                 tracing::info!(
                     "Background: Cached vulnerability info for {} packages",
                     updated_count
@@ -1107,6 +1292,22 @@ fn format_hover_content(
                     writeln!(f, "\n#### {id} - {severity_icon} {severity_str}")?;
                 }
                 f.write_str(&vuln.description)?;
+            }
+        }
+
+        // Add transitive vulnerability information if present
+        if !info.transitive_vulnerabilities.is_empty() {
+            writeln!(f, "\n## Transitive vulnerabilities")?;
+            for t in &info.transitive_vulnerabilities {
+                let link = match &t.vulnerability.url {
+                    Some(u) => format!("[{}]({u})", t.vulnerability.id),
+                    None => t.vulnerability.id.clone(),
+                };
+                let sev = t.vulnerability.severity.as_str();
+                let name = &t.package_name;
+                let ver = &t.package_version;
+                let desc = &t.vulnerability.description;
+                writeln!(f, "- {link} **{sev}** — {name}@{ver}: {desc}")?;
             }
         }
 
@@ -1706,6 +1907,40 @@ mod tests {
         assert!(
             content.contains("2025-01-15") || content.contains("ago"),
             "Release date should be found via effective_version lookup, got:\n{content}"
+        );
+    }
+
+    #[test]
+    fn test_hover_lists_transitive_vulnerabilities() {
+        use crate::registries::{TransitiveVuln, Vulnerability, VulnerabilitySeverity};
+
+        let dep = make_dep("react", "^18.0", Some("18.2.0"));
+        let info = VersionInfo {
+            latest: Some("18.2.0".to_string()),
+            transitive_vulnerabilities: vec![TransitiveVuln {
+                package_name: "scheduler".to_string(),
+                package_version: "1.2.3".to_string(),
+                vulnerability: Vulnerability {
+                    id: "CVE-1".to_string(),
+                    severity: VulnerabilitySeverity::High,
+                    description: "desc".to_string(),
+                    url: None,
+                },
+            }],
+            ..Default::default()
+        };
+        let content = format_hover_content(&dep, FileType::Npm, &info);
+        assert!(
+            content.contains("Transitive vulnerabilities"),
+            "Hover should contain transitive section, got:\n{content}"
+        );
+        assert!(
+            content.contains("scheduler@1.2.3"),
+            "Hover should contain transitive package, got:\n{content}"
+        );
+        assert!(
+            content.contains("CVE-1"),
+            "Hover should contain transitive vuln id, got:\n{content}"
         );
     }
 }

--- a/dependi-lsp/src/cache/mod.rs
+++ b/dependi-lsp/src/cache/mod.rs
@@ -362,6 +362,7 @@ mod tests {
             yanked: false,
             yanked_versions: vec![],
             release_dates: Default::default(),
+            transitive_vulnerabilities: vec![],
         }
     }
 

--- a/dependi-lsp/src/cache/sqlite.rs
+++ b/dependi-lsp/src/cache/sqlite.rs
@@ -345,6 +345,7 @@ mod tests {
             yanked: false,
             yanked_versions: vec![],
             release_dates: Default::default(),
+            transitive_vulnerabilities: vec![],
         }
     }
 

--- a/dependi-lsp/src/document.rs
+++ b/dependi-lsp/src/document.rs
@@ -15,4 +15,7 @@ pub struct DocumentState {
     pub dependencies: Vec<Dependency>,
     /// The detected file type (determines which parser/registry to use).
     pub file_type: FileType,
+    /// Full dependency graph from the lockfile, if one was found.
+    /// Used to enumerate transitive dependencies for vulnerability scanning.
+    pub lockfile_graph: Option<std::sync::Arc<crate::parsers::lockfile_graph::LockfileGraph>>,
 }

--- a/dependi-lsp/src/document.rs
+++ b/dependi-lsp/src/document.rs
@@ -18,4 +18,9 @@ pub struct DocumentState {
     /// Full dependency graph from the lockfile, if one was found.
     /// Used to enumerate transitive dependencies for vulnerability scanning.
     pub lockfile_graph: Option<std::sync::Arc<crate::parsers::lockfile_graph::LockfileGraph>>,
+    /// Per-document transitive vulnerability attribution. Keyed by the DIRECT
+    /// dependency name in the current manifest. Not shared with other documents
+    /// because the attribution depends on this document's lockfile graph.
+    pub transitive_vulns_by_direct:
+        hashbrown::HashMap<String, Vec<crate::registries::TransitiveVuln>>,
 }

--- a/dependi-lsp/src/main.rs
+++ b/dependi-lsp/src/main.rs
@@ -188,6 +188,7 @@ async fn run_scan(
         dart::DartParser, gemfile_lock, go::GoParser, lockfile_graph::LockfileGraph,
         lockfile_graph::LockfilePackage, lockfile_graph::read_lockfile_capped, maven::MavenParser,
         npm::NpmParser, npm_lock, php::PhpParser, python::PythonParser, python_lock,
+        ruby::RubyParser,
     };
     use dependi_lsp::registries::VulnerabilitySeverity;
     use dependi_lsp::vulnerabilities::{
@@ -239,6 +240,8 @@ async fn run_scan(
         (DartParser::new().parse(&content), Ecosystem::Pub)
     } else if file_name.ends_with(".csproj") {
         (CsharpParser::new().parse(&content), Ecosystem::NuGet)
+    } else if file_name == "Gemfile" {
+        (RubyParser::new().parse(&content), Ecosystem::RubyGems)
     } else if file_name == "pom.xml" {
         (MavenParser::new().parse(&content), Ecosystem::Maven)
     } else {

--- a/dependi-lsp/src/main.rs
+++ b/dependi-lsp/src/main.rs
@@ -214,8 +214,17 @@ async fn run_scan(
         }
     }
 
-    // Read file (using async I/O)
-    let content = match tokio::fs::read_to_string(&file).await {
+    fn cargo_root_package_name(manifest_content: &str) -> Option<String> {
+        let value: toml::Value = toml::from_str(manifest_content).ok()?;
+        value
+            .get("package")?
+            .get("name")?
+            .as_str()
+            .map(|s| s.to_string())
+    }
+
+    // Read file (capped at 50 MiB to prevent hostile large inputs)
+    let content = match read_lockfile_capped(&file).await {
         Ok(c) => c,
         Err(e) => {
             eprintln!("Error reading file: {e}");
@@ -325,8 +334,9 @@ async fn run_scan(
     // Populate resolved_version on direct deps.
     // For Cargo, use parse_cargo_lock (HashMap) which correctly disambiguates multi-version
     // crates via the root package's dep list.  For other ecosystems, derive from the graph.
-    let version_map: HashMap<String, String> = if let Some(ref content) = cargo_lock_content {
-        cargo_lock::parse_cargo_lock(content, None)
+    let version_map: HashMap<String, String> = if let Some(ref lock_content) = cargo_lock_content {
+        let root_name = cargo_root_package_name(&content);
+        cargo_lock::parse_cargo_lock(lock_content, root_name.as_deref())
     } else {
         lockfile_graph
             .packages
@@ -573,10 +583,11 @@ async fn run_scan(
 async fn run_profile_parse(file: PathBuf, iterations: u32) -> ExitCode {
     use dependi_lsp::parsers::{
         Parser, cargo::CargoParser, csharp::CsharpParser, dart::DartParser, go::GoParser,
-        maven::MavenParser, npm::NpmParser, php::PhpParser, python::PythonParser, ruby::RubyParser,
+        lockfile_graph::read_lockfile_capped, maven::MavenParser, npm::NpmParser, php::PhpParser,
+        python::PythonParser, ruby::RubyParser,
     };
 
-    let content = match tokio::fs::read_to_string(&file).await {
+    let content = match read_lockfile_capped(&file).await {
         Ok(c) => c,
         Err(e) => {
             eprintln!("Error reading file: {e}");
@@ -776,7 +787,8 @@ async fn run_profile_full(file: PathBuf, iterations: u32, verbose: bool) -> Exit
     use dependi_lsp::config::NpmRegistryConfig;
     use dependi_lsp::parsers::{
         Parser, cargo::CargoParser, csharp::CsharpParser, dart::DartParser, go::GoParser,
-        maven::MavenParser, npm::NpmParser, php::PhpParser, python::PythonParser, ruby::RubyParser,
+        lockfile_graph::read_lockfile_capped, maven::MavenParser, npm::NpmParser, php::PhpParser,
+        python::PythonParser, ruby::RubyParser,
     };
     use dependi_lsp::registries::{
         Registry, crates_io::CratesIoRegistry, go_proxy::GoProxyRegistry,
@@ -787,7 +799,7 @@ async fn run_profile_full(file: PathBuf, iterations: u32, verbose: bool) -> Exit
     use dependi_lsp::vulnerabilities::{Ecosystem, VulnerabilityQuery, osv::OsvClient};
     use futures::future::join_all;
 
-    let content = match tokio::fs::read_to_string(&file).await {
+    let content = match read_lockfile_capped(&file).await {
         Ok(c) => c,
         Err(e) => {
             eprintln!("Error reading file: {e}");

--- a/dependi-lsp/src/main.rs
+++ b/dependi-lsp/src/main.rs
@@ -50,6 +50,10 @@ enum Commands {
         /// Exit with code 1 if vulnerabilities are found
         #[arg(long, default_value = "true")]
         fail_on_vulns: bool,
+
+        /// Enable lockfile-based scanning. Default on. Use `--no-use-lockfile` to disable.
+        #[arg(long = "use-lockfile", default_value_t = true, action = clap::ArgAction::Set)]
+        use_lockfile: bool,
     },
     /// Profile dependency file parsing (for use with cargo-flamegraph)
     ProfileParse {
@@ -115,7 +119,8 @@ async fn main() -> ExitCode {
             output,
             min_severity,
             fail_on_vulns,
-        }) => run_scan(file, output, min_severity, fail_on_vulns).await,
+            use_lockfile,
+        }) => run_scan(file, output, min_severity, fail_on_vulns, use_lockfile).await,
         Some(Commands::ProfileParse { file, iterations }) => {
             run_profile_parse(file, iterations).await
         }
@@ -152,13 +157,35 @@ async fn run_scan(
     output: String,
     min_severity: String,
     fail_on_vulns: bool,
+    use_lockfile: bool,
 ) -> ExitCode {
     use dependi_lsp::parsers::{
-        Parser, cargo::CargoParser, csharp::CsharpParser, dart::DartParser, go::GoParser,
-        maven::MavenParser, npm::NpmParser, php::PhpParser, python::PythonParser,
+        Parser, cargo::CargoParser, cargo_lock, composer_lock, csharp::CsharpParser,
+        dart::DartParser, gemfile_lock, go::GoParser, lockfile_graph::LockfileGraph,
+        lockfile_graph::LockfilePackage, maven::MavenParser, npm::NpmParser, npm_lock,
+        php::PhpParser, python::PythonParser, python_lock,
     };
     use dependi_lsp::registries::VulnerabilitySeverity;
-    use dependi_lsp::vulnerabilities::{Ecosystem, VulnerabilityQuery, osv::OsvClient};
+    use dependi_lsp::vulnerabilities::{Ecosystem, VulnerabilityQuery, normalize_version_for_osv, osv::OsvClient};
+    use hashbrown::{HashMap, HashSet};
+
+    fn inc_sev(
+        sev: dependi_lsp::registries::VulnerabilitySeverity,
+        total: &mut u32,
+        crit: &mut u32,
+        high: &mut u32,
+        med: &mut u32,
+        low: &mut u32,
+    ) {
+        use dependi_lsp::registries::VulnerabilitySeverity;
+        *total += 1;
+        match sev {
+            VulnerabilitySeverity::Critical => *crit += 1,
+            VulnerabilitySeverity::High => *high += 1,
+            VulnerabilitySeverity::Medium => *med += 1,
+            VulnerabilitySeverity::Low => *low += 1,
+        }
+    }
 
     // Read file (using async I/O)
     let content = match tokio::fs::read_to_string(&file).await {
@@ -198,24 +225,130 @@ async fn run_scan(
         return ExitCode::SUCCESS;
     }
 
-    eprintln!(
-        "Scanning {} dependencies in {}...",
-        dependencies.len(),
-        file.display()
-    );
+    // Detect lockfile and build graph
+    let mut lockfile_graph = LockfileGraph::default();
+    if use_lockfile {
+        match ecosystem {
+            Ecosystem::CratesIo => {
+                if let Some(path) = cargo_lock::find_cargo_lock(&file).await
+                    && let Ok(lock_content) = tokio::fs::read_to_string(&path).await
+                {
+                    lockfile_graph = cargo_lock::parse_cargo_lock_graph(&lock_content);
+                }
+            }
+            Ecosystem::Npm => {
+                if let Some((path, kind)) = npm_lock::find_npm_lockfile(&file).await
+                    && let Ok(lock_content) = tokio::fs::read_to_string(&path).await
+                {
+                    lockfile_graph = match kind {
+                        npm_lock::NpmLockfileType::PackageLock => {
+                            npm_lock::parse_package_lock_graph(&lock_content)
+                        }
+                        npm_lock::NpmLockfileType::YarnLock => {
+                            npm_lock::parse_yarn_lock_graph(&lock_content)
+                        }
+                        npm_lock::NpmLockfileType::PnpmLock => {
+                            npm_lock::parse_pnpm_lock_graph(&lock_content)
+                        }
+                        npm_lock::NpmLockfileType::BunLock => LockfileGraph::default(),
+                    };
+                }
+            }
+            Ecosystem::PyPI => {
+                if let Some((path, kind)) = python_lock::find_python_lockfile(&file, None).await
+                    && let Ok(lock_content) = tokio::fs::read_to_string(&path).await
+                {
+                    lockfile_graph = match kind {
+                        python_lock::PythonLockfileType::PoetryLock => {
+                            python_lock::parse_poetry_lock_graph(&lock_content)
+                        }
+                        python_lock::PythonLockfileType::UvLock => {
+                            python_lock::parse_uv_lock_graph(&lock_content)
+                        }
+                        python_lock::PythonLockfileType::PipfileLock => {
+                            python_lock::parse_pipfile_lock_graph(&lock_content)
+                        }
+                        python_lock::PythonLockfileType::PdmLock => LockfileGraph::default(),
+                    };
+                }
+            }
+            Ecosystem::Packagist => {
+                if let Some(path) = composer_lock::find_composer_lock(&file).await
+                    && let Ok(lock_content) = tokio::fs::read_to_string(&path).await
+                {
+                    lockfile_graph = composer_lock::parse_composer_lock_graph(&lock_content);
+                }
+            }
+            Ecosystem::RubyGems => {
+                if let Some(path) = gemfile_lock::find_gemfile_lock(&file).await
+                    && let Ok(lock_content) = tokio::fs::read_to_string(&path).await
+                {
+                    lockfile_graph = gemfile_lock::parse_gemfile_lock_graph(&lock_content);
+                }
+            }
+            _ => {} // Go/Pub/NuGet/Maven — no graph parser in this PR
+        }
+    }
 
-    // Build vulnerability queries
-    let queries: Vec<VulnerabilityQuery> = dependencies
+    // Populate resolved_version on direct deps from the graph
+    let version_map: HashMap<String, String> = lockfile_graph
+        .packages
+        .iter()
+        .map(|p| (p.name.clone(), p.version.clone()))
+        .collect();
+
+    let mut dependencies = dependencies;
+    for dep in dependencies.iter_mut() {
+        if let Some(v) = version_map.get(&dep.name) {
+            dep.resolved_version = Some(v.clone());
+        }
+    }
+
+    // Flag graph's root packages (matching manifest deps)
+    let direct_names: HashSet<String> = dependencies.iter().map(|d| d.name.clone()).collect();
+    for pkg in lockfile_graph.packages.iter_mut() {
+        if direct_names.contains(&pkg.name) {
+            pkg.is_root = true;
+        }
+    }
+
+    // Extract transitives (packages in the lockfile but not in the manifest)
+    let direct_names_vec: Vec<String> = dependencies.iter().map(|d| d.name.clone()).collect();
+    let transitives: Vec<LockfilePackage> = lockfile_graph
+        .transitives_only(&direct_names_vec)
+        .into_iter()
+        .cloned()
+        .collect();
+
+    // Build queries: direct first, then transitive. Remember the split index.
+    let mut queries: Vec<VulnerabilityQuery> = dependencies
         .iter()
         .map(|dep| VulnerabilityQuery {
             ecosystem,
             package_name: dep.name.clone(),
-            version: dep.version.clone(),
+            version: normalize_version_for_osv(dep.effective_version()),
         })
         .collect();
+    let direct_count = queries.len();
+    for t in &transitives {
+        queries.push(VulnerabilityQuery {
+            ecosystem,
+            package_name: t.name.clone(),
+            version: normalize_version_for_osv(&t.version),
+        });
+    }
 
-    // Query OSV.dev
-    let osv_client = OsvClient::default();
+    eprintln!(
+        "Scanning {direct_count} direct + {} transitive dependencies in {}...",
+        transitives.len(),
+        file.display()
+    );
+
+    // Allow tests to inject a custom OSV endpoint
+    let osv_client = match std::env::var("OSV_ENDPOINT") {
+        Ok(url) => OsvClient::with_endpoint(url),
+        Err(_) => OsvClient::default(),
+    };
     let results = match osv_client.query_batch(&queries).await {
         Ok(r) => r,
         Err(e) => {
@@ -224,42 +357,85 @@ async fn run_scan(
         }
     };
 
+    let (direct_results, transitive_results) = results.split_at(direct_count);
+
     // Parse minimum severity using shared method
     let min_sev = VulnerabilitySeverity::from_str_loose(&min_severity);
 
-    // Filter and collect vulnerabilities
-    let mut total_vulns = 0;
-    let mut critical_count = 0;
-    let mut high_count = 0;
-    let mut medium_count = 0;
-    let mut low_count = 0;
-    let mut vuln_details: Vec<serde_json::Value> = Vec::new();
+    let mut total_vulns = 0u32;
+    let mut critical_count = 0u32;
+    let mut high_count = 0u32;
+    let mut medium_count = 0u32;
+    let mut low_count = 0u32;
+    let mut direct_details: Vec<serde_json::Value> = Vec::new();
+    let mut transitive_details: Vec<serde_json::Value> = Vec::new();
 
-    for (dep, result) in dependencies.iter().zip(results.iter()) {
+    for (dep, result) in dependencies.iter().zip(direct_results.iter()) {
         for vuln in &result.vulnerabilities {
-            // Filter by severity using shared method
             if !vuln.severity.meets_threshold(&min_sev) {
                 continue;
             }
-
-            total_vulns += 1;
-            match vuln.severity {
-                VulnerabilitySeverity::Critical => critical_count += 1,
-                VulnerabilitySeverity::High => high_count += 1,
-                VulnerabilitySeverity::Medium => medium_count += 1,
-                VulnerabilitySeverity::Low => low_count += 1,
-            }
-
-            vuln_details.push(serde_json::json!({
+            inc_sev(
+                vuln.severity,
+                &mut total_vulns,
+                &mut critical_count,
+                &mut high_count,
+                &mut medium_count,
+                &mut low_count,
+            );
+            direct_details.push(serde_json::json!({
                 "package": dep.name,
-                "version": dep.version,
+                "version": dep.effective_version(),
                 "id": vuln.id,
                 "severity": vuln.severity.as_str(),
                 "description": vuln.description,
-                "url": vuln.url
+                "url": vuln.url,
             }));
         }
     }
+
+    for (pkg, result) in transitives.iter().zip(transitive_results.iter()) {
+        for vuln in &result.vulnerabilities {
+            if !vuln.severity.meets_threshold(&min_sev) {
+                continue;
+            }
+            inc_sev(
+                vuln.severity,
+                &mut total_vulns,
+                &mut critical_count,
+                &mut high_count,
+                &mut medium_count,
+                &mut low_count,
+            );
+
+            let via_direct = dependencies
+                .iter()
+                .find(|dep| {
+                    lockfile_graph
+                        .transitive_deps_of(&dep.name)
+                        .iter()
+                        .any(|tp| tp.name == pkg.name)
+                })
+                .map(|d| d.name.clone())
+                .unwrap_or_else(|| "(unknown)".to_string());
+
+            transitive_details.push(serde_json::json!({
+                "package": pkg.name,
+                "version": pkg.version,
+                "via_direct": via_direct,
+                "id": vuln.id,
+                "severity": vuln.severity.as_str(),
+                "description": vuln.description,
+                "url": vuln.url,
+            }));
+        }
+    }
+
+    let vuln_details: Vec<serde_json::Value> = direct_details
+        .iter()
+        .chain(transitive_details.iter())
+        .cloned()
+        .collect();
 
     // Output results
     match output.as_str() {

--- a/dependi-lsp/src/main.rs
+++ b/dependi-lsp/src/main.rs
@@ -254,8 +254,10 @@ async fn run_scan(
         return ExitCode::SUCCESS;
     }
 
-    // Detect lockfile and build graph
+    // Detect lockfile and build graph.
+    // For Cargo, we keep the lock content to build a disambiguated version_map separately.
     let mut lockfile_graph = LockfileGraph::default();
+    let mut cargo_lock_content: Option<String> = None;
     if use_lockfile {
         match ecosystem {
             Ecosystem::CratesIo => {
@@ -263,6 +265,7 @@ async fn run_scan(
                     && let Ok(lock_content) = read_lockfile_capped(&path).await
                 {
                     lockfile_graph = cargo_lock::parse_cargo_lock_graph(&lock_content);
+                    cargo_lock_content = Some(lock_content);
                 }
             }
             Ecosystem::Npm => {
@@ -319,12 +322,18 @@ async fn run_scan(
         }
     }
 
-    // Populate resolved_version on direct deps from the graph
-    let version_map: HashMap<String, String> = lockfile_graph
-        .packages
-        .iter()
-        .map(|p| (p.name.clone(), p.version.clone()))
-        .collect();
+    // Populate resolved_version on direct deps.
+    // For Cargo, use parse_cargo_lock (HashMap) which correctly disambiguates multi-version
+    // crates via the root package's dep list.  For other ecosystems, derive from the graph.
+    let version_map: HashMap<String, String> = if let Some(ref content) = cargo_lock_content {
+        cargo_lock::parse_cargo_lock(content, None)
+    } else {
+        lockfile_graph
+            .packages
+            .iter()
+            .map(|p| (p.name.clone(), p.version.clone()))
+            .collect()
+    };
 
     let mut dependencies = dependencies;
     for dep in dependencies.iter_mut() {

--- a/dependi-lsp/src/main.rs
+++ b/dependi-lsp/src/main.rs
@@ -51,9 +51,9 @@ enum Commands {
         #[arg(long, default_value = "true")]
         fail_on_vulns: bool,
 
-        /// Enable lockfile-based scanning. Default on. Use `--no-use-lockfile` to disable.
-        #[arg(long = "use-lockfile", default_value_t = true, action = clap::ArgAction::Set)]
-        use_lockfile: bool,
+        /// Disable lockfile-based scanning (enabled by default).
+        #[arg(long = "no-use-lockfile", action = clap::ArgAction::SetTrue)]
+        no_use_lockfile: bool,
     },
     /// Profile dependency file parsing (for use with cargo-flamegraph)
     ProfileParse {
@@ -119,8 +119,8 @@ async fn main() -> ExitCode {
             output,
             min_severity,
             fail_on_vulns,
-            use_lockfile,
-        }) => run_scan(file, output, min_severity, fail_on_vulns, use_lockfile).await,
+            no_use_lockfile,
+        }) => run_scan(file, output, min_severity, fail_on_vulns, !no_use_lockfile).await,
         Some(Commands::ProfileParse { file, iterations }) => {
             run_profile_parse(file, iterations).await
         }
@@ -186,11 +186,13 @@ async fn run_scan(
     use dependi_lsp::parsers::{
         Parser, cargo::CargoParser, cargo_lock, composer_lock, csharp::CsharpParser,
         dart::DartParser, gemfile_lock, go::GoParser, lockfile_graph::LockfileGraph,
-        lockfile_graph::LockfilePackage, maven::MavenParser, npm::NpmParser, npm_lock,
-        php::PhpParser, python::PythonParser, python_lock,
+        lockfile_graph::LockfilePackage, lockfile_graph::read_lockfile_capped, maven::MavenParser,
+        npm::NpmParser, npm_lock, php::PhpParser, python::PythonParser, python_lock,
     };
     use dependi_lsp::registries::VulnerabilitySeverity;
-    use dependi_lsp::vulnerabilities::{Ecosystem, VulnerabilityQuery, normalize_version_for_osv, osv::OsvClient};
+    use dependi_lsp::vulnerabilities::{
+        Ecosystem, VulnerabilityQuery, normalize_version_for_osv, osv::OsvClient,
+    };
     use hashbrown::{HashMap, HashSet};
 
     fn inc_sev(
@@ -255,14 +257,14 @@ async fn run_scan(
         match ecosystem {
             Ecosystem::CratesIo => {
                 if let Some(path) = cargo_lock::find_cargo_lock(&file).await
-                    && let Ok(lock_content) = tokio::fs::read_to_string(&path).await
+                    && let Ok(lock_content) = read_lockfile_capped(&path).await
                 {
                     lockfile_graph = cargo_lock::parse_cargo_lock_graph(&lock_content);
                 }
             }
             Ecosystem::Npm => {
                 if let Some((path, kind)) = npm_lock::find_npm_lockfile(&file).await
-                    && let Ok(lock_content) = tokio::fs::read_to_string(&path).await
+                    && let Ok(lock_content) = read_lockfile_capped(&path).await
                 {
                     lockfile_graph = match kind {
                         npm_lock::NpmLockfileType::PackageLock => {
@@ -280,7 +282,7 @@ async fn run_scan(
             }
             Ecosystem::PyPI => {
                 if let Some((path, kind)) = python_lock::find_python_lockfile(&file, None).await
-                    && let Ok(lock_content) = tokio::fs::read_to_string(&path).await
+                    && let Ok(lock_content) = read_lockfile_capped(&path).await
                 {
                     lockfile_graph = match kind {
                         python_lock::PythonLockfileType::PoetryLock => {
@@ -298,14 +300,14 @@ async fn run_scan(
             }
             Ecosystem::Packagist => {
                 if let Some(path) = composer_lock::find_composer_lock(&file).await
-                    && let Ok(lock_content) = tokio::fs::read_to_string(&path).await
+                    && let Ok(lock_content) = read_lockfile_capped(&path).await
                 {
                     lockfile_graph = composer_lock::parse_composer_lock_graph(&lock_content);
                 }
             }
             Ecosystem::RubyGems => {
                 if let Some(path) = gemfile_lock::find_gemfile_lock(&file).await
-                    && let Ok(lock_content) = tokio::fs::read_to_string(&path).await
+                    && let Ok(lock_content) = read_lockfile_capped(&path).await
                 {
                     lockfile_graph = gemfile_lock::parse_gemfile_lock_graph(&lock_content);
                 }
@@ -418,6 +420,8 @@ async fn run_scan(
         }
     }
 
+    let inverse = lockfile_graph.reverse_index(&direct_names_vec);
+
     for (pkg, result) in transitives.iter().zip(transitive_results.iter()) {
         for vuln in &result.vulnerabilities {
             if !vuln.severity.meets_threshold(&min_sev) {
@@ -432,15 +436,10 @@ async fn run_scan(
                 &mut low_count,
             );
 
-            let via_direct = dependencies
-                .iter()
-                .find(|dep| {
-                    lockfile_graph
-                        .transitive_deps_of(&dep.name)
-                        .iter()
-                        .any(|tp| tp.name == pkg.name)
-                })
-                .map(|d| d.name.clone())
+            let via_direct = inverse
+                .get(&pkg.name)
+                .and_then(|parents| parents.first())
+                .cloned()
                 .unwrap_or_else(|| "(unknown)".to_string());
 
             transitive_details.push(serde_json::json!({
@@ -500,7 +499,10 @@ async fn run_scan(
                 }
             }
             if !transitive_details.is_empty() {
-                println!("## Transitive dependencies ({})\n", transitive_details.len());
+                println!(
+                    "## Transitive dependencies ({})\n",
+                    transitive_details.len()
+                );
                 for v in &transitive_details {
                     let via = v["via_direct"].as_str();
                     print_markdown_entry(v, via);

--- a/dependi-lsp/src/main.rs
+++ b/dependi-lsp/src/main.rs
@@ -176,6 +176,21 @@ fn print_markdown_entry(v: &serde_json::Value, via: Option<&str>) {
     }
 }
 
+fn canonical_name(eco: dependi_lsp::vulnerabilities::Ecosystem, name: &str) -> String {
+    use dependi_lsp::parsers::{
+        composer_lock::normalize_composer_name,
+        gemfile_lock::normalize_gem_name,
+        python_lock::normalize_python_name,
+    };
+    use dependi_lsp::vulnerabilities::Ecosystem;
+    match eco {
+        Ecosystem::PyPI => normalize_python_name(name),
+        Ecosystem::Packagist => normalize_composer_name(name),
+        Ecosystem::RubyGems => normalize_gem_name(name),
+        _ => name.to_string(),
+    }
+}
+
 async fn run_scan(
     file: PathBuf,
     output: String,
@@ -347,13 +362,17 @@ async fn run_scan(
 
     let mut dependencies = dependencies;
     for dep in dependencies.iter_mut() {
-        if let Some(v) = version_map.get(&dep.name) {
+        let key = canonical_name(ecosystem, &dep.name);
+        if let Some(v) = version_map.get(&key) {
             dep.resolved_version = Some(v.clone());
         }
     }
 
     // Flag graph's root packages (matching manifest deps)
-    let direct_names: HashSet<String> = dependencies.iter().map(|d| d.name.clone()).collect();
+    let direct_names: HashSet<String> = dependencies
+        .iter()
+        .map(|d| canonical_name(ecosystem, &d.name))
+        .collect();
     for pkg in lockfile_graph.packages.iter_mut() {
         if direct_names.contains(&pkg.name) {
             pkg.is_root = true;
@@ -361,7 +380,14 @@ async fn run_scan(
     }
 
     // Extract transitives (packages in the lockfile but not in the manifest)
-    let direct_names_vec: Vec<String> = dependencies.iter().map(|d| d.name.clone()).collect();
+    let direct_names_vec: Vec<String> = dependencies
+        .iter()
+        .map(|d| canonical_name(ecosystem, &d.name))
+        .collect();
+    let normalized_to_raw: HashMap<String, String> = dependencies
+        .iter()
+        .map(|d| (canonical_name(ecosystem, &d.name), d.name.clone()))
+        .collect();
     let transitives: Vec<LockfilePackage> = lockfile_graph
         .transitives_only(&direct_names_vec)
         .into_iter()
@@ -461,6 +487,7 @@ async fn run_scan(
             let via_direct = inverse
                 .get(&pkg.name)
                 .and_then(|parents| parents.first())
+                .and_then(|n| normalized_to_raw.get(n))
                 .cloned()
                 .unwrap_or_else(|| "(unknown)".to_string());
 

--- a/dependi-lsp/src/main.rs
+++ b/dependi-lsp/src/main.rs
@@ -178,8 +178,7 @@ fn print_markdown_entry(v: &serde_json::Value, via: Option<&str>) {
 
 fn canonical_name(eco: dependi_lsp::vulnerabilities::Ecosystem, name: &str) -> String {
     use dependi_lsp::parsers::{
-        composer_lock::normalize_composer_name,
-        gemfile_lock::normalize_gem_name,
+        composer_lock::normalize_composer_name, gemfile_lock::normalize_gem_name,
         python_lock::normalize_python_name,
     };
     use dependi_lsp::vulnerabilities::Ecosystem;

--- a/dependi-lsp/src/main.rs
+++ b/dependi-lsp/src/main.rs
@@ -152,6 +152,30 @@ async fn run_lsp() {
     Server::new(stdin, stdout, socket).serve(service).await;
 }
 
+fn print_markdown_entry(v: &serde_json::Value, via: Option<&str>) {
+    let severity = v["severity"].as_str().unwrap_or("low");
+    let icon = match severity {
+        "critical" => "⚠",
+        "high" => "▲",
+        "medium" => "●",
+        _ => "○",
+    };
+    let pkg = v["package"].as_str().unwrap_or("");
+    let ver = v["version"].as_str().unwrap_or("");
+    match via {
+        Some(parent) => println!("### {pkg}@{ver} — via `{parent}`\n"),
+        None => println!("### {pkg}@{ver}\n"),
+    }
+    let id = v["id"].as_str().unwrap_or("");
+    let sev_upper = severity.to_uppercase();
+    let desc = v["description"].as_str().unwrap_or("");
+    if let Some(url) = v["url"].as_str() {
+        println!("- **[{id}]({url})** ({icon} {sev_upper}): {desc}\n");
+    } else {
+        println!("- **{id}** ({icon} {sev_upper}): {desc}\n");
+    }
+}
+
 async fn run_scan(
     file: PathBuf,
     output: String,
@@ -431,15 +455,13 @@ async fn run_scan(
         }
     }
 
-    let vuln_details: Vec<serde_json::Value> = direct_details
-        .iter()
-        .chain(transitive_details.iter())
-        .cloned()
-        .collect();
-
     // Output results
     match output.as_str() {
         "json" => {
+            let combined: Vec<&serde_json::Value> = direct_details
+                .iter()
+                .chain(transitive_details.iter())
+                .collect();
             let report = serde_json::json!({
                 "file": file.display().to_string(),
                 "summary": {
@@ -449,7 +471,9 @@ async fn run_scan(
                     "medium": medium_count,
                     "low": low_count
                 },
-                "vulnerabilities": vuln_details
+                "direct": direct_details,
+                "transitive": transitive_details,
+                "vulnerabilities": combined,
             });
             match serde_json::to_string_pretty(&report) {
                 Ok(json) => println!("{json}"),
@@ -469,54 +493,57 @@ async fn run_scan(
             println!("| ○ Low | {low_count} |");
             println!("| **Total** | **{total_vulns}** |\n");
 
-            if !vuln_details.is_empty() {
-                println!("## Vulnerabilities\n");
-                for vuln in &vuln_details {
-                    let severity = vuln["severity"].as_str();
-                    let severity_icon = match severity.unwrap_or("low") {
-                        "critical" => "⚠",
-                        "high" => "▲",
-                        "medium" => "●",
-                        _ => "○",
-                    };
-                    println!(
-                        "### {}@{}\n",
-                        vuln["package"].as_str().unwrap_or(""),
-                        vuln["version"].as_str().unwrap_or("")
-                    );
-                    if let Some(url) = vuln["url"].as_str() {
-                        println!(
-                            "- **[{}]({url})** ({severity_icon} {}): {}",
-                            vuln["id"].as_str().unwrap_or(""),
-                            severity.unwrap_or("").to_uppercase(),
-                            vuln["description"].as_str().unwrap_or("")
-                        );
-                    } else {
-                        println!(
-                            "- **{}** ({severity_icon} {}): {}",
-                            vuln["id"].as_str().unwrap_or(""),
-                            severity.unwrap_or("").to_uppercase(),
-                            vuln["description"].as_str().unwrap_or("")
-                        );
-                    }
-                    println!();
+            if !direct_details.is_empty() {
+                println!("## Direct dependencies ({})\n", direct_details.len());
+                for v in &direct_details {
+                    print_markdown_entry(v, None);
+                }
+            }
+            if !transitive_details.is_empty() {
+                println!("## Transitive dependencies ({})\n", transitive_details.len());
+                for v in &transitive_details {
+                    let via = v["via_direct"].as_str();
+                    print_markdown_entry(v, via);
                 }
             }
         }
         _ => {
-            // Summary format
-            println!("Vulnerability Scan Results for {}\n", file.display());
+            println!("Vulnerability Scan Results for {}", file.display());
+            println!(
+                "  Total: {total_vulns} ({} direct, {} transitive)",
+                direct_details.len(),
+                transitive_details.len()
+            );
             println!("  ⚠ Critical: {critical_count}");
             println!("  ▲ High:     {high_count}");
             println!("  ● Medium:   {medium_count}");
-            println!("  ○ Low:      {low_count}");
-            println!("  ─────────────");
-            println!("  Total:      {total_vulns}\n");
+            println!("  ○ Low:      {low_count}\n");
 
+            if !direct_details.is_empty() {
+                println!("Direct:");
+                for v in &direct_details {
+                    println!(
+                        "  - {}@{} [{}]",
+                        v["package"].as_str().unwrap_or(""),
+                        v["version"].as_str().unwrap_or(""),
+                        v["id"].as_str().unwrap_or("")
+                    );
+                }
+            }
+            if !transitive_details.is_empty() {
+                println!("Transitive:");
+                for v in &transitive_details {
+                    println!(
+                        "  - {}@{} (via {}) [{}]",
+                        v["package"].as_str().unwrap_or(""),
+                        v["version"].as_str().unwrap_or(""),
+                        v["via_direct"].as_str().unwrap_or("?"),
+                        v["id"].as_str().unwrap_or("")
+                    );
+                }
+            }
             if total_vulns == 0 {
-                println!("[OK] No vulnerabilities found!");
-            } else {
-                println!("⚠ {total_vulns} vulnerabilities found!");
+                println!("\n[OK] No vulnerabilities found!");
             }
         }
     }

--- a/dependi-lsp/src/main.rs
+++ b/dependi-lsp/src/main.rs
@@ -310,7 +310,8 @@ async fn run_scan(
                 }
             }
             Ecosystem::PyPI => {
-                if let Some((path, kind)) = python_lock::find_python_lockfile(&file, None).await
+                let hint = python_lock::detect_python_tool(&content);
+                if let Some((path, kind)) = python_lock::find_python_lockfile(&file, hint).await
                     && let Ok(lock_content) = read_lockfile_capped(&path).await
                 {
                     lockfile_graph = match kind {

--- a/dependi-lsp/src/parsers/cargo_lock.rs
+++ b/dependi-lsp/src/parsers/cargo_lock.rs
@@ -72,8 +72,10 @@ pub fn parse_cargo_lock(content: &str, root_package: Option<&str>) -> HashMap<St
 
 /// Parse Cargo.lock into a full dependency graph.
 ///
-/// Dependency strings in Cargo.lock follow the form "name" or "name version"
-/// (or v1 legacy "name version (source)"). We keep only the name.
+/// Dependency strings are stored as-is (e.g. `"serde"` or `"serde 1.0.195"`).
+/// Cargo writes the version when multiple versions of the same crate are locked,
+/// so preserving it allows correct transitive attribution.  Graph-walk code
+/// normalises to the name portion when resolving edges.
 pub fn parse_cargo_lock_graph(content: &str) -> LockfileGraph {
     let mut graph = LockfileGraph::default();
 
@@ -100,7 +102,7 @@ pub fn parse_cargo_lock_graph(content: &str) -> LockfileGraph {
             .map(|arr| {
                 arr.iter()
                     .filter_map(|d| d.as_str())
-                    .map(|s| s.split_whitespace().next().unwrap_or(s).to_string())
+                    .map(|s| s.to_string())
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
@@ -325,10 +327,33 @@ version = "0.8.10"
         let graph = parse_cargo_lock_graph(content);
         assert_eq!(graph.packages.len(), 4);
         let root = graph.packages.iter().find(|p| p.name == "root").unwrap();
+        // Dependencies are stored as-is; "serde" has no version, "tokio 1.36.0" keeps it.
         assert!(root.dependencies.contains(&"serde".to_string()));
-        assert!(root.dependencies.contains(&"tokio".to_string()));
+        assert!(root.dependencies.contains(&"tokio 1.36.0".to_string()));
         let tokio = graph.packages.iter().find(|p| p.name == "tokio").unwrap();
         assert_eq!(tokio.dependencies, vec!["mio".to_string()]);
+    }
+
+    #[test]
+    fn test_parse_cargo_lock_graph_preserves_dep_version_tokens() {
+        let content = r#"
+[[package]]
+name = "root"
+version = "0.1.0"
+dependencies = ["hashbrown 0.15.5", "hashbrown 0.16.1"]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+"#;
+        let graph = parse_cargo_lock_graph(content);
+        let root = graph.packages.iter().find(|p| p.name == "root").unwrap();
+        assert!(root.dependencies.iter().any(|d| d == "hashbrown 0.15.5"));
+        assert!(root.dependencies.iter().any(|d| d == "hashbrown 0.16.1"));
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/cargo_lock.rs
+++ b/dependi-lsp/src/parsers/cargo_lock.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 
 use hashbrown::HashMap;
 
+use crate::parsers::lockfile_graph::{LockfileGraph, LockfilePackage};
+
 /// Parse a Cargo.lock file and return a map of package name → resolved version.
 ///
 /// Cargo.lock uses `[[package]]` TOML array-of-tables entries with `name` and `version` fields.
@@ -66,6 +68,52 @@ pub fn parse_cargo_lock(content: &str, root_package: Option<&str>) -> HashMap<St
     }
 
     map
+}
+
+/// Parse Cargo.lock into a full dependency graph.
+///
+/// Dependency strings in Cargo.lock follow the form "name" or "name version"
+/// (or v1 legacy "name version (source)"). We keep only the name.
+pub fn parse_cargo_lock_graph(content: &str) -> LockfileGraph {
+    let mut graph = LockfileGraph::default();
+
+    let value: toml::Value = match toml::from_str(content) {
+        Ok(v) => v,
+        Err(_) => return graph,
+    };
+
+    let packages = match value.get("package").and_then(|p| p.as_array()) {
+        Some(pkgs) => pkgs,
+        None => return graph,
+    };
+
+    for pkg in packages {
+        let Some(name) = pkg.get("name").and_then(|n| n.as_str()) else {
+            continue;
+        };
+        let Some(version) = pkg.get("version").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let deps = pkg
+            .get("dependencies")
+            .and_then(|d| d.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|d| d.as_str())
+                    .map(|s| s.split_whitespace().next().unwrap_or(s).to_string())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        graph.packages.push(LockfilePackage {
+            name: name.to_string(),
+            version: version.to_string(),
+            dependencies: deps,
+            is_root: false,
+        });
+    }
+
+    graph
 }
 
 /// Find the Cargo.lock file by walking up from a Cargo.toml path.
@@ -251,5 +299,47 @@ version = "1.0.195"
 "#;
         let map = parse_cargo_lock(content, Some("my-crate"));
         assert_eq!(map.get("serde").map(|s| s.as_str()), Some("1.0.195"));
+    }
+
+    #[test]
+    fn test_parse_graph_captures_dependencies() {
+        let content = r#"
+[[package]]
+name = "root"
+version = "0.1.0"
+dependencies = ["serde", "tokio 1.36.0"]
+
+[[package]]
+name = "serde"
+version = "1.0.195"
+
+[[package]]
+name = "tokio"
+version = "1.36.0"
+dependencies = ["mio"]
+
+[[package]]
+name = "mio"
+version = "0.8.10"
+"#;
+        let graph = parse_cargo_lock_graph(content);
+        assert_eq!(graph.packages.len(), 4);
+        let root = graph.packages.iter().find(|p| p.name == "root").unwrap();
+        assert!(root.dependencies.contains(&"serde".to_string()));
+        assert!(root.dependencies.contains(&"tokio".to_string()));
+        let tokio = graph.packages.iter().find(|p| p.name == "tokio").unwrap();
+        assert_eq!(tokio.dependencies, vec!["mio".to_string()]);
+    }
+
+    #[test]
+    fn test_parse_graph_empty() {
+        let graph = parse_cargo_lock_graph("");
+        assert!(graph.packages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_graph_invalid_toml() {
+        let graph = parse_cargo_lock_graph("not valid ][ toml");
+        assert!(graph.packages.is_empty());
     }
 }

--- a/dependi-lsp/src/parsers/composer_lock.rs
+++ b/dependi-lsp/src/parsers/composer_lock.rs
@@ -251,10 +251,22 @@ mod tests {
 }"#;
         let graph = parse_composer_lock_graph(content);
         assert_eq!(graph.packages.len(), 2);
-        let console = graph.packages.iter().find(|p| p.name == "symfony/console").unwrap();
-        assert!(console.dependencies.contains(&"symfony/polyfill-php80".to_string()));
+        let console = graph
+            .packages
+            .iter()
+            .find(|p| p.name == "symfony/console")
+            .unwrap();
+        assert!(
+            console
+                .dependencies
+                .contains(&"symfony/polyfill-php80".to_string())
+        );
         assert!(!console.dependencies.iter().any(|d| d == "php"));
-        let polyfill = graph.packages.iter().find(|p| p.name == "symfony/polyfill-php80").unwrap();
+        let polyfill = graph
+            .packages
+            .iter()
+            .find(|p| p.name == "symfony/polyfill-php80")
+            .unwrap();
         assert!(!polyfill.dependencies.iter().any(|d| d.starts_with("ext-")));
     }
 }

--- a/dependi-lsp/src/parsers/composer_lock.rs
+++ b/dependi-lsp/src/parsers/composer_lock.rs
@@ -285,9 +285,16 @@ mod tests {
 }"#;
         let graph = parse_composer_lock_graph(content);
         let names: Vec<&str> = graph.packages.iter().map(|p| p.name.as_str()).collect();
-        assert!(names.contains(&"vendor/package"), "main name should be lowercased, got {names:?}");
+        assert!(
+            names.contains(&"vendor/package"),
+            "main name should be lowercased, got {names:?}"
+        );
         assert!(names.contains(&"dep/other"));
-        let vp = graph.packages.iter().find(|p| p.name == "vendor/package").unwrap();
+        let vp = graph
+            .packages
+            .iter()
+            .find(|p| p.name == "vendor/package")
+            .unwrap();
         assert!(
             vp.dependencies.contains(&"dep/other".to_string()),
             "require names must also be normalized, got {:?}",

--- a/dependi-lsp/src/parsers/composer_lock.rs
+++ b/dependi-lsp/src/parsers/composer_lock.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 
 use hashbrown::HashMap;
 
+use crate::parsers::lockfile_graph::{LockfileGraph, LockfilePackage};
+
 /// Normalize a Composer package name to lowercase.
 ///
 /// Composer package names are case-insensitive (e.g., "Vendor/Package" == "vendor/package").
@@ -53,6 +55,46 @@ pub fn parse_composer_lock(content: &str) -> HashMap<String, String> {
     }
 
     map
+}
+
+/// Parse composer.lock into a full dependency graph. Includes both `packages` and `packages-dev`.
+/// Skips platform requires (`php`, `ext-*`).
+pub fn parse_composer_lock_graph(content: &str) -> LockfileGraph {
+    let mut graph = LockfileGraph::default();
+    let value: serde_json::Value = match serde_json::from_str(content) {
+        Ok(v) => v,
+        Err(_) => return graph,
+    };
+
+    for key in &["packages", "packages-dev"] {
+        let Some(arr) = value.get(key).and_then(|p| p.as_array()) else {
+            continue;
+        };
+        for entry in arr {
+            let Some(name) = entry.get("name").and_then(|n| n.as_str()) else {
+                continue;
+            };
+            let Some(version) = entry.get("version").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let mut deps: Vec<String> = Vec::new();
+            if let Some(req) = entry.get("require").and_then(|r| r.as_object()) {
+                for dep_name in req.keys() {
+                    if dep_name != "php" && !dep_name.starts_with("ext-") {
+                        deps.push(dep_name.clone());
+                    }
+                }
+            }
+            graph.packages.push(LockfilePackage {
+                name: name.to_string(),
+                version: version.to_string(),
+                dependencies: deps,
+                is_root: false,
+            });
+        }
+    }
+
+    graph
 }
 
 /// Find the composer.lock file by walking up from a composer.json path.
@@ -192,5 +234,27 @@ mod tests {
             map.get("vendor/dev").map(|s| s.as_str()),
             Some("dev-master")
         );
+    }
+
+    #[test]
+    fn test_parse_composer_lock_graph() {
+        let content = r#"{
+  "packages": [
+    {
+      "name": "symfony/console",
+      "version": "v6.0.0",
+      "require": { "symfony/polyfill-php80": "^1.16", "php": ">=8.0" }
+    },
+    { "name": "symfony/polyfill-php80", "version": "v1.27.0", "require": { "ext-mbstring": "*" } }
+  ],
+  "packages-dev": []
+}"#;
+        let graph = parse_composer_lock_graph(content);
+        assert_eq!(graph.packages.len(), 2);
+        let console = graph.packages.iter().find(|p| p.name == "symfony/console").unwrap();
+        assert!(console.dependencies.contains(&"symfony/polyfill-php80".to_string()));
+        assert!(!console.dependencies.iter().any(|d| d == "php"));
+        let polyfill = graph.packages.iter().find(|p| p.name == "symfony/polyfill-php80").unwrap();
+        assert!(!polyfill.dependencies.iter().any(|d| d.starts_with("ext-")));
     }
 }

--- a/dependi-lsp/src/parsers/composer_lock.rs
+++ b/dependi-lsp/src/parsers/composer_lock.rs
@@ -81,12 +81,12 @@ pub fn parse_composer_lock_graph(content: &str) -> LockfileGraph {
             if let Some(req) = entry.get("require").and_then(|r| r.as_object()) {
                 for dep_name in req.keys() {
                     if dep_name != "php" && !dep_name.starts_with("ext-") {
-                        deps.push(dep_name.clone());
+                        deps.push(normalize_composer_name(dep_name));
                     }
                 }
             }
             graph.packages.push(LockfilePackage {
-                name: name.to_string(),
+                name: normalize_composer_name(name),
                 version: version.to_string(),
                 dependencies: deps,
                 is_root: false,
@@ -268,5 +268,30 @@ mod tests {
             .find(|p| p.name == "symfony/polyfill-php80")
             .unwrap();
         assert!(!polyfill.dependencies.iter().any(|d| d.starts_with("ext-")));
+    }
+
+    #[test]
+    fn test_parse_composer_lock_graph_normalizes_names() {
+        let content = r#"{
+  "packages": [
+    {
+      "name": "Vendor/Package",
+      "version": "1.0.0",
+      "require": { "Dep/Other": "^1.0" }
+    },
+    { "name": "Dep/Other", "version": "1.2.3" }
+  ],
+  "packages-dev": []
+}"#;
+        let graph = parse_composer_lock_graph(content);
+        let names: Vec<&str> = graph.packages.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"vendor/package"), "main name should be lowercased, got {names:?}");
+        assert!(names.contains(&"dep/other"));
+        let vp = graph.packages.iter().find(|p| p.name == "vendor/package").unwrap();
+        assert!(
+            vp.dependencies.contains(&"dep/other".to_string()),
+            "require names must also be normalized, got {:?}",
+            vp.dependencies
+        );
     }
 }

--- a/dependi-lsp/src/parsers/gemfile_lock.rs
+++ b/dependi-lsp/src/parsers/gemfile_lock.rs
@@ -491,8 +491,16 @@ GEM
     rack (3.0.0)
 "#;
         let graph = parse_gemfile_lock_graph(content);
-        let nokogiri = graph.packages.iter().find(|p| p.name == "nokogiri").unwrap();
-        assert_eq!(nokogiri.version, "1.15.4", "platform suffix must be stripped, got {:?}", nokogiri.version);
+        let nokogiri = graph
+            .packages
+            .iter()
+            .find(|p| p.name == "nokogiri")
+            .unwrap();
+        assert_eq!(
+            nokogiri.version, "1.15.4",
+            "platform suffix must be stripped, got {:?}",
+            nokogiri.version
+        );
         let rack = graph.packages.iter().find(|p| p.name == "rack").unwrap();
         assert_eq!(rack.version, "3.0.0");
     }

--- a/dependi-lsp/src/parsers/gemfile_lock.rs
+++ b/dependi-lsp/src/parsers/gemfile_lock.rs
@@ -197,10 +197,8 @@ pub fn parse_gemfile_lock_graph(content: &str) -> LockfileGraph {
             }
             let s = trimmed.trim();
             if let Some((name, rest)) = s.split_once(' ') {
-                let version = rest
-                    .trim()
-                    .trim_matches(|c| c == '(' || c == ')')
-                    .to_string();
+                let raw_version = rest.trim().trim_matches(|c| c == '(' || c == ')');
+                let version = strip_platform_suffix(raw_version).to_string();
                 current = Some(LockfilePackage {
                     name: normalize_gem_name(name),
                     version,
@@ -481,6 +479,22 @@ GEM
         // normalize_gem_name lowercases names
         assert!(graph.packages.iter().any(|p| p.name == "activerecord"));
         assert!(graph.packages.iter().any(|p| p.name == "active_support"));
+    }
+
+    #[test]
+    fn test_parse_gemfile_lock_graph_strips_platform_suffix() {
+        let content = r#"
+GEM
+  remote: https://rubygems.org/
+  specs:
+    nokogiri (1.15.4-x86_64-linux)
+    rack (3.0.0)
+"#;
+        let graph = parse_gemfile_lock_graph(content);
+        let nokogiri = graph.packages.iter().find(|p| p.name == "nokogiri").unwrap();
+        assert_eq!(nokogiri.version, "1.15.4", "platform suffix must be stripped, got {:?}", nokogiri.version);
+        let rack = graph.packages.iter().find(|p| p.name == "rack").unwrap();
+        assert_eq!(rack.version, "3.0.0");
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/gemfile_lock.rs
+++ b/dependi-lsp/src/parsers/gemfile_lock.rs
@@ -134,33 +134,58 @@ pub fn parse_gemfile_lock(content: &str) -> HashMap<String, String> {
 
 use crate::parsers::lockfile_graph::{LockfileGraph, LockfilePackage};
 
+#[derive(PartialEq)]
+enum GemSection {
+    None,
+    Gem,
+    Other,
+}
+
 /// Parse Gemfile.lock into a dependency graph.
+/// Only the GEM section (RubyGems.org) is included. PATH and GIT sections are excluded.
 /// The GEM/specs section uses 4-space indent for top-level gems (name + version)
 /// and 6-space indent for their dependency list (name + constraint).
 pub fn parse_gemfile_lock_graph(content: &str) -> LockfileGraph {
     let mut graph = LockfileGraph::default();
-    let mut in_gem_specs = false;
+    let mut section = GemSection::None;
+    let mut in_specs = false;
     let mut current: Option<LockfilePackage> = None;
 
     for line in content.lines() {
         let trimmed = line.trim_end();
-        if trimmed == "GEM" {
-            in_gem_specs = false;
+
+        // Section headers are at column 0 (no leading spaces, non-empty)
+        if !trimmed.is_empty() && !trimmed.starts_with(' ') {
+            if let Some(done) = current.take() {
+                graph.packages.push(done);
+            }
+            section = match trimmed.trim() {
+                "GEM" => GemSection::Gem,
+                _ => GemSection::Other,
+            };
+            in_specs = false;
             continue;
         }
+
+        if section != GemSection::Gem {
+            continue;
+        }
+
         if trimmed.trim() == "specs:" {
-            in_gem_specs = true;
+            in_specs = true;
             continue;
         }
-        if !in_gem_specs {
+
+        if !in_specs {
             continue;
         }
+
         if trimmed.is_empty() || !trimmed.starts_with("    ") {
             if let Some(done) = current.take() {
                 graph.packages.push(done);
             }
             if !trimmed.starts_with("    ") {
-                in_gem_specs = false;
+                in_specs = false;
             }
             continue;
         }
@@ -177,7 +202,7 @@ pub fn parse_gemfile_lock_graph(content: &str) -> LockfileGraph {
                     .trim_matches(|c| c == '(' || c == ')')
                     .to_string();
                 current = Some(LockfilePackage {
-                    name: name.to_string(),
+                    name: normalize_gem_name(name),
                     version,
                     dependencies: Vec::new(),
                     is_root: false,
@@ -188,7 +213,7 @@ pub fn parse_gemfile_lock_graph(content: &str) -> LockfileGraph {
             let s = trimmed.trim();
             let dep_name = s.split_whitespace().next().unwrap_or("");
             if !dep_name.is_empty() {
-                cur.dependencies.push(dep_name.to_string());
+                cur.dependencies.push(normalize_gem_name(dep_name));
             }
         }
     }
@@ -412,6 +437,50 @@ GEM
         assert!(rails.dependencies.contains(&"actioncable".to_string()));
         let rack = graph.packages.iter().find(|p| p.name == "rack").unwrap();
         assert!(rack.dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_parse_gemfile_lock_graph_ignores_path_and_git_sections() {
+        let content = r#"
+PATH
+  remote: .
+  specs:
+    local_gem (0.1.0)
+      rack (~> 3.0)
+
+GIT
+  remote: https://github.com/rails/rails.git
+  specs:
+    rails_fork (7.0.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (3.0.0)
+    rails (7.0.4)
+      rack (~> 3.0)
+"#;
+        let graph = parse_gemfile_lock_graph(content);
+        let names: Vec<&str> = graph.packages.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"rack"));
+        assert!(names.contains(&"rails"));
+        assert!(!names.contains(&"local_gem"), "PATH gems must be excluded");
+        assert!(!names.contains(&"rails_fork"), "GIT gems must be excluded");
+    }
+
+    #[test]
+    fn test_parse_gemfile_lock_graph_normalizes_names() {
+        let content = r#"
+GEM
+  specs:
+    ActiveRecord (7.0.0)
+      active_support (= 7.0.0)
+    active_support (7.0.0)
+"#;
+        let graph = parse_gemfile_lock_graph(content);
+        // normalize_gem_name lowercases names
+        assert!(graph.packages.iter().any(|p| p.name == "activerecord"));
+        assert!(graph.packages.iter().any(|p| p.name == "active_support"));
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/gemfile_lock.rs
+++ b/dependi-lsp/src/parsers/gemfile_lock.rs
@@ -132,6 +132,73 @@ pub fn parse_gemfile_lock(content: &str) -> HashMap<String, String> {
     map
 }
 
+use crate::parsers::lockfile_graph::{LockfileGraph, LockfilePackage};
+
+/// Parse Gemfile.lock into a dependency graph.
+/// The GEM/specs section uses 4-space indent for top-level gems (name + version)
+/// and 6-space indent for their dependency list (name + constraint).
+pub fn parse_gemfile_lock_graph(content: &str) -> LockfileGraph {
+    let mut graph = LockfileGraph::default();
+    let mut in_gem_specs = false;
+    let mut current: Option<LockfilePackage> = None;
+
+    for line in content.lines() {
+        let trimmed = line.trim_end();
+        if trimmed == "GEM" {
+            in_gem_specs = false;
+            continue;
+        }
+        if trimmed.trim() == "specs:" {
+            in_gem_specs = true;
+            continue;
+        }
+        if !in_gem_specs {
+            continue;
+        }
+        if trimmed.is_empty() || !trimmed.starts_with("    ") {
+            if let Some(done) = current.take() {
+                graph.packages.push(done);
+            }
+            if !trimmed.starts_with("    ") {
+                in_gem_specs = false;
+            }
+            continue;
+        }
+
+        // Level-1 gem: "    name (version)"
+        if trimmed.starts_with("    ") && !trimmed.starts_with("      ") {
+            if let Some(done) = current.take() {
+                graph.packages.push(done);
+            }
+            let s = trimmed.trim();
+            if let Some((name, rest)) = s.split_once(' ') {
+                let version = rest
+                    .trim()
+                    .trim_matches(|c| c == '(' || c == ')')
+                    .to_string();
+                current = Some(LockfilePackage {
+                    name: name.to_string(),
+                    version,
+                    dependencies: Vec::new(),
+                    is_root: false,
+                });
+            }
+        } else if let Some(cur) = current.as_mut() {
+            // Level-2 sub-dep: "      name (constraint)"
+            let s = trimmed.trim();
+            let dep_name = s.split_whitespace().next().unwrap_or("");
+            if !dep_name.is_empty() {
+                cur.dependencies.push(dep_name.to_string());
+            }
+        }
+    }
+
+    if let Some(done) = current {
+        graph.packages.push(done);
+    }
+    graph
+}
+
 /// Find the Gemfile.lock file co-located with a Gemfile.
 ///
 /// Bundler always places Gemfile.lock in the same directory as Gemfile,
@@ -322,6 +389,29 @@ GEM
 ";
         let map = parse_gemfile_lock(content);
         assert_eq!(map.get("nokogiri").map(|s| s.as_str()), Some("1.15.4"));
+    }
+
+    #[test]
+    fn test_parse_gemfile_lock_graph() {
+        let content = r#"
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (3.0.0)
+    rails (7.0.4)
+      rack (~> 3.0)
+      actioncable (= 7.0.4)
+    actioncable (7.0.4)
+      actionpack (= 7.0.4)
+    actionpack (7.0.4)
+"#;
+        let graph = parse_gemfile_lock_graph(content);
+        let rails = graph.packages.iter().find(|p| p.name == "rails").unwrap();
+        assert_eq!(rails.version, "7.0.4");
+        assert!(rails.dependencies.contains(&"rack".to_string()));
+        assert!(rails.dependencies.contains(&"actioncable".to_string()));
+        let rack = graph.packages.iter().find(|p| p.name == "rack").unwrap();
+        assert!(rack.dependencies.is_empty());
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/lockfile_graph.rs
+++ b/dependi-lsp/src/parsers/lockfile_graph.rs
@@ -42,6 +42,9 @@ pub struct LockfileGraph {
 impl LockfileGraph {
     /// DFS from `root_name`; returns unique transitive packages (excluding `root_name` itself).
     /// Returns empty vec if root is unknown. Cycles are handled via a visited set.
+    ///
+    /// Dependency strings may be `"name"` or `"name version"` (Cargo multi-version format).
+    /// The version suffix is stripped when resolving graph edges so that both forms work.
     pub fn transitive_deps_of(&self, root_name: &str) -> Vec<&LockfilePackage> {
         let mut visited: HashSet<&str> = HashSet::new();
         let mut stack: Vec<&str> = Vec::new();
@@ -50,7 +53,9 @@ impl LockfileGraph {
         if let Some(root) = self.find(root_name) {
             visited.insert(&root.name);
             for dep in &root.dependencies {
-                stack.push(dep.as_str());
+                // dep can be "name" or "name version" — use the name only for graph walk.
+                let name = dep.split_whitespace().next().unwrap_or(dep.as_str());
+                stack.push(name);
             }
         } else {
             return out;
@@ -63,7 +68,8 @@ impl LockfileGraph {
             if let Some(pkg) = self.find(name) {
                 out.push(pkg);
                 for dep in &pkg.dependencies {
-                    stack.push(dep.as_str());
+                    let n = dep.split_whitespace().next().unwrap_or(dep.as_str());
+                    stack.push(n);
                 }
             }
         }

--- a/dependi-lsp/src/parsers/lockfile_graph.rs
+++ b/dependi-lsp/src/parsers/lockfile_graph.rs
@@ -2,6 +2,22 @@
 
 use hashbrown::HashSet;
 
+/// Read a lockfile with a size cap (50 MiB) to prevent OOM on hostile inputs.
+pub async fn read_lockfile_capped(path: &std::path::Path) -> std::io::Result<String> {
+    const MAX_LOCKFILE_BYTES: u64 = 50 * 1024 * 1024;
+    let metadata = tokio::fs::metadata(path).await?;
+    if metadata.len() > MAX_LOCKFILE_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "lockfile exceeds {} MiB cap",
+                MAX_LOCKFILE_BYTES / (1024 * 1024)
+            ),
+        ));
+    }
+    tokio::fs::read_to_string(path).await
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LockfilePackage {
     pub name: String,
@@ -56,6 +72,31 @@ impl LockfileGraph {
             .iter()
             .filter(|p| !set.contains(p.name.as_str()))
             .collect()
+    }
+
+    /// Build an inverse index: for each transitive package name, the set of direct
+    /// dependency names (from `manifest_deps`) that reach it via `transitive_deps_of`.
+    ///
+    /// Returns a `HashMap<String, Vec<String>>`. When a transitive is not reachable from
+    /// any direct dep, it has no entry.
+    pub fn reverse_index(
+        &self,
+        manifest_deps: &[String],
+    ) -> hashbrown::HashMap<String, Vec<String>> {
+        let mut inverse: hashbrown::HashMap<String, Vec<String>> = hashbrown::HashMap::new();
+        for direct in manifest_deps {
+            for pkg in self.transitive_deps_of(direct) {
+                #[expect(
+                    clippy::disallowed_methods,
+                    reason = "`pkg.name` is &str; `entry_ref` would still allocate on insert for Vec<String>"
+                )]
+                inverse
+                    .entry(pkg.name.clone())
+                    .or_default()
+                    .push(direct.clone());
+            }
+        }
+        inverse
     }
 
     fn find(&self, name: &str) -> Option<&LockfilePackage> {
@@ -128,6 +169,21 @@ mod tests {
     fn test_transitive_deps_of_unknown_root() {
         let graph = LockfileGraph { packages: vec![] };
         assert!(graph.transitive_deps_of("nope").is_empty());
+    }
+
+    #[test]
+    fn test_reverse_index_attributes_transitive_to_direct() {
+        let graph = LockfileGraph {
+            packages: vec![
+                pkg("react", &["scheduler"], true),
+                pkg("vue", &["scheduler"], true),
+                pkg("scheduler", &[], false),
+            ],
+        };
+        let idx = graph.reverse_index(&["react".to_string(), "vue".to_string()]);
+        let parents = idx.get("scheduler").unwrap();
+        assert!(parents.contains(&"react".to_string()));
+        assert!(parents.contains(&"vue".to_string()));
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/lockfile_graph.rs
+++ b/dependi-lsp/src/parsers/lockfile_graph.rs
@@ -1,21 +1,27 @@
 //! Shared graph representation for lockfile contents.
 
 use hashbrown::HashSet;
+use tokio::io::AsyncReadExt;
 
-/// Read a lockfile with a size cap (50 MiB) to prevent OOM on hostile inputs.
+/// Read a lockfile with a 50 MiB size cap to prevent OOM on hostile inputs.
+/// The cap is enforced DURING the read, not before, to avoid TOCTOU races.
 pub async fn read_lockfile_capped(path: &std::path::Path) -> std::io::Result<String> {
     const MAX_LOCKFILE_BYTES: u64 = 50 * 1024 * 1024;
-    let metadata = tokio::fs::metadata(path).await?;
-    if metadata.len() > MAX_LOCKFILE_BYTES {
+    let file = tokio::fs::File::open(path).await?;
+    // `take` yields at most MAX+1 bytes; if the source is longer, the extra byte
+    // signals the overflow and we reject.
+    let mut buf = Vec::with_capacity(4096);
+    let mut reader = file.take(MAX_LOCKFILE_BYTES + 1);
+    reader.read_to_end(&mut buf).await?;
+    if buf.len() as u64 > MAX_LOCKFILE_BYTES {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!(
-                "lockfile exceeds {} MiB cap",
-                MAX_LOCKFILE_BYTES / (1024 * 1024)
-            ),
+            format!("lockfile exceeds {} MiB cap", MAX_LOCKFILE_BYTES / (1024 * 1024)),
         ));
     }
-    tokio::fs::read_to_string(path).await
+    String::from_utf8(buf).map_err(|e| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, e.utf8_error())
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -204,5 +210,26 @@ mod tests {
         assert!(!names.contains(&"react".to_string()));
         assert!(names.contains(&"react-dom".to_string()));
         assert!(names.contains(&"scheduler".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_read_lockfile_capped_rejects_oversized() {
+        use std::io::Write;
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        // Write 51 MiB (just over the cap)
+        let size = 51 * 1024 * 1024;
+        let data = vec![b'a'; size];
+        tmp.as_file().write_all(&data).unwrap();
+        let err = read_lockfile_capped(tmp.path()).await.err().unwrap();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("MiB cap"));
+    }
+
+    #[tokio::test]
+    async fn test_read_lockfile_capped_accepts_small_file() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "hello").unwrap();
+        let out = read_lockfile_capped(tmp.path()).await.unwrap();
+        assert_eq!(out, "hello");
     }
 }

--- a/dependi-lsp/src/parsers/lockfile_graph.rs
+++ b/dependi-lsp/src/parsers/lockfile_graph.rs
@@ -42,32 +42,46 @@ pub struct LockfileGraph {
 }
 
 impl LockfileGraph {
-    /// DFS from `root_name`; returns unique transitive packages (excluding `root_name` itself).
-    /// Returns empty vec if root is unknown. Cycles are handled via a visited set.
+    /// Returns all packages sharing the given name (0 or more). Some lockfiles
+    /// pin multiple versions of the same crate/package — e.g. Cargo's
+    /// transitive resolution.
+    pub fn find_all(&self, name: &str) -> Vec<&LockfilePackage> {
+        self.packages.iter().filter(|p| p.name == name).collect()
+    }
+
+    /// DFS from `root_name`. Returns unique transitive packages (by identity
+    /// `(name, version)`), excluding roots themselves. Cycle-safe.
     ///
     /// Dependency strings may be `"name"` or `"name version"` (Cargo multi-version format).
     /// The version suffix is stripped when resolving graph edges so that both forms work.
+    ///
+    /// When a lockfile contains multiple versions of the same package, ALL of them
+    /// are visited (package identity is `(name, version)`, not just `name`).
     pub fn transitive_deps_of(&self, root_name: &str) -> Vec<&LockfilePackage> {
-        let mut visited: HashSet<&str> = HashSet::new();
+        let mut visited: HashSet<(&str, &str)> = HashSet::new();
         let mut stack: Vec<&str> = Vec::new();
         let mut out: Vec<&LockfilePackage> = Vec::new();
 
-        if let Some(root) = self.find(root_name) {
-            visited.insert(&root.name);
+        // Seed with every package matching root_name (multiple versions possible).
+        for root in self.find_all(root_name) {
+            visited.insert((&root.name, &root.version));
             for dep in &root.dependencies {
                 // dep can be "name" or "name version" — use the name only for graph walk.
                 let name = dep.split_whitespace().next().unwrap_or(dep.as_str());
                 stack.push(name);
             }
-        } else {
+        }
+
+        if visited.is_empty() {
             return out;
         }
 
         while let Some(name) = stack.pop() {
-            if !visited.insert(name) {
-                continue;
-            }
-            if let Some(pkg) = self.find(name) {
+            for pkg in self.find_all(name) {
+                let key = (pkg.name.as_str(), pkg.version.as_str());
+                if !visited.insert(key) {
+                    continue;
+                }
                 out.push(pkg);
                 for dep in &pkg.dependencies {
                     let n = dep.split_whitespace().next().unwrap_or(dep.as_str());
@@ -92,7 +106,8 @@ impl LockfileGraph {
     /// dependency names (from `manifest_deps`) that reach it via `transitive_deps_of`.
     ///
     /// Returns a `HashMap<String, Vec<String>>`. When a transitive is not reachable from
-    /// any direct dep, it has no entry.
+    /// any direct dep, it has no entry. Duplicate parent entries (same direct reaching
+    /// the same transitive via multiple paths) are deduplicated.
     pub fn reverse_index(
         &self,
         manifest_deps: &[String],
@@ -110,11 +125,12 @@ impl LockfileGraph {
                     .push(direct.clone());
             }
         }
+        // Dedup parents (same direct can reach a transitive via multiple paths)
+        for v in inverse.values_mut() {
+            v.sort();
+            v.dedup();
+        }
         inverse
-    }
-
-    fn find(&self, name: &str) -> Option<&LockfilePackage> {
-        self.packages.iter().find(|p| p.name == name)
     }
 }
 
@@ -239,5 +255,89 @@ mod tests {
         std::fs::write(tmp.path(), "hello").unwrap();
         let out = read_lockfile_capped(tmp.path()).await.unwrap();
         assert_eq!(out, "hello");
+    }
+
+    #[test]
+    fn test_transitive_deps_of_multi_version_visits_all() {
+        // Cargo commonly pins multiple versions of the same crate. Ensure DFS
+        // visits ALL same-named packages (keyed by (name, version)) rather than
+        // stopping at the first match.
+        let graph = LockfileGraph {
+            packages: vec![
+                LockfilePackage {
+                    name: "root".into(),
+                    version: "0.1.0".into(),
+                    dependencies: vec!["hashbrown".into()],
+                    is_root: true,
+                },
+                LockfilePackage {
+                    name: "hashbrown".into(),
+                    version: "0.15.5".into(),
+                    dependencies: vec!["foundationdb".into()],
+                    is_root: false,
+                },
+                LockfilePackage {
+                    name: "hashbrown".into(),
+                    version: "0.16.1".into(),
+                    dependencies: vec!["allocator-api2".into()],
+                    is_root: false,
+                },
+                LockfilePackage {
+                    name: "foundationdb".into(),
+                    version: "1.0.0".into(),
+                    dependencies: vec![],
+                    is_root: false,
+                },
+                LockfilePackage {
+                    name: "allocator-api2".into(),
+                    version: "0.2.0".into(),
+                    dependencies: vec![],
+                    is_root: false,
+                },
+            ],
+        };
+
+        let transitives = graph.transitive_deps_of("root");
+        let names: Vec<String> = transitives
+            .iter()
+            .map(|p| format!("{}@{}", p.name, p.version))
+            .collect();
+
+        // BOTH hashbrown versions must be visited
+        assert!(names.iter().any(|s| s == "hashbrown@0.15.5"));
+        assert!(names.iter().any(|s| s == "hashbrown@0.16.1"));
+
+        // AND their respective children (attribution across both)
+        assert!(names.iter().any(|s| s == "foundationdb@1.0.0"));
+        assert!(names.iter().any(|s| s == "allocator-api2@0.2.0"));
+    }
+
+    #[test]
+    fn test_find_all_returns_all_matches() {
+        let graph = LockfileGraph {
+            packages: vec![
+                LockfilePackage {
+                    name: "a".into(),
+                    version: "1.0".into(),
+                    dependencies: vec![],
+                    is_root: false,
+                },
+                LockfilePackage {
+                    name: "a".into(),
+                    version: "2.0".into(),
+                    dependencies: vec![],
+                    is_root: false,
+                },
+                LockfilePackage {
+                    name: "b".into(),
+                    version: "1.0".into(),
+                    dependencies: vec![],
+                    is_root: false,
+                },
+            ],
+        };
+        assert_eq!(graph.find_all("a").len(), 2);
+        assert_eq!(graph.find_all("b").len(), 1);
+        assert_eq!(graph.find_all("c").len(), 0);
     }
 }

--- a/dependi-lsp/src/parsers/lockfile_graph.rs
+++ b/dependi-lsp/src/parsers/lockfile_graph.rs
@@ -16,12 +16,14 @@ pub async fn read_lockfile_capped(path: &std::path::Path) -> std::io::Result<Str
     if buf.len() as u64 > MAX_LOCKFILE_BYTES {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!("lockfile exceeds {} MiB cap", MAX_LOCKFILE_BYTES / (1024 * 1024)),
+            format!(
+                "lockfile exceeds {} MiB cap",
+                MAX_LOCKFILE_BYTES / (1024 * 1024)
+            ),
         ));
     }
-    String::from_utf8(buf).map_err(|e| {
-        std::io::Error::new(std::io::ErrorKind::InvalidData, e.utf8_error())
-    })
+    String::from_utf8(buf)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.utf8_error()))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/dependi-lsp/src/parsers/lockfile_graph.rs
+++ b/dependi-lsp/src/parsers/lockfile_graph.rs
@@ -258,7 +258,10 @@ mod tests {
             .collect();
         assert!(!names.contains(&"react".to_string()));
         assert!(names.contains(&"react-dom".to_string()));
-        assert!(!names.contains(&"scheduler".to_string()), "unreachable package must be excluded");
+        assert!(
+            !names.contains(&"scheduler".to_string()),
+            "unreachable package must be excluded"
+        );
     }
 
     #[test]
@@ -266,24 +269,40 @@ mod tests {
         let graph = LockfileGraph {
             packages: vec![
                 LockfilePackage {
-                    name: "react".into(), version: "18.2.0".into(),
-                    dependencies: vec!["scheduler".into()], is_root: true,
+                    name: "react".into(),
+                    version: "18.2.0".into(),
+                    dependencies: vec!["scheduler".into()],
+                    is_root: true,
                 },
                 LockfilePackage {
-                    name: "scheduler".into(), version: "0.23.0".into(),
-                    dependencies: vec![], is_root: false,
+                    name: "scheduler".into(),
+                    version: "0.23.0".into(),
+                    dependencies: vec![],
+                    is_root: false,
                 },
                 LockfilePackage {
                     // Not reachable from "react" — workspace noise
-                    name: "unrelated".into(), version: "1.0.0".into(),
-                    dependencies: vec![], is_root: false,
+                    name: "unrelated".into(),
+                    version: "1.0.0".into(),
+                    dependencies: vec![],
+                    is_root: false,
                 },
             ],
         };
         let manifest: Vec<String> = vec!["react".to_string()];
-        let names: Vec<&str> = graph.transitives_only(&manifest).iter().map(|p| p.name.as_str()).collect();
-        assert!(names.contains(&"scheduler"), "reachable transitive should be included");
-        assert!(!names.contains(&"unrelated"), "unreachable package should NOT be returned");
+        let names: Vec<&str> = graph
+            .transitives_only(&manifest)
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect();
+        assert!(
+            names.contains(&"scheduler"),
+            "reachable transitive should be included"
+        );
+        assert!(
+            !names.contains(&"unrelated"),
+            "unreachable package should NOT be returned"
+        );
         assert!(!names.contains(&"react"), "direct dep should be excluded");
     }
 

--- a/dependi-lsp/src/parsers/lockfile_graph.rs
+++ b/dependi-lsp/src/parsers/lockfile_graph.rs
@@ -1,0 +1,152 @@
+//! Shared graph representation for lockfile contents.
+
+use hashbrown::HashSet;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LockfilePackage {
+    pub name: String,
+    pub version: String,
+    /// Names of packages directly required by this one (no version info).
+    pub dependencies: Vec<String>,
+    /// True when this package is declared in the manifest (a direct dependency).
+    pub is_root: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LockfileGraph {
+    pub packages: Vec<LockfilePackage>,
+}
+
+impl LockfileGraph {
+    /// DFS from `root_name`; returns unique transitive packages (excluding `root_name` itself).
+    /// Returns empty vec if root is unknown. Cycles are handled via a visited set.
+    pub fn transitive_deps_of(&self, root_name: &str) -> Vec<&LockfilePackage> {
+        let mut visited: HashSet<&str> = HashSet::new();
+        let mut stack: Vec<&str> = Vec::new();
+        let mut out: Vec<&LockfilePackage> = Vec::new();
+
+        if let Some(root) = self.find(root_name) {
+            visited.insert(&root.name);
+            for dep in &root.dependencies {
+                stack.push(dep.as_str());
+            }
+        } else {
+            return out;
+        }
+
+        while let Some(name) = stack.pop() {
+            if !visited.insert(name) {
+                continue;
+            }
+            if let Some(pkg) = self.find(name) {
+                out.push(pkg);
+                for dep in &pkg.dependencies {
+                    stack.push(dep.as_str());
+                }
+            }
+        }
+
+        out
+    }
+
+    /// Packages that are not declared in the manifest (pure transitives).
+    pub fn transitives_only(&self, manifest_deps: &[String]) -> Vec<&LockfilePackage> {
+        let set: HashSet<&str> = manifest_deps.iter().map(String::as_str).collect();
+        self.packages
+            .iter()
+            .filter(|p| !set.contains(p.name.as_str()))
+            .collect()
+    }
+
+    fn find(&self, name: &str) -> Option<&LockfilePackage> {
+        self.packages.iter().find(|p| p.name == name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pkg(name: &str, deps: &[&str], is_root: bool) -> LockfilePackage {
+        LockfilePackage {
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            dependencies: deps.iter().map(|s| s.to_string()).collect(),
+            is_root,
+        }
+    }
+
+    #[test]
+    fn test_transitive_deps_of_single_level() {
+        let graph = LockfileGraph {
+            packages: vec![
+                pkg("react", &["react-dom"], true),
+                pkg("react-dom", &[], false),
+            ],
+        };
+        let names: Vec<&str> = graph
+            .transitive_deps_of("react")
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["react-dom"]);
+    }
+
+    #[test]
+    fn test_transitive_deps_of_multi_level() {
+        let graph = LockfileGraph {
+            packages: vec![
+                pkg("react", &["react-dom"], true),
+                pkg("react-dom", &["scheduler"], false),
+                pkg("scheduler", &[], false),
+            ],
+        };
+        let names: Vec<String> = graph
+            .transitive_deps_of("react")
+            .iter()
+            .map(|p| p.name.clone())
+            .collect();
+        assert!(names.contains(&"react-dom".to_string()));
+        assert!(names.contains(&"scheduler".to_string()));
+        assert_eq!(names.len(), 2);
+    }
+
+    #[test]
+    fn test_transitive_deps_of_cyclic() {
+        let graph = LockfileGraph {
+            packages: vec![pkg("a", &["b"], true), pkg("b", &["a"], false)],
+        };
+        let names: Vec<&str> = graph
+            .transitive_deps_of("a")
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["b"]);
+    }
+
+    #[test]
+    fn test_transitive_deps_of_unknown_root() {
+        let graph = LockfileGraph { packages: vec![] };
+        assert!(graph.transitive_deps_of("nope").is_empty());
+    }
+
+    #[test]
+    fn test_transitives_only_excludes_manifest_deps() {
+        let graph = LockfileGraph {
+            packages: vec![
+                pkg("react", &["react-dom"], true),
+                pkg("react-dom", &[], false),
+                pkg("scheduler", &[], false),
+            ],
+        };
+        let manifest: Vec<String> = vec!["react".to_string()];
+        let names: Vec<String> = graph
+            .transitives_only(&manifest)
+            .iter()
+            .map(|p| p.name.clone())
+            .collect();
+        assert!(!names.contains(&"react".to_string()));
+        assert!(names.contains(&"react-dom".to_string()));
+        assert!(names.contains(&"scheduler".to_string()));
+    }
+}

--- a/dependi-lsp/src/parsers/lockfile_graph.rs
+++ b/dependi-lsp/src/parsers/lockfile_graph.rs
@@ -93,13 +93,35 @@ impl LockfileGraph {
         out
     }
 
-    /// Packages that are not declared in the manifest (pure transitives).
+    /// Packages that are reachable from any manifest dep but not declared directly
+    /// in the manifest (pure transitives). Workspace lockfiles can contain packages
+    /// from unrelated projects; those are excluded because they are not reachable
+    /// from any direct dependency.
     pub fn transitives_only(&self, manifest_deps: &[String]) -> Vec<&LockfilePackage> {
-        let set: HashSet<&str> = manifest_deps.iter().map(String::as_str).collect();
-        self.packages
-            .iter()
-            .filter(|p| !set.contains(p.name.as_str()))
-            .collect()
+        // Build the set of direct package names
+        let direct_set: HashSet<&str> = manifest_deps.iter().map(String::as_str).collect();
+
+        // Collect packages reachable from any direct dep. We de-dup by (name, version)
+        // to avoid returning the same package multiple times when several direct deps
+        // reach it.
+        let mut seen: HashSet<(&str, &str)> = HashSet::new();
+        let mut out: Vec<&LockfilePackage> = Vec::new();
+
+        for direct in manifest_deps {
+            for pkg in self.transitive_deps_of(direct) {
+                // Skip packages whose name is itself in the manifest — they are
+                // direct deps, not transitives.
+                if direct_set.contains(pkg.name.as_str()) {
+                    continue;
+                }
+                let key = (pkg.name.as_str(), pkg.version.as_str());
+                if seen.insert(key) {
+                    out.push(pkg);
+                }
+            }
+        }
+
+        out
     }
 
     /// Build an inverse index: for each transitive package name, the set of direct
@@ -222,6 +244,9 @@ mod tests {
             packages: vec![
                 pkg("react", &["react-dom"], true),
                 pkg("react-dom", &[], false),
+                // "scheduler" is NOT reachable from "react" in this graph, so it
+                // should no longer be returned now that transitives_only uses
+                // reachability rather than a simple name exclusion.
                 pkg("scheduler", &[], false),
             ],
         };
@@ -233,7 +258,33 @@ mod tests {
             .collect();
         assert!(!names.contains(&"react".to_string()));
         assert!(names.contains(&"react-dom".to_string()));
-        assert!(names.contains(&"scheduler".to_string()));
+        assert!(!names.contains(&"scheduler".to_string()), "unreachable package must be excluded");
+    }
+
+    #[test]
+    fn test_transitives_only_excludes_unreachable_packages() {
+        let graph = LockfileGraph {
+            packages: vec![
+                LockfilePackage {
+                    name: "react".into(), version: "18.2.0".into(),
+                    dependencies: vec!["scheduler".into()], is_root: true,
+                },
+                LockfilePackage {
+                    name: "scheduler".into(), version: "0.23.0".into(),
+                    dependencies: vec![], is_root: false,
+                },
+                LockfilePackage {
+                    // Not reachable from "react" — workspace noise
+                    name: "unrelated".into(), version: "1.0.0".into(),
+                    dependencies: vec![], is_root: false,
+                },
+            ],
+        };
+        let manifest: Vec<String> = vec!["react".to_string()];
+        let names: Vec<&str> = graph.transitives_only(&manifest).iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"scheduler"), "reachable transitive should be included");
+        assert!(!names.contains(&"unrelated"), "unreachable package should NOT be returned");
+        assert!(!names.contains(&"react"), "direct dep should be excluded");
     }
 
     #[tokio::test]

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -55,13 +55,13 @@ pub trait Parser: Send + Sync {
 
 pub mod cargo;
 pub mod cargo_lock;
-pub mod lockfile_graph;
 pub mod composer_lock;
 pub mod csharp;
 pub mod dart;
 pub mod gemfile_lock;
 pub mod go;
 pub mod go_sum;
+pub mod lockfile_graph;
 pub mod maven;
 pub mod npm;
 pub mod npm_lock;

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -55,6 +55,7 @@ pub trait Parser: Send + Sync {
 
 pub mod cargo;
 pub mod cargo_lock;
+pub mod lockfile_graph;
 pub mod composer_lock;
 pub mod csharp;
 pub mod dart;

--- a/dependi-lsp/src/parsers/npm_lock.rs
+++ b/dependi-lsp/src/parsers/npm_lock.rs
@@ -442,7 +442,12 @@ pub fn parse_pnpm_lock_graph(content: &str) -> LockfileGraph {
 
     for line in content.lines() {
         // Exit packages section on any new top-level key (e.g. "snapshots:", "settings:", etc.)
-        if in_packages && !line.is_empty() && !line.starts_with(' ') && !line.starts_with('\t') && line != "packages:" {
+        if in_packages
+            && !line.is_empty()
+            && !line.starts_with(' ')
+            && !line.starts_with('\t')
+            && line != "packages:"
+        {
             in_packages = false;
             if let Some(finish) = current.take() {
                 graph.packages.push(finish);
@@ -1142,8 +1147,10 @@ snapshots:
         let names: Vec<&str> = graph.packages.iter().map(|p| p.name.as_str()).collect();
         // Should include react but NOT react-dom (which lives under snapshots:)
         assert!(names.contains(&"react"));
-        assert!(!names.iter().any(|n| n.contains('(')),
-            "no entry name should contain a peer-suffix paren, got {names:?}");
+        assert!(
+            !names.iter().any(|n| n.contains('(')),
+            "no entry name should contain a peer-suffix paren, got {names:?}"
+        );
     }
 
     #[test]
@@ -1156,7 +1163,12 @@ packages:
     resolution: {integrity: sha512-xxx}
 "#;
         let graph = parse_pnpm_lock_graph(content);
-        assert!(graph.packages.iter().any(|p| p.name == "react-dom" && p.version == "18.2.0"));
+        assert!(
+            graph
+                .packages
+                .iter()
+                .any(|p| p.name == "react-dom" && p.version == "18.2.0")
+        );
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/npm_lock.rs
+++ b/dependi-lsp/src/parsers/npm_lock.rs
@@ -1186,7 +1186,7 @@ packages:
         let graph = parse_pnpm_lock_graph(content);
         let names: Vec<&str> = graph.packages.iter().map(|p| p.name.as_str()).collect();
         assert!(
-            names.iter().any(|n| *n == "@types/node"),
+            names.contains(&"@types/node"),
             "quoted key should yield unquoted name, got {names:?}"
         );
         let ty = graph.packages.iter().find(|p| p.name == "@types/node").unwrap();

--- a/dependi-lsp/src/parsers/npm_lock.rs
+++ b/dependi-lsp/src/parsers/npm_lock.rs
@@ -499,10 +499,12 @@ pub fn parse_pnpm_lock_graph(content: &str) -> LockfileGraph {
         }
         if in_deps && line.starts_with("      ") {
             let trimmed = line.trim_start();
-            let dep_name = trimmed
+            let dep_name_raw = trimmed
                 .split_once(':')
                 .map(|(n, _)| n.trim())
                 .unwrap_or(trimmed.trim());
+            // pnpm v9 quotes scoped names like '@emotion/cache'
+            let dep_name = dep_name_raw.trim_matches('\'').trim_matches('"');
             if !dep_name.is_empty()
                 && let Some(cur) = current.as_mut()
             {
@@ -1195,6 +1197,31 @@ packages:
             .find(|p| p.name == "@types/node")
             .unwrap();
         assert_eq!(ty.version, "20.11.5");
+    }
+
+    #[test]
+    fn test_parse_pnpm_lock_graph_unquotes_scoped_dep_names() {
+        let content = r#"
+lockfileVersion: '9.0'
+
+packages:
+
+  react@18.2.0:
+    resolution: {integrity: sha512-xxx}
+    dependencies:
+      '@emotion/cache': 11.11.0
+      react-dom: 18.2.0
+
+  '@emotion/cache@11.11.0':
+    resolution: {integrity: sha512-yyy}
+"#;
+        let graph = parse_pnpm_lock_graph(content);
+        let react = graph.packages.iter().find(|p| p.name == "react").unwrap();
+        assert!(
+            react.dependencies.contains(&"@emotion/cache".to_string()),
+            "scoped dep name should be unquoted, got {:?}", react.dependencies
+        );
+        assert!(react.dependencies.contains(&"react-dom".to_string()));
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/npm_lock.rs
+++ b/dependi-lsp/src/parsers/npm_lock.rs
@@ -1189,7 +1189,11 @@ packages:
             names.contains(&"@types/node"),
             "quoted key should yield unquoted name, got {names:?}"
         );
-        let ty = graph.packages.iter().find(|p| p.name == "@types/node").unwrap();
+        let ty = graph
+            .packages
+            .iter()
+            .find(|p| p.name == "@types/node")
+            .unwrap();
         assert_eq!(ty.version, "20.11.5");
     }
 

--- a/dependi-lsp/src/parsers/npm_lock.rs
+++ b/dependi-lsp/src/parsers/npm_lock.rs
@@ -480,6 +480,8 @@ pub fn parse_pnpm_lock_graph(content: &str) -> LockfileGraph {
                 graph.packages.push(finish);
             }
             let key = rest.trim_end_matches(':').trim();
+            // Strip optional surrounding quotes (pnpm v9 may quote scoped names).
+            let key = key.trim_matches('\'').trim_matches('"');
             if let Some((name, version)) = split_pnpm_key(key) {
                 current = Some(LockfilePackage {
                     name,
@@ -1169,6 +1171,26 @@ packages:
                 .iter()
                 .any(|p| p.name == "react-dom" && p.version == "18.2.0")
         );
+    }
+
+    #[test]
+    fn test_parse_pnpm_lock_graph_strips_quoted_keys() {
+        let content = r#"
+lockfileVersion: '9.0'
+
+packages:
+
+  '@types/node@20.11.5':
+    resolution: {integrity: sha512-xxx}
+"#;
+        let graph = parse_pnpm_lock_graph(content);
+        let names: Vec<&str> = graph.packages.iter().map(|p| p.name.as_str()).collect();
+        assert!(
+            names.iter().any(|n| *n == "@types/node"),
+            "quoted key should yield unquoted name, got {names:?}"
+        );
+        let ty = graph.packages.iter().find(|p| p.name == "@types/node").unwrap();
+        assert_eq!(ty.version, "20.11.5");
     }
 
     #[test]

--- a/dependi-lsp/src/parsers/npm_lock.rs
+++ b/dependi-lsp/src/parsers/npm_lock.rs
@@ -448,8 +448,20 @@ pub fn parse_pnpm_lock_graph(content: &str) -> LockfileGraph {
         if !in_packages {
             continue;
         }
-        // Package entry: "  /name@ver:" or "  /@scope/name@ver:"
-        if let Some(rest) = line.strip_prefix("  /") {
+        // Package entry: "  /name@ver:" (v6) or "  name@ver:" (v9)
+        let entry_key = if let Some(rest) = line.strip_prefix("  /") {
+            Some(rest)
+        } else if line.starts_with("  ")
+            && !line.starts_with("   ")
+            && line.trim().contains('@')
+            && line.trim_end().ends_with(':')
+        {
+            Some(&line[2..])
+        } else {
+            None
+        };
+
+        if let Some(rest) = entry_key {
             if let Some(finish) = current.take() {
                 graph.packages.push(finish);
             }
@@ -1062,6 +1074,33 @@ packages:
         assert_eq!(react.dependencies, vec!["scheduler".to_string()]);
     }
 
+    #[test]
+    fn test_parse_pnpm_lock_graph_v9() {
+        let content = r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      react: 18.2.0
+
+packages:
+  react@18.2.0:
+    resolution: {integrity: sha512-xxx}
+    dependencies:
+      scheduler: 0.23.0
+  scheduler@0.23.0:
+    resolution: {integrity: sha512-yyy}
+"#;
+        let graph = parse_pnpm_lock_graph(content);
+        let names: Vec<&str> = graph.packages.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"react"));
+        assert!(names.contains(&"scheduler"));
+        let react = graph.packages.iter().find(|p| p.name == "react").unwrap();
+        assert_eq!(react.version, "18.2.0");
+        assert_eq!(react.dependencies, vec!["scheduler".to_string()]);
+    }
+
     // -----------------------------------------------------------------------
     // parse_yarn_lock_graph
     // -----------------------------------------------------------------------
@@ -1080,7 +1119,12 @@ packages:
   version "0.23.0"
 "#;
         let graph = parse_yarn_lock_graph(content);
-        assert!(graph.packages.iter().any(|p| p.name == "react" && p.version == "18.2.0"));
+        assert!(
+            graph
+                .packages
+                .iter()
+                .any(|p| p.name == "react" && p.version == "18.2.0")
+        );
         let react = graph.packages.iter().find(|p| p.name == "react").unwrap();
         assert!(react.dependencies.contains(&"scheduler".to_string()));
     }

--- a/dependi-lsp/src/parsers/npm_lock.rs
+++ b/dependi-lsp/src/parsers/npm_lock.rs
@@ -10,6 +10,8 @@ use std::path::{Path, PathBuf};
 
 use hashbrown::HashMap;
 
+use crate::parsers::lockfile_graph::{LockfileGraph, LockfilePackage};
+
 /// Type of Node.js lockfile detected.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum NpmLockfileType {
@@ -380,6 +382,189 @@ fn clean_jsonc(content: &str) -> String {
     }
 
     result
+}
+
+// ---------------------------------------------------------------------------
+// Graph extraction — package-lock.json, pnpm-lock.yaml, yarn.lock v1
+// ---------------------------------------------------------------------------
+
+/// Parse a `package-lock.json` (lockfile v2/v3 flat `packages` format) into a graph.
+///
+/// v1 nested format is intentionally not supported here (superseded since npm 7, 2020).
+pub fn parse_package_lock_graph(content: &str) -> LockfileGraph {
+    let mut graph = LockfileGraph::default();
+    let value: serde_json::Value = match serde_json::from_str(content) {
+        Ok(v) => v,
+        Err(_) => return graph,
+    };
+
+    let Some(packages) = value.get("packages").and_then(|p| p.as_object()) else {
+        return graph;
+    };
+
+    for (key, entry) in packages {
+        if key.is_empty() {
+            continue; // root entry represents the manifest itself
+        }
+        // Key form "node_modules/<name>" or "node_modules/@scope/name"
+        let name = match key.rsplit_once("node_modules/") {
+            Some((_, rest)) => rest.to_string(),
+            None => continue,
+        };
+        let Some(version) = entry.get("version").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let dependencies: Vec<String> = entry
+            .get("dependencies")
+            .and_then(|d| d.as_object())
+            .map(|obj| obj.keys().cloned().collect())
+            .unwrap_or_default();
+
+        graph.packages.push(LockfilePackage {
+            name,
+            version: version.to_string(),
+            dependencies,
+            is_root: false,
+        });
+    }
+
+    graph
+}
+
+/// Parse a pnpm-lock.yaml into a graph. Uses a minimal line-based walker because the
+/// project has no YAML parser in dependencies; this mirrors the approach of existing
+/// pnpm parsing in the file.
+pub fn parse_pnpm_lock_graph(content: &str) -> LockfileGraph {
+    let mut graph = LockfileGraph::default();
+    let mut in_packages = false;
+    let mut current: Option<LockfilePackage> = None;
+    let mut in_deps = false;
+
+    for line in content.lines() {
+        if line == "packages:" {
+            in_packages = true;
+            continue;
+        }
+        if !in_packages {
+            continue;
+        }
+        // Package entry: "  /name@ver:" or "  /@scope/name@ver:"
+        if let Some(rest) = line.strip_prefix("  /") {
+            if let Some(finish) = current.take() {
+                graph.packages.push(finish);
+            }
+            let key = rest.trim_end_matches(':').trim();
+            if let Some((name, version)) = split_pnpm_key(key) {
+                current = Some(LockfilePackage {
+                    name,
+                    version,
+                    dependencies: Vec::new(),
+                    is_root: false,
+                });
+            }
+            in_deps = false;
+            continue;
+        }
+        if line.trim() == "dependencies:" {
+            in_deps = true;
+            continue;
+        }
+        if in_deps && line.starts_with("      ") {
+            let trimmed = line.trim_start();
+            let dep_name = trimmed
+                .split_once(':')
+                .map(|(n, _)| n.trim())
+                .unwrap_or(trimmed.trim());
+            if !dep_name.is_empty()
+                && let Some(cur) = current.as_mut()
+            {
+                cur.dependencies.push(dep_name.to_string());
+            }
+        } else if !line.starts_with("      ") {
+            in_deps = false;
+        }
+    }
+
+    if let Some(finish) = current {
+        graph.packages.push(finish);
+    }
+    graph
+}
+
+/// Split a pnpm key like "react@18.2.0" or "@babel/core@7.0.0" into (name, version).
+fn split_pnpm_key(key: &str) -> Option<(String, String)> {
+    let at = key.rfind('@')?;
+    if at == 0 {
+        return None; // scoped name starts with '@' — first '@' is not the separator
+    }
+    Some((key[..at].to_string(), key[at + 1..].to_string()))
+}
+
+/// Parse yarn.lock (v1 format) into a graph. v2+ (Berry) uses a different format,
+/// out of scope here.
+pub fn parse_yarn_lock_graph(content: &str) -> LockfileGraph {
+    let mut graph = LockfileGraph::default();
+    let mut current: Option<LockfilePackage> = None;
+    let mut in_deps = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+
+        if !line.starts_with(' ')
+            && line.contains('@')
+            && line.ends_with(':')
+            && !line.starts_with('#')
+        {
+            if let Some(finished) = current.take() {
+                graph.packages.push(finished);
+            }
+            let header = line.trim_end_matches(':').trim();
+            // Multiple keys comma-separated; take the first
+            let first_key_raw = header.split(',').next().unwrap_or(header).trim();
+            let first_key = first_key_raw.trim_matches('"');
+            if let Some(at_pos) = first_key.rfind('@')
+                && at_pos != 0
+            {
+                current = Some(LockfilePackage {
+                    name: first_key[..at_pos].to_string(),
+                    version: String::new(),
+                    dependencies: Vec::new(),
+                    is_root: false,
+                });
+            }
+            in_deps = false;
+            continue;
+        }
+
+        if let Some(cur) = current.as_mut() {
+            if let Some(v) = trimmed.strip_prefix("version ") {
+                cur.version = v.trim().trim_matches('"').to_string();
+                in_deps = false;
+                continue;
+            }
+            if trimmed == "dependencies:" {
+                in_deps = true;
+                continue;
+            }
+            if in_deps && line.starts_with("    ") {
+                let name = trimmed
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or("")
+                    .trim_matches('"');
+                if !name.is_empty() {
+                    cur.dependencies.push(name.to_string());
+                }
+            } else if !line.starts_with("  ") {
+                in_deps = false;
+            }
+        }
+    }
+
+    if let Some(finished) = current {
+        graph.packages.push(finished);
+    }
+    graph
 }
 
 // ---------------------------------------------------------------------------
@@ -818,5 +1003,85 @@ packages:
         let content = r#"{"packages": {"a": ["a@1.2.3"]}}"#;
         let map = parse_npm_lockfile(content, NpmLockfileType::BunLock);
         assert_eq!(map.get("a").map(|s| s.as_str()), Some("1.2.3"));
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_package_lock_graph
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_package_lock_graph_v3() {
+        let content = r#"{
+  "name": "demo",
+  "lockfileVersion": 3,
+  "packages": {
+    "": { "name": "demo", "version": "1.0.0", "dependencies": { "react": "^18.0.0" } },
+    "node_modules/react": { "version": "18.2.0", "dependencies": { "scheduler": "^0.23.0" } },
+    "node_modules/scheduler": { "version": "0.23.0" }
+  }
+}"#;
+        let graph = parse_package_lock_graph(content);
+        let names: Vec<&str> = graph.packages.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"react"));
+        assert!(names.contains(&"scheduler"));
+        let react = graph.packages.iter().find(|p| p.name == "react").unwrap();
+        assert_eq!(react.version, "18.2.0");
+        assert_eq!(react.dependencies, vec!["scheduler".to_string()]);
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_pnpm_lock_graph
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_pnpm_lock_graph() {
+        let content = r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      react:
+        specifier: ^18.0.0
+        version: 18.2.0
+
+packages:
+  /react@18.2.0:
+    resolution: {integrity: sha512-xxx}
+    dependencies:
+      scheduler: 0.23.0
+  /scheduler@0.23.0:
+    resolution: {integrity: sha512-yyy}
+"#;
+        let graph = parse_pnpm_lock_graph(content);
+        let names: Vec<&str> = graph.packages.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"react"));
+        assert!(names.contains(&"scheduler"));
+        let react = graph.packages.iter().find(|p| p.name == "react").unwrap();
+        assert_eq!(react.version, "18.2.0");
+        assert_eq!(react.dependencies, vec!["scheduler".to_string()]);
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_yarn_lock_graph
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_yarn_lock_graph_v1() {
+        let content = r#"
+# THIS IS AN AUTOGENERATED FILE
+
+"react@^18.0.0":
+  version "18.2.0"
+  dependencies:
+    scheduler "^0.23.0"
+
+"scheduler@^0.23.0":
+  version "0.23.0"
+"#;
+        let graph = parse_yarn_lock_graph(content);
+        assert!(graph.packages.iter().any(|p| p.name == "react" && p.version == "18.2.0"));
+        let react = graph.packages.iter().find(|p| p.name == "react").unwrap();
+        assert!(react.dependencies.contains(&"scheduler".to_string()));
     }
 }

--- a/dependi-lsp/src/parsers/npm_lock.rs
+++ b/dependi-lsp/src/parsers/npm_lock.rs
@@ -441,6 +441,15 @@ pub fn parse_pnpm_lock_graph(content: &str) -> LockfileGraph {
     let mut in_deps = false;
 
     for line in content.lines() {
+        // Exit packages section on any new top-level key (e.g. "snapshots:", "settings:", etc.)
+        if in_packages && !line.is_empty() && !line.starts_with(' ') && !line.starts_with('\t') && line != "packages:" {
+            in_packages = false;
+            if let Some(finish) = current.take() {
+                graph.packages.push(finish);
+            }
+            continue;
+        }
+
         if line == "packages:" {
             in_packages = true;
             continue;
@@ -504,12 +513,20 @@ pub fn parse_pnpm_lock_graph(content: &str) -> LockfileGraph {
 }
 
 /// Split a pnpm key like "react@18.2.0" or "@babel/core@7.0.0" into (name, version).
+///
+/// Strips peer-dep suffix before splitting: "react-dom@18.2.0(react@18.2.0)" → ("react-dom", "18.2.0").
 fn split_pnpm_key(key: &str) -> Option<(String, String)> {
-    let at = key.rfind('@')?;
+    // Peer-dep suffix in pnpm v9: "name@ver(peer@ver)(other@ver)" — trim at the first '('
+    // that isn't part of the name. Package names can't contain '(' so this is safe.
+    let base = match key.find('(') {
+        Some(idx) => &key[..idx],
+        None => key,
+    };
+    let at = base.rfind('@')?;
     if at == 0 {
         return None; // scoped name starts with '@' — first '@' is not the separator
     }
-    Some((key[..at].to_string(), key[at + 1..].to_string()))
+    Some((base[..at].to_string(), base[at + 1..].to_string()))
 }
 
 /// Parse yarn.lock (v1 format) into a graph. v2+ (Berry) uses a different format,
@@ -1104,6 +1121,43 @@ packages:
     // -----------------------------------------------------------------------
     // parse_yarn_lock_graph
     // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_pnpm_lock_graph_exits_packages_section_on_snapshots() {
+        let content = r#"
+lockfileVersion: '9.0'
+
+packages:
+
+  react@18.2.0:
+    resolution: {integrity: sha512-xxx}
+
+snapshots:
+
+  react-dom@18.2.0(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+"#;
+        let graph = parse_pnpm_lock_graph(content);
+        let names: Vec<&str> = graph.packages.iter().map(|p| p.name.as_str()).collect();
+        // Should include react but NOT react-dom (which lives under snapshots:)
+        assert!(names.contains(&"react"));
+        assert!(!names.iter().any(|n| n.contains('(')),
+            "no entry name should contain a peer-suffix paren, got {names:?}");
+    }
+
+    #[test]
+    fn test_split_pnpm_key_handles_peer_suffix() {
+        // Only run if split_pnpm_key is accessible; otherwise test through parse_pnpm_lock_graph
+        let content = r#"
+lockfileVersion: '9.0'
+packages:
+  react-dom@18.2.0(react@18.2.0):
+    resolution: {integrity: sha512-xxx}
+"#;
+        let graph = parse_pnpm_lock_graph(content);
+        assert!(graph.packages.iter().any(|p| p.name == "react-dom" && p.version == "18.2.0"));
+    }
 
     #[test]
     fn test_parse_yarn_lock_graph_v1() {

--- a/dependi-lsp/src/parsers/npm_lock.rs
+++ b/dependi-lsp/src/parsers/npm_lock.rs
@@ -1219,7 +1219,8 @@ packages:
         let react = graph.packages.iter().find(|p| p.name == "react").unwrap();
         assert!(
             react.dependencies.contains(&"@emotion/cache".to_string()),
-            "scoped dep name should be unquoted, got {:?}", react.dependencies
+            "scoped dep name should be unquoted, got {:?}",
+            react.dependencies
         );
         assert!(react.dependencies.contains(&"react-dom".to_string()));
     }

--- a/dependi-lsp/src/parsers/python_lock.rs
+++ b/dependi-lsp/src/parsers/python_lock.rs
@@ -10,6 +10,8 @@ use std::path::{Path, PathBuf};
 
 use hashbrown::HashMap;
 
+use crate::parsers::lockfile_graph::{LockfileGraph, LockfilePackage};
+
 /// Type of Python lockfile detected.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PythonLockfileType {
@@ -247,6 +249,121 @@ fn parse_pipfile_lock(content: &str) -> HashMap<String, String> {
     }
 
     map
+}
+
+// ---------------------------------------------------------------------------
+// Graph parsers (lockfile → LockfileGraph)
+// ---------------------------------------------------------------------------
+
+/// Parse poetry.lock into a graph.
+pub fn parse_poetry_lock_graph(content: &str) -> LockfileGraph {
+    let mut graph = LockfileGraph::default();
+    let value: toml::Value = match toml::from_str(content) {
+        Ok(v) => v,
+        Err(_) => return graph,
+    };
+    let Some(packages) = value.get("package").and_then(|p| p.as_array()) else {
+        return graph;
+    };
+    for pkg in packages {
+        let Some(name) = pkg.get("name").and_then(|n| n.as_str()) else {
+            continue;
+        };
+        let Some(version) = pkg.get("version").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let deps = pkg
+            .get("dependencies")
+            .and_then(|d| d.as_table())
+            .map(|t| {
+                t.keys()
+                    .map(|k| normalize_python_name(k))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        graph.packages.push(LockfilePackage {
+            name: normalize_python_name(name),
+            version: version.to_string(),
+            dependencies: deps,
+            is_root: false,
+        });
+    }
+    graph
+}
+
+/// Parse Pipfile.lock into a graph. Pipfile.lock does NOT record sub-deps natively;
+/// the graph will include all packages but edges are limited to what's explicitly present.
+pub fn parse_pipfile_lock_graph(content: &str) -> LockfileGraph {
+    let mut graph = LockfileGraph::default();
+    let value: serde_json::Value = match serde_json::from_str(content) {
+        Ok(v) => v,
+        Err(_) => return graph,
+    };
+    for section in &["default", "develop"] {
+        let Some(obj) = value.get(section).and_then(|s| s.as_object()) else {
+            continue;
+        };
+        for (name, entry) in obj {
+            let Some(version_raw) = entry.get("version").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let version = version_raw.trim_start_matches("==").to_string();
+            let deps: Vec<String> = entry
+                .get("dependencies")
+                .and_then(|d| d.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|e| e.as_str())
+                        .map(normalize_python_name)
+                        .collect()
+                })
+                .unwrap_or_default();
+            graph.packages.push(LockfilePackage {
+                name: normalize_python_name(name),
+                version,
+                dependencies: deps,
+                is_root: false,
+            });
+        }
+    }
+    graph
+}
+
+/// Parse uv.lock into a graph.
+pub fn parse_uv_lock_graph(content: &str) -> LockfileGraph {
+    let mut graph = LockfileGraph::default();
+    let value: toml::Value = match toml::from_str(content) {
+        Ok(v) => v,
+        Err(_) => return graph,
+    };
+    let Some(packages) = value.get("package").and_then(|p| p.as_array()) else {
+        return graph;
+    };
+    for pkg in packages {
+        let Some(name) = pkg.get("name").and_then(|n| n.as_str()) else {
+            continue;
+        };
+        let Some(version) = pkg.get("version").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let deps = pkg
+            .get("dependencies")
+            .and_then(|d| d.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|item| item.get("name").and_then(|n| n.as_str()))
+                    .map(normalize_python_name)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        graph.packages.push(LockfilePackage {
+            name: normalize_python_name(name),
+            version: version.to_string(),
+            dependencies: deps,
+            is_root: false,
+        });
+    }
+    graph
 }
 
 // ---------------------------------------------------------------------------
@@ -765,5 +882,71 @@ version = "6.1"
     fn parse_invalid_toml() {
         let map = parse_toml_package_array("not valid toml ][");
         assert!(map.is_empty());
+    }
+
+    // -- graph parsers --------------------------------------------------------
+
+    #[test]
+    fn test_parse_poetry_lock_graph() {
+        let content = r#"
+[[package]]
+name = "requests"
+version = "2.31.0"
+
+[package.dependencies]
+urllib3 = ">=1.21.1,<3"
+certifi = ">=2017.4.17"
+
+[[package]]
+name = "urllib3"
+version = "2.0.7"
+
+[[package]]
+name = "certifi"
+version = "2023.11.17"
+"#;
+        let graph = parse_poetry_lock_graph(content);
+        let requests = graph.packages.iter().find(|p| p.name == "requests").unwrap();
+        assert_eq!(requests.version, "2.31.0");
+        assert!(requests.dependencies.contains(&"urllib3".to_string()));
+        assert!(requests.dependencies.contains(&"certifi".to_string()));
+    }
+
+    #[test]
+    fn test_parse_pipfile_lock_graph() {
+        let content = r#"{
+  "default": {
+    "requests": { "version": "==2.31.0", "dependencies": ["urllib3"] },
+    "urllib3": { "version": "==2.0.7" }
+  },
+  "develop": {}
+}"#;
+        let graph = parse_pipfile_lock_graph(content);
+        let requests = graph.packages.iter().find(|p| p.name == "requests").unwrap();
+        assert_eq!(requests.version, "2.31.0");
+        assert!(requests.dependencies.contains(&"urllib3".to_string()));
+    }
+
+    #[test]
+    fn test_parse_uv_lock_graph() {
+        let content = r#"
+version = 1
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+dependencies = [
+    { name = "urllib3" },
+    { name = "certifi" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.0.7"
+"#;
+        let graph = parse_uv_lock_graph(content);
+        let requests = graph.packages.iter().find(|p| p.name == "requests").unwrap();
+        assert!(requests.dependencies.contains(&"urllib3".to_string()));
+        assert!(requests.dependencies.contains(&"certifi".to_string()));
     }
 }

--- a/dependi-lsp/src/parsers/python_lock.rs
+++ b/dependi-lsp/src/parsers/python_lock.rs
@@ -906,7 +906,11 @@ name = "certifi"
 version = "2023.11.17"
 "#;
         let graph = parse_poetry_lock_graph(content);
-        let requests = graph.packages.iter().find(|p| p.name == "requests").unwrap();
+        let requests = graph
+            .packages
+            .iter()
+            .find(|p| p.name == "requests")
+            .unwrap();
         assert_eq!(requests.version, "2.31.0");
         assert!(requests.dependencies.contains(&"urllib3".to_string()));
         assert!(requests.dependencies.contains(&"certifi".to_string()));
@@ -922,7 +926,11 @@ version = "2023.11.17"
   "develop": {}
 }"#;
         let graph = parse_pipfile_lock_graph(content);
-        let requests = graph.packages.iter().find(|p| p.name == "requests").unwrap();
+        let requests = graph
+            .packages
+            .iter()
+            .find(|p| p.name == "requests")
+            .unwrap();
         assert_eq!(requests.version, "2.31.0");
         assert!(requests.dependencies.contains(&"urllib3".to_string()));
     }
@@ -945,7 +953,11 @@ name = "urllib3"
 version = "2.0.7"
 "#;
         let graph = parse_uv_lock_graph(content);
-        let requests = graph.packages.iter().find(|p| p.name == "requests").unwrap();
+        let requests = graph
+            .packages
+            .iter()
+            .find(|p| p.name == "requests")
+            .unwrap();
         assert!(requests.dependencies.contains(&"urllib3".to_string()));
         assert!(requests.dependencies.contains(&"certifi".to_string()));
     }

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -67,7 +67,9 @@ pub fn create_diagnostics(
                     })
                     .collect();
 
-                if !filtered_vulns.is_empty() {
+                if !filtered_vulns.is_empty()
+                    || !version_info.transitive_vulnerabilities.is_empty()
+                {
                     diagnostics.push(create_vulnerability_summary_diagnostic(
                         dep,
                         &filtered_vulns,
@@ -363,9 +365,13 @@ fn create_vulnerability_summary_diagnostic(
         .iter()
         .map(|t| &t.vulnerability.severity)
         .max_by_key(|s| severity_to_num(s));
-    let max_severity = match max_transitive_sev {
-        Some(ts) if severity_to_num(ts) > severity_to_num(max_direct_sev) => ts,
-        _ => max_direct_sev,
+    let max_severity = if vulns.is_empty() {
+        max_transitive_sev.unwrap_or(&VulnerabilitySeverity::Low)
+    } else {
+        match max_transitive_sev {
+            Some(ts) if severity_to_num(ts) > severity_to_num(max_direct_sev) => ts,
+            _ => max_direct_sev,
+        }
     };
 
     let diagnostic_severity = match max_severity {
@@ -374,19 +380,26 @@ fn create_vulnerability_summary_diagnostic(
         VulnerabilitySeverity::Low => DiagnosticSeverity::HINT,
     };
 
-    // Build summary message
-    let vuln_word = if count == 1 { "vuln" } else { "vulns" };
-    let vuln_ids: Vec<_> = vulns.iter().map(|v| v.id.as_str()).collect();
-    let mut message = format!("⚠ {count} {vuln_word}: {}", vuln_ids.join(", "));
+    // Build summary message: direct only, transitive only, or both
+    let message = if vulns.is_empty() {
+        // Transitive-only case
+        build_transitive_summary_message(transitive_vulns)
+    } else {
+        let vuln_word = if count == 1 { "vuln" } else { "vulns" };
+        let vuln_ids: Vec<_> = vulns.iter().map(|v| v.id.as_str()).collect();
+        let mut msg = format!("⚠ {count} {vuln_word}: {}", vuln_ids.join(", "));
+        if !transitive_vulns.is_empty() {
+            let tv_msg = build_transitive_summary_message(transitive_vulns);
+            msg.push_str(" — ");
+            msg.push_str(&tv_msg);
+        }
+        msg
+    };
 
-    // Append transitive vulnerability summary if present
-    if !transitive_vulns.is_empty() {
-        let tv_msg = build_transitive_summary_message(transitive_vulns);
-        message.push_str(" — ");
-        message.push_str(&tv_msg);
-    }
+    // The diagnostic code uses the total count (direct + transitive CVE entries)
+    let total_count = count + transitive_vulns.len();
 
-    // Collect related information for all vulnerabilities
+    // Collect related information for direct vulnerabilities
     let related_info: Vec<_> = vulns
         .iter()
         .filter_map(|&vuln| {
@@ -418,7 +431,7 @@ fn create_vulnerability_summary_diagnostic(
             },
         },
         severity: Some(diagnostic_severity),
-        code: Some(NumberOrString::String(format!("{count}-vulns"))),
+        code: Some(NumberOrString::String(format!("{total_count}-vulns"))),
         source: Some("dependi-security".to_string()),
         message,
         related_information: (!related_info.is_empty()).then_some(related_info),
@@ -1271,5 +1284,60 @@ mod tests {
             !yanked_diags[0].message.contains("crates.io"),
             "Yanked diagnostic should NOT reference 'crates.io' for npm packages"
         );
+    }
+
+    #[test]
+    fn test_diagnostic_fires_on_transitive_only_vulns() {
+        use crate::registries::{TransitiveVuln, Vulnerability, VulnerabilitySeverity, VersionInfo};
+
+        let deps = vec![create_test_dependency("my-dep", "1.0.0", 5)];
+        let cache = MemoryCache::new();
+        cache.insert(
+            "test:my-dep".to_string(),
+            VersionInfo {
+                latest: Some("1.0.0".to_string()),
+                transitive_vulnerabilities: vec![TransitiveVuln {
+                    package_name: "scheduler".into(),
+                    package_version: "1.2.3".into(),
+                    vulnerability: Vulnerability {
+                        id: "CVE-1".into(),
+                        severity: VulnerabilitySeverity::High,
+                        description: "desc".into(),
+                        url: None,
+                    },
+                }],
+                ..Default::default()
+            },
+        );
+
+        let diagnostics = create_diagnostics(
+            &deps,
+            &cache,
+            |name| format!("test:{name}"),
+            None,
+            FileType::Cargo,
+        );
+
+        let vuln_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| {
+                d.code
+                    .as_ref()
+                    .is_some_and(|c| matches!(c, NumberOrString::String(s) if s.contains("vulns")))
+            })
+            .collect();
+
+        assert_eq!(vuln_diags.len(), 1, "Should emit diagnostic for transitive-only vulns");
+        assert!(
+            vuln_diags[0].message.contains("transitive"),
+            "Message should contain 'transitive', got: {}",
+            vuln_diags[0].message
+        );
+        assert!(
+            vuln_diags[0].message.contains("scheduler@1.2.3"),
+            "Message should contain 'scheduler@1.2.3', got: {}",
+            vuln_diags[0].message
+        );
+        assert_eq!(vuln_diags[0].severity, Some(DiagnosticSeverity::ERROR));
     }
 }

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -21,6 +21,7 @@ pub fn create_diagnostics(
     cache_key_fn: impl Fn(&str) -> String,
     min_severity: Option<VulnerabilitySeverity>,
     file_type: FileType,
+    doc_transitive_vulns: &hashbrown::HashMap<String, Vec<TransitiveVuln>>,
 ) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
@@ -55,7 +56,9 @@ pub fn create_diagnostics(
                 );
                 diagnostics.push(create_deprecation_diagnostic(dep, &version_info));
             } else {
-                // Add vulnerability diagnostic (summary) only if not deprecated or yanked
+                // Add vulnerability diagnostic (summary) only if not deprecated or yanked.
+                // Per-document transitive vulns are sourced from doc_transitive_vulns to avoid
+                // cross-workspace contamination from the shared global version_cache.
                 let filtered_vulns: Vec<_> = version_info
                     .vulnerabilities
                     .iter()
@@ -67,12 +70,16 @@ pub fn create_diagnostics(
                     })
                     .collect();
 
-                if !filtered_vulns.is_empty() || !version_info.transitive_vulnerabilities.is_empty()
-                {
+                let transitive_vulns = doc_transitive_vulns
+                    .get(&dep.name)
+                    .map(|v| v.as_slice())
+                    .unwrap_or(&[]);
+
+                if !filtered_vulns.is_empty() || !transitive_vulns.is_empty() {
                     diagnostics.push(create_vulnerability_summary_diagnostic(
                         dep,
                         &filtered_vulns,
-                        &version_info.transitive_vulnerabilities,
+                        transitive_vulns,
                     ));
                 }
             }
@@ -491,6 +498,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         assert_eq!(diagnostics.len(), 1);
@@ -516,6 +524,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         assert_eq!(diagnostics.len(), 0);
@@ -531,6 +540,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         assert_eq!(diagnostics.len(), 0);
@@ -576,6 +586,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let deprecation_diags: Vec<_> = diagnostics
@@ -619,6 +630,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let deprecation_diags: Vec<_> = diagnostics
@@ -661,6 +673,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let deprecation_diags: Vec<_> = diagnostics
@@ -716,6 +729,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let yanked_diags: Vec<_> = diagnostics
@@ -755,6 +769,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let yanked_diags: Vec<_> = diagnostics
@@ -793,6 +808,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let yanked_diags: Vec<_> = diagnostics
@@ -854,6 +870,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let yanked_diags: Vec<_> = diagnostics
@@ -901,6 +918,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         assert_eq!(diagnostics.len(), 1);
@@ -940,6 +958,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let vuln_diags: Vec<_> = diagnostics
@@ -989,6 +1008,7 @@ mod tests {
             |name| format!("test:{name}"),
             Some(VulnerabilitySeverity::High),
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let vuln_diags: Vec<_> = diagnostics
@@ -1024,6 +1044,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let deprecation_diags: Vec<_> = diagnostics
@@ -1061,6 +1082,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let yanked_diags: Vec<_> = diagnostics
@@ -1149,6 +1171,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let vuln_diags: Vec<_> = diagnostics
@@ -1188,6 +1211,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let vuln_diags: Vec<_> = diagnostics
@@ -1227,6 +1251,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &hashbrown::HashMap::new(),
         );
 
         let vuln_diags: Vec<_> = diagnostics
@@ -1261,6 +1286,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Npm,
+            &hashbrown::HashMap::new(),
         );
 
         let yanked_diags: Vec<_> = diagnostics
@@ -1297,18 +1323,25 @@ mod tests {
             "test:my-dep".to_string(),
             VersionInfo {
                 latest: Some("1.0.0".to_string()),
-                transitive_vulnerabilities: vec![TransitiveVuln {
-                    package_name: "scheduler".into(),
-                    package_version: "1.2.3".into(),
-                    vulnerability: Vulnerability {
-                        id: "CVE-1".into(),
-                        severity: VulnerabilitySeverity::High,
-                        description: "desc".into(),
-                        url: None,
-                    },
-                }],
                 ..Default::default()
             },
+        );
+
+        // Transitive vulns are now stored per-document, not in version_cache.
+        let mut doc_transitives: hashbrown::HashMap<String, Vec<TransitiveVuln>> =
+            hashbrown::HashMap::new();
+        doc_transitives.insert(
+            "my-dep".to_string(),
+            vec![TransitiveVuln {
+                package_name: "scheduler".into(),
+                package_version: "1.2.3".into(),
+                vulnerability: Vulnerability {
+                    id: "CVE-1".into(),
+                    severity: VulnerabilitySeverity::High,
+                    description: "desc".into(),
+                    url: None,
+                },
+            }],
         );
 
         let diagnostics = create_diagnostics(
@@ -1317,6 +1350,7 @@ mod tests {
             |name| format!("test:{name}"),
             None,
             FileType::Cargo,
+            &doc_transitives,
         );
 
         let vuln_diags: Vec<_> = diagnostics

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -67,8 +67,7 @@ pub fn create_diagnostics(
                     })
                     .collect();
 
-                if !filtered_vulns.is_empty()
-                    || !version_info.transitive_vulnerabilities.is_empty()
+                if !filtered_vulns.is_empty() || !version_info.transitive_vulnerabilities.is_empty()
                 {
                     diagnostics.push(create_vulnerability_summary_diagnostic(
                         dep,
@@ -1288,7 +1287,9 @@ mod tests {
 
     #[test]
     fn test_diagnostic_fires_on_transitive_only_vulns() {
-        use crate::registries::{TransitiveVuln, Vulnerability, VulnerabilitySeverity, VersionInfo};
+        use crate::registries::{
+            TransitiveVuln, VersionInfo, Vulnerability, VulnerabilitySeverity,
+        };
 
         let deps = vec![create_test_dependency("my-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
@@ -1327,7 +1328,11 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(vuln_diags.len(), 1, "Should emit diagnostic for transitive-only vulns");
+        assert_eq!(
+            vuln_diags.len(),
+            1,
+            "Should emit diagnostic for transitive-only vulns"
+        );
         assert!(
             vuln_diags[0].message.contains("transitive"),
             "Message should contain 'transitive', got: {}",

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -70,28 +70,27 @@ pub fn create_diagnostics(
                     })
                     .collect();
 
-                let filtered_transitive_vulns: Vec<TransitiveVuln>;
-                let transitive_vulns: &[TransitiveVuln] =
-                    match (doc_transitive_vulns.get(&dep.name), min_severity.as_ref()) {
-                        (Some(tvs), Some(min)) => {
-                            filtered_transitive_vulns = tvs
-                                .iter()
-                                .filter(|tv| {
-                                    meets_severity_threshold(&tv.vulnerability.severity, min)
-                                })
-                                .cloned()
-                                .collect();
-                            &filtered_transitive_vulns
-                        }
-                        (Some(tvs), None) => tvs.as_slice(),
-                        (None, _) => &[],
-                    };
+                let filtered_transitive: Vec<&TransitiveVuln> = doc_transitive_vulns
+                    .get(&dep.name)
+                    .map(|v| {
+                        v.iter()
+                            .filter(|t| {
+                                min_severity
+                                    .as_ref()
+                                    .map(|min| {
+                                        meets_severity_threshold(&t.vulnerability.severity, min)
+                                    })
+                                    .unwrap_or(true)
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
 
-                if !filtered_vulns.is_empty() || !transitive_vulns.is_empty() {
+                if !filtered_vulns.is_empty() || !filtered_transitive.is_empty() {
                     diagnostics.push(create_vulnerability_summary_diagnostic(
                         dep,
                         &filtered_vulns,
-                        transitive_vulns,
+                        &filtered_transitive,
                     ));
                 }
             }
@@ -338,7 +337,7 @@ fn create_yanked_diagnostic(
 
 /// Build a short message listing transitive vulnerabilities for a direct dep.
 /// Shows up to 3 entries, then "+N more".
-pub fn build_transitive_summary_message(tv: &[TransitiveVuln]) -> String {
+pub fn build_transitive_summary_message(tv: &[&TransitiveVuln]) -> String {
     if tv.is_empty() {
         return String::new();
     }
@@ -356,14 +355,14 @@ pub fn build_transitive_summary_message(tv: &[TransitiveVuln]) -> String {
         parts.push(format!("+{} more", tv.len() - 3));
     }
     let n = tv.len();
-    format!("{n} transitive CVE(s): {}", parts.join(", "))
+    format!("{n} transitive vuln(s): {}", parts.join(", "))
 }
 
 /// Create a summary diagnostic for multiple vulnerabilities
 fn create_vulnerability_summary_diagnostic(
     dep: &Dependency,
     vulns: &[&Vulnerability],
-    transitive_vulns: &[TransitiveVuln],
+    transitive_vulns: &[&TransitiveVuln],
 ) -> Diagnostic {
     let count = vulns.len();
 
@@ -414,7 +413,7 @@ fn create_vulnerability_summary_diagnostic(
         msg
     };
 
-    // The diagnostic code uses the total count (direct + transitive CVE entries)
+    // The diagnostic code uses the total count (direct + transitive vuln entries)
     let total_count = count + transitive_vulns.len();
 
     // Collect related information for direct vulnerabilities
@@ -1114,7 +1113,7 @@ mod tests {
 
     #[test]
     fn test_build_transitive_summary_message_formats_correctly() {
-        let tvs = vec![crate::registries::TransitiveVuln {
+        let tvs = [crate::registries::TransitiveVuln {
             package_name: "scheduler".to_string(),
             package_version: "1.2.3".to_string(),
             vulnerability: crate::registries::Vulnerability {
@@ -1124,7 +1123,8 @@ mod tests {
                 url: None,
             },
         }];
-        let msg = build_transitive_summary_message(&tvs);
+        let refs: Vec<&_> = tvs.iter().collect();
+        let msg = build_transitive_summary_message(&refs);
         assert!(msg.contains("scheduler@1.2.3"));
         assert!(msg.contains("CVE-1"));
         assert!(msg.contains("1 transitive"));
@@ -1142,14 +1142,15 @@ mod tests {
                 url: None,
             },
         };
-        let tvs = vec![
+        let tvs = [
             mk("a", "X1"),
             mk("b", "X2"),
             mk("c", "X3"),
             mk("d", "X4"),
             mk("e", "X5"),
         ];
-        let msg = build_transitive_summary_message(&tvs);
+        let refs: Vec<&_> = tvs.iter().collect();
+        let msg = build_transitive_summary_message(&refs);
         assert!(msg.contains("+2 more"));
     }
 

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -8,7 +8,7 @@ use crate::cache::ReadCache;
 use crate::file_types::FileType;
 use crate::parsers::Dependency;
 use crate::providers::inlay_hints::{VersionStatus, compare_versions, is_local_dependency};
-use crate::registries::{VersionInfo, Vulnerability, VulnerabilitySeverity};
+use crate::registries::{TransitiveVuln, VersionInfo, Vulnerability, VulnerabilitySeverity};
 use crate::utils::fmt_truncate_string;
 
 /// Create diagnostics for a list of dependencies
@@ -71,6 +71,7 @@ pub fn create_diagnostics(
                     diagnostics.push(create_vulnerability_summary_diagnostic(
                         dep,
                         &filtered_vulns,
+                        &version_info.transitive_vulnerabilities,
                     ));
                 }
             }
@@ -315,25 +316,57 @@ fn create_yanked_diagnostic(
     }
 }
 
+/// Build a short message listing transitive vulnerabilities for a direct dep.
+/// Shows up to 3 entries, then "+N more".
+pub fn build_transitive_summary_message(tv: &[TransitiveVuln]) -> String {
+    if tv.is_empty() {
+        return String::new();
+    }
+    let mut parts: Vec<String> = tv
+        .iter()
+        .take(3)
+        .map(|t| {
+            let name = &t.package_name;
+            let ver = &t.package_version;
+            let id = &t.vulnerability.id;
+            format!("{name}@{ver} ({id})")
+        })
+        .collect();
+    if tv.len() > 3 {
+        parts.push(format!("+{} more", tv.len() - 3));
+    }
+    let n = tv.len();
+    format!("{n} transitive CVE(s): {}", parts.join(", "))
+}
+
 /// Create a summary diagnostic for multiple vulnerabilities
 fn create_vulnerability_summary_diagnostic(
     dep: &Dependency,
     vulns: &[&Vulnerability],
+    transitive_vulns: &[TransitiveVuln],
 ) -> Diagnostic {
     let count = vulns.len();
 
-    // Use the highest severity among all vulnerabilities
+    // Use the highest severity among all vulnerabilities (direct + transitive)
     let severity_to_num = |s: &VulnerabilitySeverity| match s {
         VulnerabilitySeverity::Critical => 4,
         VulnerabilitySeverity::High => 3,
         VulnerabilitySeverity::Medium => 2,
         VulnerabilitySeverity::Low => 1,
     };
-    let max_severity = vulns
+    let max_direct_sev = vulns
         .iter()
         .map(|v| &v.severity)
         .max_by_key(|s| severity_to_num(s))
         .unwrap_or(&VulnerabilitySeverity::Low);
+    let max_transitive_sev = transitive_vulns
+        .iter()
+        .map(|t| &t.vulnerability.severity)
+        .max_by_key(|s| severity_to_num(s));
+    let max_severity = match max_transitive_sev {
+        Some(ts) if severity_to_num(ts) > severity_to_num(max_direct_sev) => ts,
+        _ => max_direct_sev,
+    };
 
     let diagnostic_severity = match max_severity {
         VulnerabilitySeverity::Critical | VulnerabilitySeverity::High => DiagnosticSeverity::ERROR,
@@ -344,7 +377,14 @@ fn create_vulnerability_summary_diagnostic(
     // Build summary message
     let vuln_word = if count == 1 { "vuln" } else { "vulns" };
     let vuln_ids: Vec<_> = vulns.iter().map(|v| v.id.as_str()).collect();
-    let message = format!("⚠ {count} {vuln_word}: {}", vuln_ids.join(", "));
+    let mut message = format!("⚠ {count} {vuln_word}: {}", vuln_ids.join(", "));
+
+    // Append transitive vulnerability summary if present
+    if !transitive_vulns.is_empty() {
+        let tv_msg = build_transitive_summary_message(transitive_vulns);
+        message.push_str(" — ");
+        message.push_str(&tv_msg);
+    }
 
     // Collect related information for all vulnerabilities
     let related_info: Vec<_> = vulns
@@ -1024,6 +1064,53 @@ mod tests {
         assert!(yanked_diags[0].related_information.is_some());
         let related = yanked_diags[0].related_information.as_ref().unwrap();
         assert_eq!(related.len(), 2);
+    }
+
+    #[test]
+    fn test_build_transitive_summary_message_formats_correctly() {
+        let tvs = vec![crate::registries::TransitiveVuln {
+            package_name: "scheduler".to_string(),
+            package_version: "1.2.3".to_string(),
+            vulnerability: crate::registries::Vulnerability {
+                id: "CVE-1".to_string(),
+                severity: crate::registries::VulnerabilitySeverity::High,
+                description: "x".to_string(),
+                url: None,
+            },
+        }];
+        let msg = build_transitive_summary_message(&tvs);
+        assert!(msg.contains("scheduler@1.2.3"));
+        assert!(msg.contains("CVE-1"));
+        assert!(msg.contains("1 transitive"));
+    }
+
+    #[test]
+    fn test_build_transitive_summary_message_truncates_after_three() {
+        let mk = |name: &str, id: &str| crate::registries::TransitiveVuln {
+            package_name: name.to_string(),
+            package_version: "1.0.0".to_string(),
+            vulnerability: crate::registries::Vulnerability {
+                id: id.to_string(),
+                severity: crate::registries::VulnerabilitySeverity::Low,
+                description: "x".to_string(),
+                url: None,
+            },
+        };
+        let tvs = vec![
+            mk("a", "X1"),
+            mk("b", "X2"),
+            mk("c", "X3"),
+            mk("d", "X4"),
+            mk("e", "X5"),
+        ];
+        let msg = build_transitive_summary_message(&tvs);
+        assert!(msg.contains("+2 more"));
+    }
+
+    #[test]
+    fn test_build_transitive_summary_message_empty() {
+        let msg = build_transitive_summary_message(&[]);
+        assert_eq!(msg, "");
     }
 
     #[test]

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -70,10 +70,22 @@ pub fn create_diagnostics(
                     })
                     .collect();
 
-                let transitive_vulns = doc_transitive_vulns
-                    .get(&dep.name)
-                    .map(|v| v.as_slice())
-                    .unwrap_or(&[]);
+                let filtered_transitive_vulns: Vec<TransitiveVuln>;
+                let transitive_vulns: &[TransitiveVuln] =
+                    match (doc_transitive_vulns.get(&dep.name), min_severity.as_ref()) {
+                        (Some(tvs), Some(min)) => {
+                            filtered_transitive_vulns = tvs
+                                .iter()
+                                .filter(|tv| {
+                                    meets_severity_threshold(&tv.vulnerability.severity, min)
+                                })
+                                .cloned()
+                                .collect();
+                            &filtered_transitive_vulns
+                        }
+                        (Some(tvs), None) => tvs.as_slice(),
+                        (None, _) => &[],
+                    };
 
                 if !filtered_vulns.is_empty() || !transitive_vulns.is_empty() {
                     diagnostics.push(create_vulnerability_summary_diagnostic(
@@ -1378,5 +1390,80 @@ mod tests {
             vuln_diags[0].message
         );
         assert_eq!(vuln_diags[0].severity, Some(DiagnosticSeverity::ERROR));
+    }
+
+    #[test]
+    fn test_transitive_vulns_respect_min_severity() {
+        let deps = vec![create_test_dependency("my-dep", "1.0.0", 5)];
+        let cache = MemoryCache::new();
+        cache.insert(
+            "test:my-dep".to_string(),
+            VersionInfo {
+                latest: Some("1.0.0".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let mut doc_transitives: hashbrown::HashMap<String, Vec<TransitiveVuln>> =
+            hashbrown::HashMap::new();
+        doc_transitives.insert(
+            "my-dep".to_string(),
+            vec![
+                TransitiveVuln {
+                    package_name: "low-pkg".into(),
+                    package_version: "1.0".into(),
+                    vulnerability: Vulnerability {
+                        id: "LOW-1".into(),
+                        severity: VulnerabilitySeverity::Low,
+                        description: "low".into(),
+                        url: None,
+                    },
+                },
+                TransitiveVuln {
+                    package_name: "high-pkg".into(),
+                    package_version: "2.0".into(),
+                    vulnerability: Vulnerability {
+                        id: "HIGH-1".into(),
+                        severity: VulnerabilitySeverity::High,
+                        description: "high".into(),
+                        url: None,
+                    },
+                },
+            ],
+        );
+
+        let diagnostics = create_diagnostics(
+            &deps,
+            &cache,
+            |name| format!("test:{name}"),
+            Some(VulnerabilitySeverity::High),
+            FileType::Cargo,
+            &doc_transitives,
+        );
+
+        let vuln_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| {
+                d.code
+                    .as_ref()
+                    .is_some_and(|c| matches!(c, NumberOrString::String(s) if s.contains("vulns")))
+            })
+            .collect();
+
+        assert_eq!(
+            vuln_diags.len(),
+            1,
+            "Should emit exactly one diagnostic for the high-severity transitive vuln"
+        );
+        assert!(
+            vuln_diags[0].message.contains("HIGH-1"),
+            "Message should contain HIGH-1, got: {}",
+            vuln_diags[0].message
+        );
+        assert!(
+            !vuln_diags[0].message.contains("LOW-1"),
+            "Message should NOT contain LOW-1 when min_severity=High, got: {}",
+            vuln_diags[0].message
+        );
     }
 }

--- a/dependi-lsp/src/registries/cargo_sparse.rs
+++ b/dependi-lsp/src/registries/cargo_sparse.rs
@@ -197,6 +197,7 @@ impl Registry for CargoSparseRegistry {
             yanked,
             yanked_versions,
             release_dates: HashMap::new(),
+            transitive_vulnerabilities: vec![],
         })
     }
 }

--- a/dependi-lsp/src/registries/crates_io.rs
+++ b/dependi-lsp/src/registries/crates_io.rs
@@ -265,6 +265,7 @@ impl Registry for CratesIoRegistry {
             yanked,
             yanked_versions,
             release_dates,
+            transitive_vulnerabilities: vec![],
         })
     }
 }

--- a/dependi-lsp/src/registries/go_proxy.rs
+++ b/dependi-lsp/src/registries/go_proxy.rs
@@ -198,6 +198,7 @@ impl Registry for GoProxyRegistry {
             yanked: false,
             yanked_versions: vec![], // Not applicable to Go
             release_dates,
+            transitive_vulnerabilities: vec![],
         })
     }
 }

--- a/dependi-lsp/src/registries/maven_central.rs
+++ b/dependi-lsp/src/registries/maven_central.rs
@@ -137,6 +137,7 @@ impl Registry for MavenCentralRegistry {
             yanked: false,
             yanked_versions: vec![],
             release_dates: hashbrown::HashMap::new(),
+            transitive_vulnerabilities: vec![],
         })
     }
 

--- a/dependi-lsp/src/registries/mod.rs
+++ b/dependi-lsp/src/registries/mod.rs
@@ -82,6 +82,16 @@ use hashbrown::HashMap;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
+/// A vulnerability discovered in a transitive dependency reached through a direct package.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TransitiveVuln {
+    #[serde(rename = "package")]
+    pub package_name: String,
+    #[serde(rename = "version")]
+    pub package_version: String,
+    pub vulnerability: Vulnerability,
+}
+
 /// Information about a package version from a registry
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct VersionInfo {
@@ -110,6 +120,9 @@ pub struct VersionInfo {
     /// Release dates for each version (version string -> DateTime)
     #[serde(default)]
     pub release_dates: HashMap<String, DateTime<Utc>>,
+    /// Vulnerabilities discovered in transitive dependencies reached through this package.
+    #[serde(default)]
+    pub transitive_vulnerabilities: Vec<TransitiveVuln>,
 }
 
 impl VersionInfo {
@@ -339,5 +352,33 @@ mod tests {
         let info = VersionInfo::default();
 
         assert!(!info.is_version_yanked("1.0.0"));
+    }
+}
+
+#[cfg(test)]
+mod transitive_vuln_tests {
+    use super::*;
+
+    #[test]
+    fn test_version_info_default_has_empty_transitive_vulns() {
+        let info = VersionInfo::default();
+        assert!(info.transitive_vulnerabilities.is_empty());
+    }
+
+    #[test]
+    fn test_transitive_vuln_serializes_with_package_and_version() {
+        let v = TransitiveVuln {
+            package_name: "scheduler".to_string(),
+            package_version: "1.2.3".to_string(),
+            vulnerability: Vulnerability {
+                id: "CVE-XXX".to_string(),
+                severity: VulnerabilitySeverity::High,
+                description: "desc".to_string(),
+                url: None,
+            },
+        };
+        let json = serde_json::to_string(&v).unwrap();
+        assert!(json.contains("\"package\":\"scheduler\""));
+        assert!(json.contains("\"version\":\"1.2.3\""));
     }
 }

--- a/dependi-lsp/src/registries/npm.rs
+++ b/dependi-lsp/src/registries/npm.rs
@@ -378,6 +378,7 @@ impl Registry for NpmRegistry {
             yanked: false,
             yanked_versions: vec![], // Not applicable to npm
             release_dates,
+            transitive_vulnerabilities: vec![],
         })
     }
 }

--- a/dependi-lsp/src/registries/nuget.rs
+++ b/dependi-lsp/src/registries/nuget.rs
@@ -266,6 +266,7 @@ impl Registry for NuGetRegistry {
             yanked: false,
             yanked_versions: vec![], // Not applicable to NuGet
             release_dates,
+            transitive_vulnerabilities: vec![],
         })
     }
 }

--- a/dependi-lsp/src/registries/packagist.rs
+++ b/dependi-lsp/src/registries/packagist.rs
@@ -231,6 +231,7 @@ impl Registry for PackagistRegistry {
             yanked: false,
             yanked_versions: vec![], // Not applicable to Packagist
             release_dates,
+            transitive_vulnerabilities: vec![],
         })
     }
 }

--- a/dependi-lsp/src/registries/pub_dev.rs
+++ b/dependi-lsp/src/registries/pub_dev.rs
@@ -226,6 +226,7 @@ impl Registry for PubDevRegistry {
             yanked: pkg.latest.retracted,
             yanked_versions: vec![], // Not applicable to pub.dev
             release_dates,
+            transitive_vulnerabilities: vec![],
         })
     }
 }

--- a/dependi-lsp/src/registries/pypi.rs
+++ b/dependi-lsp/src/registries/pypi.rs
@@ -255,6 +255,7 @@ impl Registry for PyPiRegistry {
             yanked: false,
             yanked_versions: vec![], // Not applicable to PyPI
             release_dates,
+            transitive_vulnerabilities: vec![],
         })
     }
 }

--- a/dependi-lsp/src/registries/rubygems.rs
+++ b/dependi-lsp/src/registries/rubygems.rs
@@ -213,6 +213,7 @@ impl Registry for RubyGemsRegistry {
             yanked: false,
             yanked_versions: vec![], // Not applicable to RubyGems
             release_dates,
+            transitive_vulnerabilities: vec![],
         })
     }
 }

--- a/dependi-lsp/src/vulnerabilities/mod.rs
+++ b/dependi-lsp/src/vulnerabilities/mod.rs
@@ -64,7 +64,7 @@ pub struct VulnerabilityQuery {
 ///
 /// If normalization would produce an empty string (e.g. operator-only input),
 /// the original trimmed input is returned unchanged.
-pub(crate) fn normalize_version_for_osv(version: &str) -> String {
+pub fn normalize_version_for_osv(version: &str) -> String {
     // Step 1: trim surrounding whitespace
     let trimmed = version.trim();
 

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -436,10 +436,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_osv_client_with_endpoint_uses_custom_url() {
-        let client = OsvClient::with_endpoint("http://127.0.0.1:65535".to_string());
-        // Port 65535 is not listening; the call should error, not reach osv.dev.
-        let result = client.query_batch(&[]).await;
-        assert!(result.is_err() || result.as_ref().map(|v| v.is_empty()).unwrap_or(false));
+        let client = OsvClient::with_endpoint("http://127.0.0.1:1".to_string());
+        // Port 1 is not listening; a real query must error, proving the client
+        // actually attempted to reach the custom URL (and not fallen back to
+        // api.osv.dev).
+        let query = VulnerabilityQuery {
+            ecosystem: Ecosystem::CratesIo,
+            package_name: "serde".to_string(),
+            version: "1.0.0".to_string(),
+        };
+        let result = client.query_batch(&[query]).await;
+        assert!(
+            result.is_err(),
+            "query to unreachable endpoint should error, got {result:?}"
+        );
     }
 
     #[test]

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -40,6 +40,19 @@ impl OsvClient {
         })
     }
 
+    /// Constructor used in tests to point the client at a mock server.
+    pub fn with_endpoint(endpoint: String) -> Self {
+        Self {
+            base_url: endpoint,
+            client: Arc::new(
+                Client::builder()
+                    .timeout(Duration::from_secs(30))
+                    .build()
+                    .expect("reqwest client should build"),
+            ),
+        }
+    }
+
     fn convert_vulnerability(osv: &OsvVulnerability) -> Vulnerability {
         let id = osv
             .aliases
@@ -419,6 +432,14 @@ mod tests {
 
         let vuln = &result.vulnerabilities[0];
         assert!(vuln.id.starts_with("RUSTSEC"));
+    }
+
+    #[tokio::test]
+    async fn test_osv_client_with_endpoint_uses_custom_url() {
+        let client = OsvClient::with_endpoint("http://127.0.0.1:65535".to_string());
+        // Port 65535 is not listening; the call should error, not reach osv.dev.
+        let result = client.query_batch(&[]).await;
+        assert!(result.is_err() || result.as_ref().map(|v| v.is_empty()).unwrap_or(false));
     }
 
     #[test]

--- a/dependi-lsp/tests/fixtures/npm-project-with-lockfile/package-lock.json
+++ b/dependi-lsp/tests/fixtures/npm-project-with-lockfile/package-lock.json
@@ -1,0 +1,9 @@
+{
+  "name": "demo",
+  "lockfileVersion": 3,
+  "packages": {
+    "": { "name": "demo", "version": "1.0.0", "dependencies": { "react": "^18.0.0" } },
+    "node_modules/react": { "version": "18.2.0", "dependencies": { "scheduler": "^0.23.0" } },
+    "node_modules/scheduler": { "version": "0.23.0" }
+  }
+}

--- a/dependi-lsp/tests/fixtures/npm-project-with-lockfile/package.json
+++ b/dependi-lsp/tests/fixtures/npm-project-with-lockfile/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "demo",
+  "version": "1.0.0",
+  "dependencies": { "react": "^18.0.0" }
+}

--- a/dependi-lsp/tests/fixtures/python-project-with-lockfile/poetry.lock
+++ b/dependi-lsp/tests/fixtures/python-project-with-lockfile/poetry.lock
@@ -1,0 +1,10 @@
+[[package]]
+name = "requests"
+version = "2.31.0"
+
+[package.dependencies]
+urllib3 = ">=1.21.1,<3"
+
+[[package]]
+name = "urllib3"
+version = "2.0.7"

--- a/dependi-lsp/tests/fixtures/python-project-with-lockfile/pyproject.toml
+++ b/dependi-lsp/tests/fixtures/python-project-with-lockfile/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.poetry]
+name = "demo"
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+requests = "^2.31.0"

--- a/dependi-lsp/tests/fixtures/rust-project-with-lockfile/Cargo.lock
+++ b/dependi-lsp/tests/fixtures/rust-project-with-lockfile/Cargo.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "demo"
+version = "0.1.0"
+dependencies = ["serde"]
+
+[[package]]
+name = "serde"
+version = "1.0.195"
+dependencies = ["serde_derive"]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.195"

--- a/dependi-lsp/tests/fixtures/rust-project-with-lockfile/Cargo.toml
+++ b/dependi-lsp/tests/fixtures/rust-project-with-lockfile/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "demo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1"

--- a/dependi-lsp/tests/integration_test.rs
+++ b/dependi-lsp/tests/integration_test.rs
@@ -147,6 +147,7 @@ fn test_cache_integration() {
         yanked: false,
         yanked_versions: vec![],
         release_dates: Default::default(),
+        transitive_vulnerabilities: vec![],
     };
 
     cache.insert("crates:serde".to_string(), serde_info.clone());

--- a/dependi-lsp/tests/scan_cli_test.rs
+++ b/dependi-lsp/tests/scan_cli_test.rs
@@ -59,7 +59,13 @@ async fn test_scan_uses_lockfile_and_reports_transitive() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stdout.contains("\"transitive\""),
-        "expected transitive array in JSON output. stdout=\n{stdout}\nstderr=\n{stderr}"
+        "expected transitive key in JSON. stdout=\n{stdout}"
+    );
+    // The npm fixture has `react` as direct and `scheduler` as transitive. The mock
+    // returns a vuln on the second query (the transitive). Confirm:
+    assert!(
+        stdout.contains("scheduler") || stdout.contains("CVE-TEST-001"),
+        "expected transitive CVE to appear in output, got:\n{stdout}"
     );
     assert!(
         stdout.contains("\"direct\""),

--- a/dependi-lsp/tests/scan_cli_test.rs
+++ b/dependi-lsp/tests/scan_cli_test.rs
@@ -76,14 +76,7 @@ fn test_scan_no_use_lockfile_flag_skips_detection() {
 
     let output = Command::new(dependi_lsp_bin())
         .env("OSV_ENDPOINT", "http://127.0.0.1:1") // unreachable
-        .args([
-            "scan",
-            "--output",
-            "json",
-            "--use-lockfile",
-            "false",
-            "--file",
-        ])
+        .args(["scan", "--output", "json", "--no-use-lockfile", "--file"])
         .arg(&fixture)
         .output()
         .expect("failed to run dependi-lsp");

--- a/dependi-lsp/tests/scan_cli_test.rs
+++ b/dependi-lsp/tests/scan_cli_test.rs
@@ -1,0 +1,127 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use wiremock::matchers::{method, path, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn dependi_lsp_bin() -> String {
+    env!("CARGO_BIN_EXE_dependi-lsp").to_string()
+}
+
+fn fixture_path(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(rel)
+}
+
+#[tokio::test]
+async fn test_scan_uses_lockfile_and_reports_transitive() {
+    let server = MockServer::start().await;
+
+    // Mock OSV querybatch: npm fixture has direct [react] + transitive [scheduler].
+    // Return no vulns for react (index 0) and a vuln for scheduler (index 1).
+    Mock::given(method("POST"))
+        .and(path("/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [
+                { "vulns": [] },
+                { "vulns": [{ "id": "CVE-TEST-001", "modified": "2024-01-01T00:00:00Z" }] }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    // Mock individual vuln lookups (check_rustsec_unmaintained calls GET /vulns/{id}).
+    // CVE-TEST-001 is not a RUSTSEC id so this won't be called, but guard against it anyway.
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/vulns/.+"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "CVE-TEST-001",
+            "summary": "test summary",
+            "details": "test details",
+            "severity": [{ "type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" }],
+            "references": []
+        })))
+        .mount(&server)
+        .await;
+
+    let fixture = fixture_path("npm-project-with-lockfile/package.json");
+
+    let output = Command::new(dependi_lsp_bin())
+        .env("OSV_ENDPOINT", server.uri())
+        .args(["scan", "--output", "json", "--file"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run dependi-lsp");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("\"transitive\""),
+        "expected transitive array in JSON output. stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+    assert!(
+        stdout.contains("\"direct\""),
+        "expected direct array in JSON output. stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+}
+
+#[test]
+fn test_scan_no_use_lockfile_flag_skips_detection() {
+    // When --no-use-lockfile is passed, even with a lockfile present the graph should be empty.
+    // We point OSV_ENDPOINT at an unreachable port so any actual query errors fast and we
+    // check that no "transitive" data was computed.
+    let fixture = fixture_path("rust-project-with-lockfile/Cargo.toml");
+
+    let output = Command::new(dependi_lsp_bin())
+        .env("OSV_ENDPOINT", "http://127.0.0.1:1") // unreachable
+        .args([
+            "scan",
+            "--output",
+            "json",
+            "--use-lockfile",
+            "false",
+            "--file",
+        ])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run dependi-lsp");
+
+    // With a broken endpoint, the query fails → ExitCode::FAILURE (1). That's ok;
+    // the flag just needs to parse. The stderr should confirm the command ran.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Scanning") || stderr.contains("Error"),
+        "expected scan to run, got stderr: {stderr}"
+    );
+}
+
+#[test]
+fn test_scan_malformed_lockfile_falls_back() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("Cargo.toml"),
+        r#"
+[package]
+name = "x"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1"
+"#,
+    )
+    .expect("write manifest");
+    std::fs::write(tmp.path().join("Cargo.lock"), "not valid toml ][").expect("write lockfile");
+
+    let output = Command::new(dependi_lsp_bin())
+        .env("OSV_ENDPOINT", "http://127.0.0.1:1") // unreachable so we don't hit network
+        .args(["scan", "--output", "json", "--file"])
+        .arg(tmp.path().join("Cargo.toml"))
+        .output()
+        .expect("run");
+    // Should not crash. Exit code may be 0 or 1 depending on how graceful the fallback is;
+    // what we care about is not a panic.
+    assert!(output.status.code().is_some(), "process exited abnormally");
+}


### PR DESCRIPTION
## Summary

Resolves #224. Extends `dependi-lsp scan` and the LSP editor to use lockfiles
for accurate vulnerability scanning including **transitive dependencies**.

- Introduces `LockfileGraph`/`LockfilePackage` with cycle-safe DFS and an
  inverse index for O(T+D×N) transitive attribution (previously would have
  been O(T×D×N)).
- Adds `parse_*_graph` parsers for **9 lockfile formats**: Cargo.lock,
  package-lock.json (v2/v3), pnpm-lock.yaml (v6 + v9), yarn.lock (v1),
  poetry.lock, uv.lock, Pipfile.lock, composer.lock, Gemfile.lock.
- CLI reports now surface a distinct **Transitive dependencies** section
  (JSON/Markdown/summary) with each transitive CVE attributed to the direct
  parent via `via_direct` (npm audit-style).
- LSP diagnostics on the direct dep line now mention transitive CVEs and
  escalate severity when a transitive CVE is more critical.
- LSP hover content shows a dedicated `Transitive vulnerabilities` section.
- New `--no-use-lockfile` flag for debugging.
- Lockfile reads are capped at 50 MiB to prevent OOM on hostile inputs.

Go/Maven/C#/Dart/Bun/PDM/NuGet/pubspec are intentionally **out of scope** for
this PR and will follow up (the backend still preserves prior behavior for
them).

## Details

### New public API

```rust
// registries
pub struct TransitiveVuln {
    pub package_name: String,       // serializes as "package"
    pub package_version: String,    // serializes as "version"
    pub vulnerability: Vulnerability,
}

// VersionInfo gains:
pub transitive_vulnerabilities: Vec<TransitiveVuln>,
```

### CLI report schema (backward compatible)

```json
{
  "file": "...",
  "summary": { "total": 5, "critical": 1, ... },
  "direct":     [ { "package": "react", "version": "18.2.0", ... } ],
  "transitive": [ { "package": "scheduler", "version": "1.2.3",
                    "via_direct": "react", ... } ],
  "vulnerabilities": [ /* concatenation, preserved for existing consumers */ ]
}
```

### Adversarial review

Ran three reviewers in parallel (rust-reviewer, code-reviewer,
security-reviewer). Fixes from findings are in commit \`a0d307e\`:

- **CRITICAL**: \`--no-use-lockfile\` flag was broken (clap \`ArgAction::Set\`
  requires a value) — switched to \`ArgAction::SetTrue\` + \`!no_use_lockfile\`.
- **CRITICAL**: \`parse_gemfile_lock_graph\` was matching \`specs:\` in PATH/GIT
  sections, polluting the graph with local/fork gems — added section state
  machine mirroring \`parse_gemfile_lock\`.
- **HIGH**: \`parse_pnpm_lock_graph\` only understood v6 (\`  /name@ver:\`) —
  added v9 format (\`  name@ver:\`) detection.
- **HIGH**: O(T×D×N) transitive attribution replaced by \`reverse_index()\`
  precomputed once.
- **HIGH/MEDIUM**: Gemfile name normalization, composer name normalization.
- **SECURITY**: 50 MiB cap on lockfile reads.

## Test plan

- [x] \`cargo test --lib\` — 583 pass, 1 ignored
- [x] \`cargo test --test scan_cli_test\` — 3 integration tests pass (wiremock-mocked OSV)
- [x] \`cargo test --test integration_test\` — pass
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] Manual smoke: \`dependi-lsp scan --help\` shows \`--no-use-lockfile\`
- [x] Unit coverage for graph parsers (v6 and v9 pnpm, Gemfile PATH/GIT exclusion, Cargo cycle, reverse_index attribution, etc.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds lockfile-based scanning to `dependi-lsp scan` and the LSP to detect and attribute transitive vulnerabilities, fulfilling #224. Reports and diagnostics show transitives with correct parent attribution and resolved versions, including multi-version and multi-parent cases.

- **New Features**
  - Walks full dependency graphs from lockfiles via `LockfileGraph`.
  - Parsers for `Cargo.lock`, `package-lock.json` (v2/v3), `pnpm-lock.yaml` (v6/v9), `yarn.lock` (v1), `poetry.lock`, `uv.lock`, `Pipfile.lock`, `composer.lock`, `Gemfile.lock`.
  - CLI adds a Transitive dependencies section with `via_direct`; LSP diagnostics and hovers list transitives and escalate severity when higher than the direct dep.
  - New `--no-use-lockfile` flag to disable lockfile-based scanning.

- **Bug Fixes**
  - Correctness: identity is (name, version) during DFS; reverse index attributes each transitive vuln to all direct parents; traversal limited to packages reachable from manifest deps; Cargo uses `Cargo.lock`’s resolved versions with root package disambiguation.
  - Parsing/name handling: canonicalize manifest names for PyPI/Packagist/RubyGems; pnpm v9 supported (exit packages section, strip peer suffix, unquote scoped names in keys/dependencies); `Gemfile.lock` excludes PATH/GIT and strips platform suffix; Composer names normalized; `package-lock.json` v2/v3 support clarified.
  - LSP/diagnostics: transitive findings stored per document; cached transitives are attributed on every run; respect `min_severity` and use “vuln(s)” wording; cache transitive vuln payloads only when non-empty to avoid memory growth.
  - Safety/perf: lockfile and manifest reads capped at 50 MiB (cap enforced during read); transitive OSV queries de-duplicated via vuln cache; fixed `--no-use-lockfile` behavior; detect Python tool hint before searching for a lockfile.

<sup>Written for commit 1c8e749060659a63d36f97b8de835029c9f77b3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lockfile-aware scanning surfaces transitive vulnerabilities attributed to the direct dependency; CLI/JSON/Markdown separate Direct and Transitive sections. LSP diagnostics and hover show summarized transitive CVEs (up to 3) with package@version, severity, description and link. Added a flag to disable lockfile use and support for custom OSV endpoint.

* **Bug Fixes**
  * OSV queries use resolved versions from lockfiles for more accurate matches.

* **Security**
  * Lockfile reads capped at 50 MiB.

* **Tests**
  * New integration tests and fixtures for lockfile/transitive scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->