### PR TITLE
fix: handle bare PEP 440 pre-release in version comparison (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   querying OSV — previously the CLI queried using the specifier string (e.g.
   `^1.0`), which caused false negatives.
 - Respect the `package` field of `Cargo.toml` dependencies
+- Bare PEP 440 pre-release versions (e.g., `4.0.0a6`, `1.0b2`, `2.0rc1`,
+  `1.0.0.dev1`) no longer trigger spurious downgrade suggestions in
+  `compare_versions`. This scenario occurred with Python lockfile resolution
+  (poetry/uv/pdm/pipenv) pinning a direct requirement to a 4.x pre-release
+  while PyPI's latest stable was a lower major (e.g., apscheduler 3.11.x).
+  `compare_versions` now retries semver parsing after stripping PEP 440
+  pre-release markers when the initial parse fails
+  ([#154](https://github.com/mpiton/zed-dependi/issues/154)).
 
 ### Security
 

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -1924,9 +1924,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/dependi-lsp/fuzz/Cargo.lock
+++ b/dependi-lsp/fuzz/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "dirs",
  "futures",
  "hashbrown 0.17.0",
+ "quick-xml",
  "r2d2",
  "reqwest",
  "rusqlite",
@@ -1315,6 +1316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,9 +1644,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/dependi-lsp/src/providers/inlay_hints.rs
+++ b/dependi-lsp/src/providers/inlay_hints.rs
@@ -461,26 +461,33 @@ pub fn compare_versions(current: &str, info: &VersionInfo) -> VersionStatus {
     // lockfile resolution or an explicit pin like `==4.0.0a6`), which the first
     // attempt cannot parse and which would otherwise trigger a bogus downgrade
     // suggestion via the string-equality fallback (see issue #154).
-    let current_clean = normalize_version(&truncate_version(
-        &strip_python_prerelease(&current_normalized),
-        3,
-    ));
-    let latest_clean = normalize_version(&truncate_version(
-        &strip_python_prerelease(&latest_normalized),
-        3,
-    ));
+    //
+    // Only truncate to 3 segments when stripping actually changed the input
+    // (a PEP 440 marker like `dev1` can expand to a trailing `.0` that pushes
+    // the result to 4 segments). Leaving genuine 4-segment calendar versions
+    // like `2024.1.1.5` untouched avoids silently collapsing them.
+    let current_clean = clean_for_semver(&current_normalized);
+    let latest_clean = clean_for_semver(&latest_normalized);
 
     match (
         semver::Version::parse(&current_clean),
         semver::Version::parse(&latest_clean),
     ) {
-        (Ok(current_ver), Ok(latest_ver)) => {
-            if current_ver >= latest_ver {
-                VersionStatus::UpToDate
-            } else {
-                VersionStatus::UpdateAvailable(latest.to_owned())
+        (Ok(current_ver), Ok(latest_ver)) => match current_ver.cmp(&latest_ver) {
+            core::cmp::Ordering::Greater => VersionStatus::UpToDate,
+            core::cmp::Ordering::Less => VersionStatus::UpdateAvailable(latest.to_owned()),
+            core::cmp::Ordering::Equal => {
+                // Cleaned versions parsed equal — check whether stripping
+                // collapsed a real difference (e.g., `4.0.0a6` vs `4.0.0a7`
+                // both strip to `4.0.0`). If originals differ, report an
+                // update rather than hiding the change.
+                if current_normalized == latest_normalized {
+                    VersionStatus::UpToDate
+                } else {
+                    VersionStatus::UpdateAvailable(latest.to_owned())
+                }
             }
-        }
+        },
         _ => {
             // Final fallback: string comparison on cleaned versions
             if current_clean == latest_clean {
@@ -489,6 +496,19 @@ pub fn compare_versions(current: &str, info: &VersionInfo) -> VersionStatus {
                 VersionStatus::UpdateAvailable(latest.to_owned())
             }
         }
+    }
+}
+
+/// Normalize a version for the second-attempt semver parse in `compare_versions`.
+/// Strips PEP 440 pre-release markers. Truncates to 3 segments only when the
+/// strip actually modified the input, so genuine 4-segment calendar versions
+/// (e.g., `2024.1.1.5`) are preserved.
+fn clean_for_semver(version: &str) -> String {
+    let stripped = strip_python_prerelease(version);
+    if stripped == version {
+        normalize_version(&stripped)
+    } else {
+        normalize_version(&truncate_version(&stripped, 3))
     }
 }
 
@@ -750,6 +770,48 @@ mod tests {
         // Exact pin with == operator
         let info = make_version_info("3.11.2");
         let result = compare_versions("==4.0.0a6", &info);
+        assert!(matches!(result, VersionStatus::UpToDate), "Got: {result:?}");
+    }
+
+    #[test]
+    fn test_compare_versions_prerelease_older_than_latest_prerelease() {
+        // When latest itself is a pre-release (no stable on PyPI yet), a lower
+        // pre-release on the same base version must still report an update
+        // instead of collapsing to UpToDate via the strip.
+        let info = make_version_info("4.0.0a7");
+        match compare_versions("4.0.0a6", &info) {
+            VersionStatus::UpdateAvailable(v) => assert_eq!(v, "4.0.0a7"),
+            other => panic!("Expected UpdateAvailable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_compare_versions_prerelease_vs_same_base_stable() {
+        // Pre-release on the same base as a released stable must report an
+        // update: 4.0.0a6 < 4.0.0.
+        let info = make_version_info("4.0.0");
+        match compare_versions("4.0.0a6", &info) {
+            VersionStatus::UpdateAvailable(v) => assert_eq!(v, "4.0.0"),
+            other => panic!("Expected UpdateAvailable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_compare_versions_calver_four_segments_update_available() {
+        // Calendar-versioned packages can legitimately use 4 segments (e.g.,
+        // `2024.1.1.5`). The second-attempt path must not silently truncate
+        // `latest` and report UpToDate when a real update exists.
+        let info = make_version_info("2024.1.1.5");
+        match compare_versions("2024.1.1.3", &info) {
+            VersionStatus::UpdateAvailable(v) => assert_eq!(v, "2024.1.1.5"),
+            other => panic!("Expected UpdateAvailable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_compare_versions_calver_four_segments_up_to_date() {
+        let info = make_version_info("2024.1.1.5");
+        let result = compare_versions("2024.1.1.5", &info);
         assert!(matches!(result, VersionStatus::UpToDate), "Got: {result:?}");
     }
 

--- a/dependi-lsp/src/providers/inlay_hints.rs
+++ b/dependi-lsp/src/providers/inlay_hints.rs
@@ -443,10 +443,36 @@ pub fn compare_versions(current: &str, info: &VersionInfo) -> VersionStatus {
     let current_normalized = normalize_version(current);
     let latest_normalized = normalize_version(latest);
 
-    // Parse as semver for proper comparison
-    match (
+    // First attempt: direct semver parse (handles clean semver and semver pre-release
+    // like Rust's `1.0.0-alpha.1`).
+    if let (Ok(current_ver), Ok(latest_ver)) = (
         semver::Version::parse(&current_normalized),
         semver::Version::parse(&latest_normalized),
+    ) {
+        return if current_ver >= latest_ver {
+            VersionStatus::UpToDate
+        } else {
+            VersionStatus::UpdateAvailable(latest.to_owned())
+        };
+    }
+
+    // Second attempt: strip PEP 440 pre-release markers, then retry semver parse.
+    // Handles Python bare pre-release versions (e.g., `4.0.0a6` coming from a
+    // lockfile resolution or an explicit pin like `==4.0.0a6`), which the first
+    // attempt cannot parse and which would otherwise trigger a bogus downgrade
+    // suggestion via the string-equality fallback (see issue #154).
+    let current_clean = normalize_version(&truncate_version(
+        &strip_python_prerelease(&current_normalized),
+        3,
+    ));
+    let latest_clean = normalize_version(&truncate_version(
+        &strip_python_prerelease(&latest_normalized),
+        3,
+    ));
+
+    match (
+        semver::Version::parse(&current_clean),
+        semver::Version::parse(&latest_clean),
     ) {
         (Ok(current_ver), Ok(latest_ver)) => {
             if current_ver >= latest_ver {
@@ -456,8 +482,8 @@ pub fn compare_versions(current: &str, info: &VersionInfo) -> VersionStatus {
             }
         }
         _ => {
-            // Fallback to string comparison if semver parsing fails
-            if current_normalized == latest_normalized {
+            // Final fallback: string comparison on cleaned versions
+            if current_clean == latest_clean {
                 VersionStatus::UpToDate
             } else {
                 VersionStatus::UpdateAvailable(latest.to_owned())
@@ -679,6 +705,52 @@ mod tests {
             compare_versions("~=4.0a", &info),
             VersionStatus::UpToDate
         ));
+    }
+
+    #[test]
+    fn test_issue_154_compatible_release_matches_real_pypi_latest() {
+        // Reproduces the reported scenario of issue #154: a PyPI package
+        // (apscheduler) with stable latest in a lower major than the pinned
+        // pre-release (`~=4.0a`) — must be UpToDate, not a downgrade suggestion.
+        let info = make_version_info("3.11.2");
+        let result = compare_versions("~=4.0a", &info);
+        assert!(matches!(result, VersionStatus::UpToDate), "Got: {result:?}");
+    }
+
+    #[test]
+    fn test_issue_154_bare_prerelease_from_lockfile() {
+        // If a Python lockfile resolves apscheduler to a pre-release (e.g., "4.0.0a6"),
+        // `effective_version()` returns the bare pre-release, which bypasses the ~= path
+        let info = make_version_info("3.11.2");
+        let result = compare_versions("4.0.0a6", &info);
+        assert!(matches!(result, VersionStatus::UpToDate), "Got: {result:?}");
+    }
+
+    #[test]
+    fn test_issue_154_bare_prerelease_variants() {
+        let info = make_version_info("3.11.2");
+        for v in [
+            "4.0a",
+            "4.0a1",
+            "4.0.0a1",
+            "4.0.0b2",
+            "4.0.0rc1",
+            "4.0.0.dev1",
+        ] {
+            let result = compare_versions(v, &info);
+            assert!(
+                matches!(result, VersionStatus::UpToDate),
+                "Input {v}: Got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_issue_154_exact_pin_prerelease() {
+        // Exact pin with == operator
+        let info = make_version_info("3.11.2");
+        let result = compare_versions("==4.0.0a6", &info);
+        assert!(matches!(result, VersionStatus::UpToDate), "Got: {result:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Issue #154 reopened: `apscheduler~=4.0a` still suggested downgrade to `~=3.11` in v1.7.0 despite the earlier #157 fix
- `compare_versions` now handles bare PEP 440 pre-release versions in the general code path, not just the `~=` branch
- Adds 4 regression tests covering lockfile-resolved pre-release, `==` pin, and multiple PEP 440 marker forms

## Root Cause

The original fix (#157) only addressed the `~=` compatible-release operator path in `compare_versions`. Later Python lockfile resolution (poetry/uv/pdm/pipenv) populated `Dependency.resolved_version`, and `effective_version()` started returning the resolved lockfile value (e.g., `"4.0.0a6"`) instead of the declared specifier `"~=4.0a"`.

Flow under regression:

1. Lockfile resolves `apscheduler` → `resolved_version = "4.0.0a6"`
2. `effective_version()` returns bare `"4.0.0a6"` (no `~=` prefix)
3. `compare_versions("4.0.0a6", info{latest:"3.11.2"})` skips the `~=` branch
4. `semver::Version::parse("4.0.0a6")` fails (invalid semver — needs `-a6` form)
5. Fallback string compare: `"4.0.0a6" != "3.11.2"` → `UpdateAvailable("3.11.2")` → bogus downgrade

## Fix

`compare_versions` now retries semver parsing after stripping PEP 440 pre-release markers when the initial parse fails. The existing `strip_python_prerelease` helper is reused, plus `truncate_version(_, 3)` to keep at most `major.minor.patch` after stripping (handles 4-segment `.dev1` form).

Safety:
- Clean semver (`1.0.0`, `3.11.2`): parses on first attempt → retry branch never runs
- Semver pre-release (Rust `1.0.0-alpha.1`): parses on first attempt → retry branch never runs
- Only PEP 440 bare pre-releases that fail semver parse benefit from the retry

## Test plan

- [x] `test_issue_154_compatible_release_matches_real_pypi_latest` — `~=4.0a` vs real PyPI `3.11.2`
- [x] `test_issue_154_bare_prerelease_from_lockfile` — bare `4.0.0a6` (lockfile-resolved)
- [x] `test_issue_154_bare_prerelease_variants` — `4.0a`, `4.0a1`, `4.0.0a1`, `4.0.0b2`, `4.0.0rc1`, `4.0.0.dev1`
- [x] `test_issue_154_exact_pin_prerelease` — `==4.0.0a6`
- [x] 593 unit tests pass (4 new)
- [x] 8 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings`: clean
- [x] `cargo fmt --all -- --check`: clean
- [x] Release build: OK

Fixes #154

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #154 by preventing false downgrade suggestions for Python bare PEP 440 pre-releases in `compare_versions` while preserving 4‑segment calendar versions. Also bumps `rustls-webpki` to 0.103.13 to address RUSTSEC-2026-0104.

- **Bug Fixes**
  - Retry semver after stripping PEP 440 markers; truncate to `major.minor.patch` only if stripping changed the input (no collapse of calver like `2024.1.1.5`).
  - If cleaned versions parse equal but originals differ (e.g., `4.0.0a6` vs `4.0.0a7` or `4.0.0`), report an update.
  - Keep final fallback on cleaned strings; add regression tests and update `CHANGELOG.md`.

- **Dependencies**
  - Update `rustls-webpki` to `0.103.13` (RUSTSEC-2026-0104); refresh lockfiles in `dependi-lsp` and `dependi-lsp/fuzz`.

<sup>Written for commit 46b39157f61e5c2aee203c990c5fbd67814c0875. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected version comparison so pre-release markers (e.g., a, b, rc, dev) no longer cause incorrect downgrade or update alerts; dependency status now reflects true update availability across varied pre-release formats.

* **Tests**
  * Added regression tests covering multiple pre-release and calendar-version edge cases to prevent future regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->