### PR TITLE
feat: add 'Ignore package' code action (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Ignore package "<name>"` quick-fix code action on every dependency. Adds
+  the package to `lsp.dependi.initialization_options.ignore` in the workspace
+  `.zed/settings.json`, creating the file if it does not exist, deduplicating
+  if the package is already listed, and preserving any other settings
+  ([#226](https://github.com/mpiton/zed-dependi/issues/226))
+- Diagnostics and "Update" code actions now respect the `ignore` list
+  (previously only inlay hints did), giving consistent silencing behavior for
+  packages users have chosen to ignore
 - `--output html` format for `dependi-lsp scan` — self-contained HTML report
   with summary table and separate Direct/Transitive sections, HTML-escaped
   against hostile advisory content, suitable for CI/CD artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   querying OSV — previously the CLI queried using the specifier string (e.g.
   `^1.0`), which caused false negatives.
 - Respect the `package` field of `Cargo.toml` dependencies
+- `settings_edit::build_create_edit` now uses a full-document replace range
+  instead of a zero-width insert at `(0,0)`. With `ignore_if_exists: true`,
+  if `.zed/settings.json` appeared between read and apply the `CreateFile`
+  would be skipped and the text edit would prepend new JSON to the existing
+  file, corrupting it ([#226](https://github.com/mpiton/zed-dependi/issues/226))
+- `find_workspace_root` now returns `None` when no ancestor contains `.zed/`
+  instead of falling back to the manifest's parent directory. Prevents a
+  stray `.zed/settings.json` being written to a nested directory when the
+  real Zed workspace lives higher up; the Ignore code action degrades
+  gracefully when no workspace root can be resolved
+- `Backend::code_action` no longer holds a `DashMap` guard across `.await`
+  boundaries; it now snapshots document state into owned values and drops
+  the guard before any async I/O to avoid potential deadlocks
+- `Ignore package` quick-fix now emitted for Maven property-reference
+  dependencies (e.g., `${spring.version}`). These deps remain ineligible
+  for the `Update` action (which would break property-driven version
+  management) but can still be silenced. Also restored the pre-refactor
+  behavior that `Update all N dependencies` considers every non-ignored
+  dep in the file rather than only those inside the requested range
 - Bare PEP 440 pre-release versions (e.g., `4.0.0a6`, `1.0b2`, `2.0rc1`,
   `1.0.0.dev1`) no longer trigger spurious downgrade suggestions in
   `compare_versions`. This scenario occurred with Python lockfile resolution

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -1886,21 +1886,7 @@ impl LanguageServer for DependiBackend {
                 // Only show hints for dependencies in the visible range
                 (params.range.start.line..=params.range.end.line).contains(&dep.version_span.line)
             })
-            .filter(|dep| {
-                // Skip ignored packages
-                !ignored_packages.iter().any(|pattern| {
-                    if pattern.contains('*') {
-                        let parts: Vec<&str> = pattern.split('*').collect();
-                        if parts.len() == 2 {
-                            dep.name.starts_with(parts[0]) && dep.name.ends_with(parts[1])
-                        } else {
-                            dep.name.starts_with(parts[0])
-                        }
-                    } else {
-                        dep.name == *pattern
-                    }
-                })
-            })
+            .filter(|dep| !crate::config::is_package_ignored(&dep.name, &ignored_packages))
             .filter_map(|dep| {
                 let cache_key = dep_cache_key(dep, file_type);
                 let version_info = self.version_cache.get(&cache_key);

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -2010,6 +2010,12 @@ impl LanguageServer for DependiBackend {
             return Ok(Some(vec![]));
         };
 
+        let ignored_packages = self
+            .config
+            .read()
+            .map(|c| c.ignore.clone())
+            .unwrap_or_default();
+
         let file_type = doc.file_type;
         let cache_key_map: HashMap<String, String> = doc
             .dependencies
@@ -2028,6 +2034,9 @@ impl LanguageServer for DependiBackend {
                     .cloned()
                     .unwrap_or_else(|| file_type.cache_key(name))
             },
+            &ignored_packages,
+            None, // workspace_root — wired in Task 7
+            None, // current_settings — wired in Task 7
         );
 
         Ok(Some(actions))

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -53,7 +53,11 @@ use crate::{
 };
 
 /// Walk parents of `file_path` looking for a `.zed/` directory.
-/// Returns the first ancestor that contains it, or the file's parent dir as fallback.
+/// Returns the first ancestor that contains it, or `None` if no ancestor has `.zed/`.
+///
+/// Returning `None` (rather than guessing the file's parent) avoids writing
+/// `.zed/settings.json` to a nested directory when the real workspace lives higher up.
+/// The Ignore code action degrades gracefully when this returns `None`.
 ///
 /// Uses `tokio::fs::metadata` (async) per project rule: no blocking I/O in async tasks.
 async fn find_workspace_root(file_path: &std::path::Path) -> Option<std::path::PathBuf> {
@@ -66,7 +70,7 @@ async fn find_workspace_root(file_path: &std::path::Path) -> Option<std::path::P
             return Some(ancestor.to_path_buf());
         }
     }
-    Some(start.to_path_buf())
+    None
 }
 
 /// Extract the `[package].name` field from a Cargo.toml manifest.
@@ -2023,8 +2027,21 @@ impl LanguageServer for DependiBackend {
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
         let uri = &params.text_document.uri;
 
-        let Some(doc) = self.documents.get(uri) else {
-            return Ok(Some(vec![]));
+        // Snapshot everything we need from the document state, then drop the
+        // DashMap guard before any .await — holding a guard across .await can
+        // deadlock other tasks waiting on the same key.
+        let (file_type, dependencies, cache_key_map) = {
+            let Some(doc) = self.documents.get(uri) else {
+                return Ok(Some(vec![]));
+            };
+            let file_type = doc.file_type;
+            let dependencies = doc.dependencies.clone();
+            let cache_key_map: HashMap<String, String> = doc
+                .dependencies
+                .iter()
+                .map(|dep| (dep.name.clone(), dep_cache_key(dep, file_type)))
+                .collect();
+            (file_type, dependencies, cache_key_map)
         };
 
         let ignored_packages = self
@@ -2032,13 +2049,6 @@ impl LanguageServer for DependiBackend {
             .read()
             .map(|c| c.ignore.clone())
             .unwrap_or_default();
-
-        let file_type = doc.file_type;
-        let cache_key_map: HashMap<String, String> = doc
-            .dependencies
-            .iter()
-            .map(|dep| (dep.name.clone(), dep_cache_key(dep, file_type)))
-            .collect();
 
         // Detect workspace root + read .zed/settings.json (best-effort).
         // If anything fails, the Ignore action will be omitted but Update actions still work.
@@ -2056,7 +2066,7 @@ impl LanguageServer for DependiBackend {
         };
 
         let actions = create_code_actions(
-            &doc.dependencies,
+            &dependencies,
             &self.version_cache,
             uri,
             params.range,
@@ -2256,10 +2266,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_find_workspace_root_falls_back_to_parent_dir() {
-        // Use a deeply nested tempdir path that's unlikely to have `.zed/`
-        // in any ancestor, then assert the returned path equals the file's
-        // parent dir (not just `is_some()`).
+    async fn test_find_workspace_root_returns_none_when_no_zed_ancestor() {
         let dir = tempfile::tempdir().expect("tempdir");
         let nested = dir.path().join("a").join("b").join("c").join("d");
         std::fs::create_dir_all(&nested).expect("create nested");
@@ -2267,7 +2274,9 @@ mod tests {
         std::fs::write(&file, "").expect("create file");
 
         let found = super::find_workspace_root(&file).await;
-        // Should fall back to file's parent dir (no .zed in any ancestor).
-        assert_eq!(found.as_deref(), Some(nested.as_path()));
+        assert!(
+            found.is_none(),
+            "expected None when no ancestor has .zed/, got {found:?}"
+        );
     }
 }

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -697,7 +697,13 @@ impl ProcessingContext {
         );
 
         // Publish diagnostics IMMEDIATELY (versions are available, vulnerabilities will update later)
-        let (diagnostics_enabled, security_show_diags, min_severity, security_enabled) = self
+        let (
+            diagnostics_enabled,
+            security_show_diags,
+            min_severity,
+            security_enabled,
+            ignored_packages,
+        ) = self
             .config
             .read()
             .map(|c| {
@@ -710,9 +716,10 @@ impl ProcessingContext {
                         None
                     },
                     c.security.enabled,
+                    c.ignore.clone(),
                 )
             })
-            .unwrap_or((true, true, None, true));
+            .unwrap_or((true, true, None, true, Vec::new()));
 
         if diagnostics_enabled {
             let severity_filter = if security_show_diags {
@@ -744,6 +751,7 @@ impl ProcessingContext {
                 severity_filter,
                 file_type,
                 &empty_transitives,
+                &ignored_packages,
             );
 
             self.client

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -54,10 +54,15 @@ use crate::{
 
 /// Walk parents of `file_path` looking for a `.zed/` directory.
 /// Returns the first ancestor that contains it, or the file's parent dir as fallback.
-fn find_workspace_root(file_path: &std::path::Path) -> Option<std::path::PathBuf> {
+///
+/// Uses `tokio::fs::metadata` (async) per project rule: no blocking I/O in async tasks.
+async fn find_workspace_root(file_path: &std::path::Path) -> Option<std::path::PathBuf> {
     let start = file_path.parent()?;
     for ancestor in start.ancestors() {
-        if ancestor.join(".zed").is_dir() {
+        let candidate = ancestor.join(".zed");
+        if let Ok(meta) = tokio::fs::metadata(&candidate).await
+            && meta.is_dir()
+        {
             return Some(ancestor.to_path_buf());
         }
     }
@@ -2038,7 +2043,10 @@ impl LanguageServer for DependiBackend {
         // Detect workspace root + read .zed/settings.json (best-effort).
         // If anything fails, the Ignore action will be omitted but Update actions still work.
         let file_path = uri.to_file_path().ok();
-        let workspace_root = file_path.as_deref().and_then(find_workspace_root);
+        let workspace_root = match file_path.as_deref() {
+            Some(p) => find_workspace_root(p).await,
+            None => None,
+        };
         let current_settings: Option<String> = match &workspace_root {
             Some(root) => {
                 let settings_path = root.join(".zed").join("settings.json");
@@ -2233,8 +2241,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_find_workspace_root_locates_zed_dir() {
+    #[tokio::test]
+    async fn test_find_workspace_root_locates_zed_dir() {
         let dir = tempfile::tempdir().expect("tempdir");
         let workspace = dir.path();
         std::fs::create_dir_all(workspace.join(".zed")).expect("create .zed");
@@ -2243,21 +2251,23 @@ mod tests {
         std::fs::create_dir_all(nested_file.parent().unwrap()).expect("create subdir");
         std::fs::write(&nested_file, "").expect("create file");
 
-        let found = super::find_workspace_root(&nested_file);
+        let found = super::find_workspace_root(&nested_file).await;
         assert_eq!(found.as_deref(), Some(workspace));
     }
 
-    #[test]
-    fn test_find_workspace_root_falls_back_to_parent_dir() {
+    #[tokio::test]
+    async fn test_find_workspace_root_falls_back_to_parent_dir() {
+        // Use a deeply nested tempdir path that's unlikely to have `.zed/`
+        // in any ancestor, then assert the returned path equals the file's
+        // parent dir (not just `is_some()`).
         let dir = tempfile::tempdir().expect("tempdir");
-        let workspace = dir.path();
-        let file = workspace.join("Cargo.toml");
+        let nested = dir.path().join("a").join("b").join("c").join("d");
+        std::fs::create_dir_all(&nested).expect("create nested");
+        let file = nested.join("Cargo.toml");
         std::fs::write(&file, "").expect("create file");
 
-        let found = super::find_workspace_root(&file);
-        // Walks up from `workspace`, no .zed found anywhere — falls back to `workspace`.
-        // Note: ancestors of /tmp may have .zed in unrelated user dirs in dev environment.
-        // Accept either workspace itself OR an ancestor that has .zed (rare).
-        assert!(found.is_some(), "expected Some, got None");
+        let found = super::find_workspace_root(&file).await;
+        // Should fall back to file's parent dir (no .zed in any ancestor).
+        assert_eq!(found.as_deref(), Some(nested.as_path()));
     }
 }

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -52,6 +52,18 @@ use crate::{
     reports::fmt_markdown_report,
 };
 
+/// Walk parents of `file_path` looking for a `.zed/` directory.
+/// Returns the first ancestor that contains it, or the file's parent dir as fallback.
+fn find_workspace_root(file_path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let start = file_path.parent()?;
+    for ancestor in start.ancestors() {
+        if ancestor.join(".zed").is_dir() {
+            return Some(ancestor.to_path_buf());
+        }
+    }
+    Some(start.to_path_buf())
+}
+
 /// Extract the `[package].name` field from a Cargo.toml manifest.
 /// Used to pass the root package name to `parse_cargo_lock` for multi-version disambiguation.
 fn cargo_root_package_name(manifest_content: &str) -> Option<String> {
@@ -2022,6 +2034,19 @@ impl LanguageServer for DependiBackend {
             .iter()
             .map(|dep| (dep.name.clone(), dep_cache_key(dep, file_type)))
             .collect();
+
+        // Detect workspace root + read .zed/settings.json (best-effort).
+        // If anything fails, the Ignore action will be omitted but Update actions still work.
+        let file_path = uri.to_file_path().ok();
+        let workspace_root = file_path.as_deref().and_then(find_workspace_root);
+        let current_settings: Option<String> = match &workspace_root {
+            Some(root) => {
+                let settings_path = root.join(".zed").join("settings.json");
+                tokio::fs::read_to_string(&settings_path).await.ok()
+            }
+            None => None,
+        };
+
         let actions = create_code_actions(
             &doc.dependencies,
             &self.version_cache,
@@ -2035,8 +2060,8 @@ impl LanguageServer for DependiBackend {
                     .unwrap_or_else(|| file_type.cache_key(name))
             },
             &ignored_packages,
-            None, // workspace_root — wired in Task 7
-            None, // current_settings — wired in Task 7
+            workspace_root.as_deref(),
+            current_settings.as_deref(),
         );
 
         Ok(Some(actions))
@@ -2206,5 +2231,33 @@ mod tests {
             content.contains("CVE-1"),
             "Hover should contain transitive vuln id, got:\n{content}"
         );
+    }
+
+    #[test]
+    fn test_find_workspace_root_locates_zed_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let workspace = dir.path();
+        std::fs::create_dir_all(workspace.join(".zed")).expect("create .zed");
+
+        let nested_file = workspace.join("subdir").join("Cargo.toml");
+        std::fs::create_dir_all(nested_file.parent().unwrap()).expect("create subdir");
+        std::fs::write(&nested_file, "").expect("create file");
+
+        let found = super::find_workspace_root(&nested_file);
+        assert_eq!(found.as_deref(), Some(workspace));
+    }
+
+    #[test]
+    fn test_find_workspace_root_falls_back_to_parent_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let workspace = dir.path();
+        let file = workspace.join("Cargo.toml");
+        std::fs::write(&file, "").expect("create file");
+
+        let found = super::find_workspace_root(&file);
+        // Walks up from `workspace`, no .zed found anywhere — falls back to `workspace`.
+        // Note: ancestors of /tmp may have .zed in unrelated user dirs in dev environment.
+        // Accept either workspace itself OR an ancestor that has .zed (rare).
+        assert!(found.is_some(), "expected Some, got None");
     }
 }

--- a/dependi-lsp/src/config.rs
+++ b/dependi-lsp/src/config.rs
@@ -241,6 +241,30 @@ impl Config {
     }
 }
 
+/// Returns true if `name` matches any pattern in `patterns`.
+///
+/// Supported pattern syntax:
+/// - exact match: `"lodash"` matches only `"lodash"`
+/// - prefix wildcard: `"@company/*"` matches names starting with `"@company/"`
+/// - suffix wildcard: `"*-test"` matches names ending with `"-test"`
+/// - both wildcards: `"internal-*-lib"` matches names with that prefix AND suffix
+///
+/// Multiple `*` patterns fall back to prefix-only match (matches the first segment).
+pub fn is_package_ignored(name: &str, patterns: &[String]) -> bool {
+    patterns.iter().any(|pattern| {
+        if pattern.contains('*') {
+            let parts: Vec<&str> = pattern.split('*').collect();
+            if parts.len() == 2 {
+                name.starts_with(parts[0]) && name.ends_with(parts[1])
+            } else {
+                name.starts_with(parts[0])
+            }
+        } else {
+            name == *pattern
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -629,5 +653,50 @@ mod tests {
             config.registries.maven.url,
             "https://nexus.internal.corp/repository/maven-public"
         );
+    }
+
+    #[test]
+    fn test_is_package_ignored_exact_match() {
+        let patterns = vec!["lodash".to_string(), "react".to_string()];
+        assert!(super::is_package_ignored("lodash", &patterns));
+        assert!(super::is_package_ignored("react", &patterns));
+        assert!(!super::is_package_ignored("vue", &patterns));
+    }
+
+    #[test]
+    fn test_is_package_ignored_prefix_wildcard() {
+        let patterns = vec!["@company/*".to_string()];
+        assert!(super::is_package_ignored("@company/utils", &patterns));
+        assert!(super::is_package_ignored("@company/", &patterns));
+        assert!(!super::is_package_ignored("@other/utils", &patterns));
+    }
+
+    #[test]
+    fn test_is_package_ignored_suffix_wildcard() {
+        let patterns = vec!["*-test".to_string()];
+        assert!(super::is_package_ignored("foo-test", &patterns));
+        assert!(super::is_package_ignored("-test", &patterns));
+        assert!(!super::is_package_ignored("foo-prod", &patterns));
+    }
+
+    #[test]
+    fn test_is_package_ignored_both_wildcards() {
+        let patterns = vec!["internal-*-lib".to_string()];
+        assert!(super::is_package_ignored("internal-foo-lib", &patterns));
+        assert!(super::is_package_ignored("internal--lib", &patterns));
+        assert!(!super::is_package_ignored("external-foo-lib", &patterns));
+    }
+
+    #[test]
+    fn test_is_package_ignored_empty_patterns() {
+        let patterns: Vec<String> = vec![];
+        assert!(!super::is_package_ignored("lodash", &patterns));
+    }
+
+    #[test]
+    fn test_is_package_ignored_multiple_wildcards_falls_back_to_prefix() {
+        let patterns = vec!["a-*-b-*-c".to_string()];
+        assert!(super::is_package_ignored("a-anything", &patterns));
+        assert!(!super::is_package_ignored("b-anything", &patterns));
     }
 }

--- a/dependi-lsp/src/config.rs
+++ b/dependi-lsp/src/config.rs
@@ -243,13 +243,18 @@ impl Config {
 
 /// Returns true if `name` matches any pattern in `patterns`.
 ///
-/// Supported pattern syntax:
+/// Supported pattern syntax (preserves the historical inlay-hints filter behavior):
 /// - exact match: `"lodash"` matches only `"lodash"`
 /// - prefix wildcard: `"@company/*"` matches names starting with `"@company/"`
 /// - suffix wildcard: `"*-test"` matches names ending with `"-test"`
 /// - both wildcards: `"internal-*-lib"` matches names with that prefix AND suffix
+///   (the middle may be empty: `"internal--lib"` is matched)
 ///
-/// Multiple `*` patterns fall back to prefix-only match (matches the first segment).
+/// Caveats — known sharp edges of this simple matcher:
+/// - A bare `"*"` pattern matches every package.
+/// - Patterns with more than one `*` (e.g., `"a-*-b-*-c"`) are NOT fully supported;
+///   they fall back to a prefix-only match against the substring before the first `*`.
+///   For richer matching, prefer one or two `*` patterns, or list packages explicitly.
 pub fn is_package_ignored(name: &str, patterns: &[String]) -> bool {
     patterns.iter().any(|pattern| {
         if pattern.contains('*') {
@@ -698,5 +703,28 @@ mod tests {
         let patterns = vec!["a-*-b-*-c".to_string()];
         assert!(super::is_package_ignored("a-anything", &patterns));
         assert!(!super::is_package_ignored("b-anything", &patterns));
+    }
+
+    #[test]
+    fn test_is_package_ignored_bare_wildcard_matches_all() {
+        // Documented sharp edge: bare "*" matches every name.
+        let patterns = vec!["*".to_string()];
+        assert!(super::is_package_ignored("anything", &patterns));
+        assert!(super::is_package_ignored("", &patterns));
+    }
+
+    #[test]
+    fn test_is_package_ignored_prefix_suffix_overlap_with_empty_middle() {
+        // Pattern "prefix*suffix" matches when prefix and suffix overlap to zero middle chars.
+        let patterns = vec!["internal-*-lib".to_string()];
+        assert!(super::is_package_ignored("internal--lib", &patterns));
+    }
+
+    #[test]
+    fn test_is_package_ignored_empty_pattern_string_matches_only_empty_name() {
+        // An empty-string pattern is an exact-match for the empty name.
+        let patterns = vec!["".to_string()];
+        assert!(super::is_package_ignored("", &patterns));
+        assert!(!super::is_package_ignored("anything", &patterns));
     }
 }

--- a/dependi-lsp/src/lib.rs
+++ b/dependi-lsp/src/lib.rs
@@ -13,5 +13,6 @@ pub mod parsers;
 pub mod providers;
 pub mod registries;
 pub mod reports;
+pub mod settings_edit;
 pub mod utils;
 pub mod vulnerabilities;

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -88,6 +88,10 @@ fn normalize_version(version: &str) -> String {
 }
 
 /// Create code actions for dependencies in the given range
+#[expect(
+    clippy::too_many_arguments,
+    reason = "LSP context requires passing doc state, cache, range, ignore list, and workspace metadata together; refactoring into a struct is tracked for a follow-up."
+)]
 pub fn create_code_actions(
     dependencies: &[Dependency],
     cache: &impl ReadCache,
@@ -95,16 +99,32 @@ pub fn create_code_actions(
     range: Range,
     file_type: FileType,
     cache_key_fn: impl Fn(&str) -> String,
+    ignored: &[String],
+    workspace_root: Option<&std::path::Path>,
+    current_settings: Option<&str>,
 ) -> Vec<CodeActionOrCommand> {
-    let mut actions: Vec<CodeActionOrCommand> = dependencies
+    let _ = (workspace_root, current_settings); // wired in Task 6
+
+    // Pre-filter active (non-ignored, non-property, in-range) deps once so
+    // ignored packages are excluded from BOTH per-dep update actions AND
+    // the Update-All tally.
+    let active: Vec<&Dependency> = dependencies
         .iter()
-        .filter(|dep| (range.start.line..=range.end.line).contains(&dep.version_span.line))
-        .filter(|dep| !is_property_reference(dep))
+        .filter(|dep| {
+            (range.start.line..=range.end.line).contains(&dep.version_span.line)
+                && !is_property_reference(dep)
+                && !crate::config::is_package_ignored(&dep.name, ignored)
+        })
+        .collect();
+
+    let mut actions: Vec<CodeActionOrCommand> = active
+        .iter()
         .filter_map(|dep| create_update_action(dep, cache, uri, file_type, &cache_key_fn))
         .collect();
 
+    let active_owned: Vec<Dependency> = active.iter().map(|d| (*d).clone()).collect();
     if let Some(update_all) =
-        create_update_all_action(dependencies, cache, uri, file_type, &cache_key_fn)
+        create_update_all_action(&active_owned, cache, uri, file_type, &cache_key_fn)
     {
         actions.insert(0, update_all);
     }
@@ -368,9 +388,17 @@ mod tests {
             },
         };
 
-        let actions = create_code_actions(&deps, &cache, &uri, range, FileType::Cargo, |name| {
-            format!("test:{name}")
-        });
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        );
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -406,9 +434,17 @@ mod tests {
             },
         };
 
-        let actions = create_code_actions(&deps, &cache, &uri, range, FileType::Cargo, |name| {
-            format!("test:{name}")
-        });
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        );
 
         assert_eq!(actions.len(), 0);
     }
@@ -464,9 +500,17 @@ mod tests {
             },
         };
 
-        let actions = create_code_actions(&deps, &cache, &uri, range, FileType::Cargo, |name| {
-            format!("test:{name}")
-        });
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        );
 
         assert_eq!(actions.len(), 4);
         match &actions[0] {
@@ -524,9 +568,17 @@ mod tests {
             },
         };
 
-        let actions = create_code_actions(&deps, &cache, &uri, range, FileType::Cargo, |name| {
-            format!("test:{name}")
-        });
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        );
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -572,9 +624,17 @@ mod tests {
             },
         };
 
-        let actions = create_code_actions(&deps, &cache, &uri, range, FileType::Cargo, |name| {
-            format!("test:{name}")
-        });
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        );
 
         assert_eq!(actions.len(), 0);
     }
@@ -666,9 +726,17 @@ mod tests {
             },
         };
 
-        let actions = create_code_actions(&deps, &cache, &uri, range, FileType::Cargo, |name| {
-            format!("test:{name}")
-        });
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        );
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -705,9 +773,17 @@ mod tests {
             },
         };
 
-        let actions = create_code_actions(&deps, &cache, &uri, range, FileType::Cargo, |name| {
-            format!("test:{name}")
-        });
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        );
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -744,9 +820,17 @@ mod tests {
             },
         };
 
-        let actions = create_code_actions(&deps, &cache, &uri, range, FileType::Cargo, |name| {
-            format!("test:{name}")
-        });
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        );
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -862,9 +946,17 @@ mod tests {
             },
         };
 
-        let actions = create_code_actions(&deps, &cache, &uri, range, FileType::Python, |name| {
-            format!("test:{name}")
-        });
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Python,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        );
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -907,9 +999,17 @@ mod tests {
             },
         };
 
-        let actions = create_code_actions(&deps, &cache, &uri, range, FileType::Python, |name| {
-            format!("test:{name}")
-        });
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Python,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        );
 
         assert_eq!(actions.len(), 0);
     }
@@ -938,9 +1038,17 @@ mod tests {
             },
         };
 
-        let actions = create_code_actions(&deps, &cache, &uri, range, FileType::Cargo, |name| {
-            format!("test:{name}")
-        });
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        );
 
         assert_eq!(actions.len(), 0);
     }
@@ -962,10 +1070,102 @@ mod tests {
             },
         };
 
-        let actions = create_code_actions(&deps, &cache, &uri, range, FileType::Cargo, |name| {
-            format!("test:{name}")
-        });
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        );
 
         assert_eq!(actions.len(), 0);
+    }
+
+    #[test]
+    fn test_update_action_skipped_for_ignored_package() {
+        let cache = MemoryCache::new();
+        cache.insert(
+            "test:lodash".to_string(),
+            VersionInfo {
+                latest: Some("2.0.0".to_string()),
+                ..Default::default()
+            },
+        );
+        let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
+        let uri = Url::parse("file:///test/Cargo.toml").unwrap();
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 10,
+                character: 0,
+            },
+        };
+        let ignored = vec!["lodash".to_string()];
+
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &ignored,
+            None,
+            None,
+        );
+
+        assert!(
+            actions.is_empty(),
+            "ignored package should produce no actions"
+        );
+    }
+
+    #[test]
+    fn test_update_action_emitted_when_not_ignored() {
+        let cache = MemoryCache::new();
+        cache.insert(
+            "test:react".to_string(),
+            VersionInfo {
+                latest: Some("18.0.0".to_string()),
+                ..Default::default()
+            },
+        );
+        let deps = vec![create_test_dependency("react", "17.0.0", 5)];
+        let uri = Url::parse("file:///test/Cargo.toml").unwrap();
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 10,
+                character: 0,
+            },
+        };
+        let ignored = vec!["lodash".to_string()];
+
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &ignored,
+            None,
+            None,
+        );
+
+        assert!(
+            !actions.is_empty(),
+            "non-ignored outdated package should produce action"
+        );
     }
 }

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -127,9 +127,8 @@ pub fn create_code_actions(
         }
     }
 
-    let active_owned: Vec<Dependency> = active.iter().map(|d| (*d).clone()).collect();
     if let Some(update_all) =
-        create_update_all_action(&active_owned, cache, uri, file_type, &cache_key_fn)
+        create_update_all_action(&active, cache, uri, file_type, &cache_key_fn)
     {
         actions.insert(0, update_all);
     }
@@ -247,7 +246,7 @@ fn create_ignore_action(
 
 /// Create an "Update All Dependencies" code action when 2+ updates are available
 fn create_update_all_action(
-    dependencies: &[Dependency],
+    dependencies: &[&Dependency],
     cache: &impl ReadCache,
     uri: &Url,
     file_type: FileType,
@@ -255,6 +254,7 @@ fn create_update_all_action(
 ) -> Option<CodeActionOrCommand> {
     let outdated_deps: Vec<(&Dependency, String)> = dependencies
         .iter()
+        .copied()
         .filter(|dep| !is_property_reference(dep))
         .filter_map(|dep| {
             let cache_key = cache_key_fn(&dep.name);

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -103,23 +103,39 @@ pub fn create_code_actions(
     workspace_root: Option<&std::path::Path>,
     current_settings: Option<&str>,
 ) -> Vec<CodeActionOrCommand> {
-    // Pre-filter active (non-ignored, non-property, in-range) deps once so
-    // ignored packages are excluded from BOTH per-dep update actions AND
-    // the Update-All tally.
-    let active: Vec<&Dependency> = dependencies
+    // Three slices with distinct scopes:
+    //   - non_ignored:        all non-ignored deps in the file (used for Update-All tally)
+    //   - ignore_candidates:  in-range, non-ignored — eligible for the Ignore action
+    //                         (property refs CAN still be ignored even though they
+    //                         can't safely be Updated)
+    //   - update_candidates:  in-range, non-ignored, NOT property reference —
+    //                         eligible for individual Update actions
+    let non_ignored: Vec<&Dependency> = dependencies
         .iter()
-        .filter(|dep| {
-            (range.start.line..=range.end.line).contains(&dep.version_span.line)
-                && !is_property_reference(dep)
-                && !crate::config::is_package_ignored(&dep.name, ignored)
-        })
+        .filter(|dep| !crate::config::is_package_ignored(&dep.name, ignored))
+        .collect();
+
+    let ignore_candidates: Vec<&Dependency> = non_ignored
+        .iter()
+        .copied()
+        .filter(|dep| (range.start.line..=range.end.line).contains(&dep.version_span.line))
+        .collect();
+
+    let update_candidates: Vec<&Dependency> = ignore_candidates
+        .iter()
+        .copied()
+        .filter(|dep| !is_property_reference(dep))
         .collect();
 
     let mut actions: Vec<CodeActionOrCommand> = Vec::new();
-    for dep in &active {
+
+    for dep in &update_candidates {
         if let Some(update) = create_update_action(dep, cache, uri, file_type, &cache_key_fn) {
             actions.push(update);
         }
+    }
+
+    for dep in &ignore_candidates {
         if let Some(root) = workspace_root
             && let Some(ignore) = create_ignore_action(dep, root, current_settings)
         {
@@ -128,7 +144,7 @@ pub fn create_code_actions(
     }
 
     if let Some(update_all) =
-        create_update_all_action(&active, cache, uri, file_type, &cache_key_fn)
+        create_update_all_action(&non_ignored, cache, uri, file_type, &cache_key_fn)
     {
         actions.insert(0, update_all);
     }
@@ -1351,6 +1367,63 @@ mod tests {
         assert!(
             titles.iter().any(|t| t.contains("Ignore package")),
             "expected Ignore action for up-to-date package"
+        );
+    }
+
+    #[test]
+    fn test_property_reference_gets_ignore_action_but_not_update() {
+        let cache = MemoryCache::new();
+        cache.insert(
+            "test:my-pkg".to_string(),
+            VersionInfo {
+                latest: Some("2.0.0".to_string()),
+                ..Default::default()
+            },
+        );
+        // Create a dep whose version is a Maven-style property reference.
+        let dep = create_test_dependency("my-pkg", "${my.version}", 5);
+        let deps = vec![dep];
+        let uri = Url::parse("file:///test/pom.xml").unwrap();
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 10,
+                character: 0,
+            },
+        };
+        let workspace = std::path::PathBuf::from("/tmp/ws");
+
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            Some(&workspace),
+            None,
+        );
+
+        let titles: Vec<String> = actions
+            .iter()
+            .filter_map(|a| match a {
+                CodeActionOrCommand::CodeAction(ca) => Some(ca.title.clone()),
+                _ => None,
+            })
+            .collect();
+
+        // Property reference: NO Update action, but YES Ignore action
+        assert!(
+            !titles.iter().any(|t| t.contains("Update my-pkg")),
+            "property ref must not get Update action"
+        );
+        assert!(
+            titles.iter().any(|t| t.contains("Ignore package")),
+            "property ref MUST get Ignore action"
         );
     }
 

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -103,8 +103,6 @@ pub fn create_code_actions(
     workspace_root: Option<&std::path::Path>,
     current_settings: Option<&str>,
 ) -> Vec<CodeActionOrCommand> {
-    let _ = (workspace_root, current_settings); // wired in Task 6
-
     // Pre-filter active (non-ignored, non-property, in-range) deps once so
     // ignored packages are excluded from BOTH per-dep update actions AND
     // the Update-All tally.
@@ -117,10 +115,17 @@ pub fn create_code_actions(
         })
         .collect();
 
-    let mut actions: Vec<CodeActionOrCommand> = active
-        .iter()
-        .filter_map(|dep| create_update_action(dep, cache, uri, file_type, &cache_key_fn))
-        .collect();
+    let mut actions: Vec<CodeActionOrCommand> = Vec::new();
+    for dep in &active {
+        if let Some(update) = create_update_action(dep, cache, uri, file_type, &cache_key_fn) {
+            actions.push(update);
+        }
+        if let Some(root) = workspace_root
+            && let Some(ignore) = create_ignore_action(dep, root, current_settings)
+        {
+            actions.push(ignore);
+        }
+    }
 
     let active_owned: Vec<Dependency> = active.iter().map(|d| (*d).clone()).collect();
     if let Some(update_all) =
@@ -209,6 +214,35 @@ fn create_update_action(
         }
         VersionStatus::UpToDate | VersionStatus::Unknown => None,
     }
+}
+
+/// Create an "Ignore package" code action that appends `dep.name` to the
+/// `lsp.dependi.initialization_options.ignore` list in `.zed/settings.json`.
+///
+/// Returns `None` if `build_ignore_workspace_edit` fails (e.g. malformed
+/// existing settings or invalid path); the caller silently omits the action.
+fn create_ignore_action(
+    dep: &Dependency,
+    workspace_root: &std::path::Path,
+    current_settings: Option<&str>,
+) -> Option<CodeActionOrCommand> {
+    let edit = crate::settings_edit::build_ignore_workspace_edit(
+        workspace_root,
+        &dep.name,
+        current_settings,
+    )
+    .ok()?;
+
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!("Ignore package \"{}\"", dep.name),
+        kind: Some(CodeActionKind::QUICKFIX),
+        diagnostics: None,
+        edit: Some(edit),
+        command: None,
+        is_preferred: Some(false),
+        disabled: None,
+        data: None,
+    }))
 }
 
 /// Create an "Update All Dependencies" code action when 2+ updates are available
@@ -1167,5 +1201,207 @@ mod tests {
             !actions.is_empty(),
             "non-ignored outdated package should produce action"
         );
+    }
+
+    #[test]
+    fn test_ignore_action_emitted_when_workspace_root_provided() {
+        let cache = MemoryCache::new();
+        cache.insert(
+            "test:lodash".to_string(),
+            VersionInfo {
+                latest: Some("2.0.0".to_string()),
+                ..Default::default()
+            },
+        );
+        let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
+        let uri = Url::parse("file:///test/Cargo.toml").unwrap();
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 10,
+                character: 0,
+            },
+        };
+        let workspace = std::path::PathBuf::from("/tmp/ws");
+
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            Some(&workspace),
+            None,
+        );
+
+        // Expect at least 2 actions: Update + Ignore
+        assert!(
+            actions.len() >= 2,
+            "expected Update and Ignore actions, got {}",
+            actions.len()
+        );
+
+        let titles: Vec<String> = actions
+            .iter()
+            .filter_map(|a| match a {
+                CodeActionOrCommand::CodeAction(ca) => Some(ca.title.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(titles.iter().any(|t| t.contains("Ignore package")));
+        assert!(titles.iter().any(|t| t.contains("\"lodash\"")));
+    }
+
+    #[test]
+    fn test_ignore_action_skipped_when_no_workspace_root() {
+        let cache = MemoryCache::new();
+        cache.insert(
+            "test:lodash".to_string(),
+            VersionInfo {
+                latest: Some("2.0.0".to_string()),
+                ..Default::default()
+            },
+        );
+        let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
+        let uri = Url::parse("file:///test/Cargo.toml").unwrap();
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 10,
+                character: 0,
+            },
+        };
+
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        );
+
+        let titles: Vec<String> = actions
+            .iter()
+            .filter_map(|a| match a {
+                CodeActionOrCommand::CodeAction(ca) => Some(ca.title.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !titles.iter().any(|t| t.contains("Ignore package")),
+            "expected no Ignore action without workspace_root"
+        );
+    }
+
+    #[test]
+    fn test_ignore_action_emitted_even_when_up_to_date() {
+        let cache = MemoryCache::new();
+        cache.insert(
+            "test:lodash".to_string(),
+            VersionInfo {
+                latest: Some("1.0.0".to_string()), // up-to-date
+                ..Default::default()
+            },
+        );
+        let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
+        let uri = Url::parse("file:///test/Cargo.toml").unwrap();
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 10,
+                character: 0,
+            },
+        };
+        let workspace = std::path::PathBuf::from("/tmp/ws");
+
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            Some(&workspace),
+            None,
+        );
+
+        let titles: Vec<String> = actions
+            .iter()
+            .filter_map(|a| match a {
+                CodeActionOrCommand::CodeAction(ca) => Some(ca.title.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            titles.iter().any(|t| t.contains("Ignore package")),
+            "expected Ignore action for up-to-date package"
+        );
+    }
+
+    #[test]
+    fn test_ignore_action_kind_and_preference() {
+        let cache = MemoryCache::new();
+        cache.insert(
+            "test:lodash".to_string(),
+            VersionInfo {
+                latest: Some("1.0.0".to_string()),
+                ..Default::default()
+            },
+        );
+        let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
+        let uri = Url::parse("file:///test/Cargo.toml").unwrap();
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 10,
+                character: 0,
+            },
+        };
+        let workspace = std::path::PathBuf::from("/tmp/ws");
+
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            Some(&workspace),
+            None,
+        );
+
+        let ignore = actions
+            .iter()
+            .find_map(|a| match a {
+                CodeActionOrCommand::CodeAction(ca) if ca.title.contains("Ignore package") => {
+                    Some(ca)
+                }
+                _ => None,
+            })
+            .expect("expected Ignore action");
+
+        assert_eq!(ignore.kind, Some(CodeActionKind::QUICKFIX));
+        assert_eq!(ignore.is_preferred, Some(false));
+        assert!(ignore.edit.is_some());
     }
 }

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -22,10 +22,16 @@ pub fn create_diagnostics(
     min_severity: Option<VulnerabilitySeverity>,
     file_type: FileType,
     doc_transitive_vulns: &hashbrown::HashMap<String, Vec<TransitiveVuln>>,
+    ignored: &[String],
 ) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
     for dep in dependencies {
+        // Skip dependencies matching any `ignore` pattern (matches inlay_hints behavior).
+        if crate::config::is_package_ignored(&dep.name, ignored) {
+            continue;
+        }
+
         // Show informational diagnostic for local/path dependencies
         if is_local_dependency(&dep.version) {
             diagnostics.push(create_local_dependency_diagnostic(dep));
@@ -510,6 +516,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         assert_eq!(diagnostics.len(), 1);
@@ -536,6 +543,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         assert_eq!(diagnostics.len(), 0);
@@ -552,6 +560,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         assert_eq!(diagnostics.len(), 0);
@@ -598,6 +607,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let deprecation_diags: Vec<_> = diagnostics
@@ -642,6 +652,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let deprecation_diags: Vec<_> = diagnostics
@@ -685,6 +696,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let deprecation_diags: Vec<_> = diagnostics
@@ -741,6 +753,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let yanked_diags: Vec<_> = diagnostics
@@ -781,6 +794,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let yanked_diags: Vec<_> = diagnostics
@@ -820,6 +834,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let yanked_diags: Vec<_> = diagnostics
@@ -882,6 +897,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let yanked_diags: Vec<_> = diagnostics
@@ -930,6 +946,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         assert_eq!(diagnostics.len(), 1);
@@ -970,6 +987,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let vuln_diags: Vec<_> = diagnostics
@@ -1020,6 +1038,7 @@ mod tests {
             Some(VulnerabilitySeverity::High),
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let vuln_diags: Vec<_> = diagnostics
@@ -1056,6 +1075,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let deprecation_diags: Vec<_> = diagnostics
@@ -1094,6 +1114,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let yanked_diags: Vec<_> = diagnostics
@@ -1185,6 +1206,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let vuln_diags: Vec<_> = diagnostics
@@ -1225,6 +1247,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let vuln_diags: Vec<_> = diagnostics
@@ -1265,6 +1288,7 @@ mod tests {
             None,
             FileType::Cargo,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let vuln_diags: Vec<_> = diagnostics
@@ -1300,6 +1324,7 @@ mod tests {
             None,
             FileType::Npm,
             &hashbrown::HashMap::new(),
+            &[],
         );
 
         let yanked_diags: Vec<_> = diagnostics
@@ -1364,6 +1389,7 @@ mod tests {
             None,
             FileType::Cargo,
             &doc_transitives,
+            &[],
         );
 
         let vuln_diags: Vec<_> = diagnostics
@@ -1440,6 +1466,7 @@ mod tests {
             Some(VulnerabilitySeverity::High),
             FileType::Cargo,
             &doc_transitives,
+            &[],
         );
 
         let vuln_diags: Vec<_> = diagnostics
@@ -1465,6 +1492,94 @@ mod tests {
             !vuln_diags[0].message.contains("LOW-1"),
             "Message should NOT contain LOW-1 when min_severity=High, got: {}",
             vuln_diags[0].message
+        );
+    }
+
+    #[test]
+    fn test_diagnostic_skipped_for_ignored_package() {
+        let cache = MemoryCache::new();
+        cache.insert(
+            "test:lodash".to_string(),
+            VersionInfo {
+                latest: Some("2.0.0".to_string()),
+                ..Default::default()
+            },
+        );
+        let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
+        let ignored = vec!["lodash".to_string()];
+
+        let diagnostics = create_diagnostics(
+            &deps,
+            &cache,
+            |name| format!("test:{name}"),
+            None,
+            FileType::Cargo,
+            &hashbrown::HashMap::new(),
+            &ignored,
+        );
+
+        assert!(
+            diagnostics.is_empty(),
+            "ignored package should not produce diagnostics"
+        );
+    }
+
+    #[test]
+    fn test_diagnostic_skipped_for_wildcard_match() {
+        let cache = MemoryCache::new();
+        cache.insert(
+            "test:@internal/utils".to_string(),
+            VersionInfo {
+                latest: Some("2.0.0".to_string()),
+                ..Default::default()
+            },
+        );
+        let deps = vec![create_test_dependency("@internal/utils", "1.0.0", 5)];
+        let ignored = vec!["@internal/*".to_string()];
+
+        let diagnostics = create_diagnostics(
+            &deps,
+            &cache,
+            |name| format!("test:{name}"),
+            None,
+            FileType::Cargo,
+            &hashbrown::HashMap::new(),
+            &ignored,
+        );
+
+        assert!(
+            diagnostics.is_empty(),
+            "wildcard-matched package should not produce diagnostics"
+        );
+    }
+
+    #[test]
+    fn test_diagnostic_emitted_when_not_ignored() {
+        let cache = MemoryCache::new();
+        cache.insert(
+            "test:react".to_string(),
+            VersionInfo {
+                latest: Some("18.0.0".to_string()),
+                ..Default::default()
+            },
+        );
+        let deps = vec![create_test_dependency("react", "17.0.0", 5)];
+        let ignored = vec!["lodash".to_string()];
+
+        let diagnostics = create_diagnostics(
+            &deps,
+            &cache,
+            |name| format!("test:{name}"),
+            None,
+            FileType::Cargo,
+            &hashbrown::HashMap::new(),
+            &ignored,
+        );
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "non-ignored package should produce diagnostic"
         );
     }
 }

--- a/dependi-lsp/src/settings_edit.rs
+++ b/dependi-lsp/src/settings_edit.rs
@@ -1,0 +1,303 @@
+//! Build LSP `WorkspaceEdit` payloads that modify `.zed/settings.json`
+//! to add packages to the `dependi` ignore list.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+use tower_lsp::lsp_types::{
+    CreateFile, DocumentChangeOperation, DocumentChanges, OneOf,
+    OptionalVersionedTextDocumentIdentifier, Position, Range, ResourceOp, TextDocumentEdit,
+    TextEdit, Url, WorkspaceEdit,
+};
+
+const SETTINGS_REL_PATH: &str = ".zed/settings.json";
+
+/// Build a `WorkspaceEdit` that adds `package_name` to the `dependi` ignore list
+/// inside `<workspace_root>/.zed/settings.json`.
+///
+/// - If `current_settings_text` is `None`, the edit creates the file with the
+///   minimal nested structure.
+/// - If `current_settings_text` is `Some(s)` and parses as JSON, the edit replaces
+///   the whole file with a pretty-printed version that has `package_name` appended
+///   to `lsp.dependi.initialization_options.ignore` (deduplicated).
+/// - If parsing fails, returns `Err` so the caller can silently skip the action.
+pub fn build_ignore_workspace_edit(
+    workspace_root: &Path,
+    package_name: &str,
+    current_settings_text: Option<&str>,
+) -> Result<WorkspaceEdit> {
+    let settings_path = workspace_root.join(SETTINGS_REL_PATH);
+    let settings_uri = Url::from_file_path(&settings_path)
+        .map_err(|()| anyhow::anyhow!("invalid settings.json path: {}", settings_path.display()))?;
+
+    match current_settings_text {
+        None => Ok(build_create_edit(settings_uri, package_name)),
+        Some(text) => build_replace_edit(settings_uri, package_name, text),
+    }
+}
+
+fn build_create_edit(settings_uri: Url, package_name: &str) -> WorkspaceEdit {
+    let value = json!({
+        "lsp": {
+            "dependi": {
+                "initialization_options": {
+                    "ignore": [package_name]
+                }
+            }
+        }
+    });
+    let text = serde_json::to_string_pretty(&value).unwrap_or_default() + "\n";
+
+    let create = CreateFile {
+        uri: settings_uri.clone(),
+        options: None,
+        annotation_id: None,
+    };
+    let text_edit = TextDocumentEdit {
+        text_document: OptionalVersionedTextDocumentIdentifier {
+            uri: settings_uri,
+            version: None,
+        },
+        edits: vec![OneOf::Left(TextEdit {
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+            new_text: text,
+        })],
+    };
+
+    WorkspaceEdit {
+        changes: None,
+        document_changes: Some(DocumentChanges::Operations(vec![
+            DocumentChangeOperation::Op(ResourceOp::Create(create)),
+            DocumentChangeOperation::Edit(text_edit),
+        ])),
+        change_annotations: None,
+    }
+}
+
+fn build_replace_edit(
+    settings_uri: Url,
+    package_name: &str,
+    current: &str,
+) -> Result<WorkspaceEdit> {
+    let mut root: Value =
+        serde_json::from_str(current).with_context(|| "failed to parse .zed/settings.json")?;
+
+    if !root.is_object() {
+        anyhow::bail!(".zed/settings.json root must be a JSON object");
+    }
+
+    let lsp = root
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("root must be object"))?
+        .entry("lsp")
+        .or_insert_with(|| json!({}));
+    let lsp_obj = lsp
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("'lsp' must be an object"))?;
+
+    let dependi = lsp_obj.entry("dependi").or_insert_with(|| json!({}));
+    let dependi_obj = dependi
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("'lsp.dependi' must be an object"))?;
+
+    let init_opts = dependi_obj
+        .entry("initialization_options")
+        .or_insert_with(|| json!({}));
+    let init_opts_obj = init_opts
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("'lsp.dependi.initialization_options' must be an object"))?;
+
+    let ignore_array = init_opts_obj.entry("ignore").or_insert_with(|| json!([]));
+    let arr = ignore_array
+        .as_array_mut()
+        .ok_or_else(|| anyhow::anyhow!("'ignore' must be an array"))?;
+
+    let already_present = arr.iter().any(|v| v.as_str() == Some(package_name));
+    if !already_present {
+        arr.push(Value::String(package_name.to_string()));
+    }
+
+    let new_text = serde_json::to_string_pretty(&root).unwrap_or_default() + "\n";
+    let line_count = current.lines().count() as u32;
+
+    let text_edit = TextDocumentEdit {
+        text_document: OptionalVersionedTextDocumentIdentifier {
+            uri: settings_uri,
+            version: None,
+        },
+        edits: vec![OneOf::Left(TextEdit {
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: line_count,
+                    character: 0,
+                },
+            },
+            new_text,
+        })],
+    };
+
+    Ok(WorkspaceEdit {
+        changes: None,
+        document_changes: Some(DocumentChanges::Edits(vec![text_edit])),
+        change_annotations: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_edit_text_contains(edit: &WorkspaceEdit, needle: &str) {
+        let dc = edit
+            .document_changes
+            .as_ref()
+            .expect("expected document_changes");
+        let text = match dc {
+            DocumentChanges::Edits(edits) => edits
+                .iter()
+                .flat_map(|e| e.edits.iter())
+                .filter_map(|e| match e {
+                    OneOf::Left(te) => Some(te.new_text.clone()),
+                    _ => None,
+                })
+                .collect::<String>(),
+            DocumentChanges::Operations(ops) => ops
+                .iter()
+                .filter_map(|op| match op {
+                    DocumentChangeOperation::Edit(te) => Some(
+                        te.edits
+                            .iter()
+                            .filter_map(|e| match e {
+                                OneOf::Left(t) => Some(t.new_text.clone()),
+                                _ => None,
+                            })
+                            .collect::<String>(),
+                    ),
+                    _ => None,
+                })
+                .collect::<String>(),
+        };
+        assert!(
+            text.contains(needle),
+            "expected edit text to contain `{needle}`. Actual text:\n{text}"
+        );
+    }
+
+    #[test]
+    fn test_build_edit_creates_file_when_missing() {
+        let root = std::path::PathBuf::from("/tmp/ws");
+        let edit = build_ignore_workspace_edit(&root, "lodash", None).unwrap();
+
+        let dc = edit.document_changes.as_ref().unwrap();
+        let DocumentChanges::Operations(ops) = dc else {
+            panic!("expected Operations variant when creating file");
+        };
+        assert!(matches!(
+            ops.first().unwrap(),
+            DocumentChangeOperation::Op(ResourceOp::Create(_))
+        ));
+        assert_edit_text_contains(&edit, "\"lodash\"");
+        assert_edit_text_contains(&edit, "\"ignore\"");
+        assert_edit_text_contains(&edit, "\"dependi\"");
+    }
+
+    #[test]
+    fn test_build_edit_inserts_into_empty_object() {
+        let root = std::path::PathBuf::from("/tmp/ws");
+        let edit = build_ignore_workspace_edit(&root, "lodash", Some("{}")).unwrap();
+        assert_edit_text_contains(&edit, "\"lodash\"");
+        assert_edit_text_contains(&edit, "\"ignore\"");
+    }
+
+    #[test]
+    fn test_build_edit_appends_to_existing_ignore_list() {
+        let root = std::path::PathBuf::from("/tmp/ws");
+        let current = r#"{
+  "lsp": {
+    "dependi": {
+      "initialization_options": {
+        "ignore": ["react"]
+      }
+    }
+  }
+}"#;
+        let edit = build_ignore_workspace_edit(&root, "lodash", Some(current)).unwrap();
+        assert_edit_text_contains(&edit, "\"lodash\"");
+        assert_edit_text_contains(&edit, "\"react\"");
+    }
+
+    #[test]
+    fn test_build_edit_dedupes_existing_package() {
+        let root = std::path::PathBuf::from("/tmp/ws");
+        let current = r#"{
+  "lsp": {
+    "dependi": {
+      "initialization_options": {
+        "ignore": ["lodash"]
+      }
+    }
+  }
+}"#;
+        let edit = build_ignore_workspace_edit(&root, "lodash", Some(current)).unwrap();
+        let dc = edit.document_changes.as_ref().unwrap();
+        let DocumentChanges::Edits(edits) = dc else {
+            panic!("expected Edits variant on update");
+        };
+        let text = &edits[0].edits[0];
+        let OneOf::Left(te) = text else {
+            panic!("expected TextEdit");
+        };
+        let count = te.new_text.matches("\"lodash\"").count();
+        assert_eq!(count, 1, "package name should not be duplicated");
+    }
+
+    #[test]
+    fn test_build_edit_preserves_other_settings() {
+        let root = std::path::PathBuf::from("/tmp/ws");
+        let current = r#"{
+  "theme": "One Dark",
+  "lsp": {
+    "dependi": {
+      "initialization_options": {
+        "ignore": []
+      }
+    }
+  }
+}"#;
+        let edit = build_ignore_workspace_edit(&root, "lodash", Some(current)).unwrap();
+        assert_edit_text_contains(&edit, "\"One Dark\"");
+        assert_edit_text_contains(&edit, "\"theme\"");
+        assert_edit_text_contains(&edit, "\"lodash\"");
+    }
+
+    #[test]
+    fn test_build_edit_handles_invalid_json_returns_err() {
+        let root = std::path::PathBuf::from("/tmp/ws");
+        let result = build_ignore_workspace_edit(&root, "lodash", Some("{ invalid"));
+        assert!(result.is_err(), "invalid JSON should return Err");
+    }
+
+    #[test]
+    fn test_build_edit_inserts_lsp_path_when_missing() {
+        let root = std::path::PathBuf::from("/tmp/ws");
+        let current = r#"{ "theme": "dark" }"#;
+        let edit = build_ignore_workspace_edit(&root, "lodash", Some(current)).unwrap();
+        assert_edit_text_contains(&edit, "\"lodash\"");
+        assert_edit_text_contains(&edit, "\"dependi\"");
+        assert_edit_text_contains(&edit, "\"theme\"");
+    }
+}

--- a/dependi-lsp/src/settings_edit.rs
+++ b/dependi-lsp/src/settings_edit.rs
@@ -69,8 +69,8 @@ fn build_create_edit(settings_uri: Url, package_name: &str) -> WorkspaceEdit {
                     character: 0,
                 },
                 end: Position {
-                    line: 0,
-                    character: 0,
+                    line: u32::MAX,
+                    character: u32::MAX,
                 },
             },
             new_text: text,

--- a/dependi-lsp/src/settings_edit.rs
+++ b/dependi-lsp/src/settings_edit.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use serde_json::{Value, json};
 use tower_lsp::lsp_types::{
-    CreateFile, DocumentChangeOperation, DocumentChanges, OneOf,
+    CreateFile, CreateFileOptions, DocumentChangeOperation, DocumentChanges, OneOf,
     OptionalVersionedTextDocumentIdentifier, Position, Range, ResourceOp, TextDocumentEdit,
     TextEdit, Url, WorkspaceEdit,
 };
@@ -51,7 +51,10 @@ fn build_create_edit(settings_uri: Url, package_name: &str) -> WorkspaceEdit {
 
     let create = CreateFile {
         uri: settings_uri.clone(),
-        options: None,
+        options: Some(CreateFileOptions {
+            overwrite: Some(false),
+            ignore_if_exists: Some(true),
+        }),
         annotation_id: None,
     };
     let text_edit = TextDocumentEdit {
@@ -128,22 +131,27 @@ fn build_replace_edit(
     }
 
     let new_text = serde_json::to_string_pretty(&root).unwrap_or_default() + "\n";
-    let line_count = current.lines().count() as u32;
 
+    // NOTE: We pass `version: None` because .zed/settings.json is not tracked
+    // as an open LSP document. Concurrent edits between read and apply are
+    // possible but rare in practice; acceptable for a local dev tool.
     let text_edit = TextDocumentEdit {
         text_document: OptionalVersionedTextDocumentIdentifier {
             uri: settings_uri,
             version: None,
         },
         edits: vec![OneOf::Left(TextEdit {
+            // Replace-whole-document: use u32::MAX for line/character to mean
+            // "end of document" per the conventional LSP pattern. Avoids
+            // off-by-one issues with line count vs. exclusive end-line.
             range: Range {
                 start: Position {
                     line: 0,
                     character: 0,
                 },
                 end: Position {
-                    line: line_count,
-                    character: 0,
+                    line: u32::MAX,
+                    character: u32::MAX,
                 },
             },
             new_text,

--- a/dependi-lsp/tests/code_actions_ignore_test.rs
+++ b/dependi-lsp/tests/code_actions_ignore_test.rs
@@ -1,0 +1,146 @@
+//! End-to-end test for the "Ignore package" code action workflow.
+//!
+//! Verifies the full lifecycle:
+//! 1. settings.json missing — edit creates the file with proper nested structure
+//! 2. settings.json exists — edit appends a new package preserving existing entries
+//! 3. settings.json exists with package already present — edit dedupes (no duplicate)
+
+use dependi_lsp::settings_edit::build_ignore_workspace_edit;
+use tempfile::tempdir;
+use tower_lsp::lsp_types::{
+    DocumentChangeOperation, DocumentChanges, OneOf, ResourceOp, WorkspaceEdit,
+};
+
+#[test]
+fn test_create_then_append_then_dedupe_full_cycle() {
+    let dir = tempdir().expect("tempdir");
+    let workspace = dir.path();
+
+    // Step 1: file does not exist — edit should be a CreateFile + insert
+    let edit = build_ignore_workspace_edit(workspace, "lodash", None).unwrap();
+    let dc = edit.document_changes.expect("document_changes");
+    let DocumentChanges::Operations(ops) = dc else {
+        panic!("expected Operations variant for create case")
+    };
+    assert!(matches!(
+        ops.first().unwrap(),
+        DocumentChangeOperation::Op(ResourceOp::Create(_))
+    ));
+
+    // Simulate Zed applying the edit: write the file
+    let settings_path = workspace.join(".zed").join("settings.json");
+    std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+    let new_text = extract_inserted_text(&ops);
+    assert!(
+        new_text.contains("\"lodash\""),
+        "create text should contain lodash"
+    );
+    assert!(
+        new_text.contains("\"ignore\""),
+        "create text should contain ignore key"
+    );
+    std::fs::write(&settings_path, &new_text).unwrap();
+
+    // Step 2: file exists — edit should append "react"
+    let current = std::fs::read_to_string(&settings_path).unwrap();
+    let edit2 = build_ignore_workspace_edit(workspace, "react", Some(&current)).unwrap();
+    let new_text2 = extract_replace_text(&edit2);
+    assert!(
+        new_text2.contains("\"lodash\""),
+        "append should preserve lodash"
+    );
+    assert!(new_text2.contains("\"react\""), "append should add react");
+    std::fs::write(&settings_path, &new_text2).unwrap();
+
+    // Step 3: re-add lodash — should dedupe
+    let current2 = std::fs::read_to_string(&settings_path).unwrap();
+    let edit3 = build_ignore_workspace_edit(workspace, "lodash", Some(&current2)).unwrap();
+    let new_text3 = extract_replace_text(&edit3);
+    let lodash_count = new_text3.matches("\"lodash\"").count();
+    assert_eq!(
+        lodash_count, 1,
+        "lodash should appear exactly once after dedupe, got {lodash_count}"
+    );
+    let react_count = new_text3.matches("\"react\"").count();
+    assert_eq!(
+        react_count, 1,
+        "react should still appear exactly once, got {react_count}"
+    );
+}
+
+#[test]
+fn test_invalid_json_returns_err_does_not_corrupt() {
+    let dir = tempdir().unwrap();
+    let workspace = dir.path();
+    let result = build_ignore_workspace_edit(workspace, "lodash", Some("{ broken"));
+    assert!(result.is_err(), "invalid JSON should return Err");
+}
+
+#[test]
+fn test_preserves_unrelated_settings_through_full_cycle() {
+    let dir = tempdir().unwrap();
+    let workspace = dir.path();
+
+    // Start with a settings.json that has unrelated keys
+    let initial = r#"{
+  "theme": "One Dark",
+  "buffer_font_size": 14,
+  "lsp": {
+    "other-server": {
+      "settings": { "format_on_save": true }
+    }
+  }
+}"#;
+
+    let edit = build_ignore_workspace_edit(workspace, "lodash", Some(initial)).unwrap();
+    let new_text = extract_replace_text(&edit);
+
+    assert!(
+        new_text.contains("\"One Dark\""),
+        "theme should be preserved"
+    );
+    assert!(
+        new_text.contains("\"buffer_font_size\""),
+        "buffer_font_size should be preserved"
+    );
+    assert!(
+        new_text.contains("\"other-server\""),
+        "other LSP server should be preserved"
+    );
+    assert!(
+        new_text.contains("\"format_on_save\""),
+        "nested settings should be preserved"
+    );
+    assert!(new_text.contains("\"lodash\""), "lodash should be added");
+    assert!(
+        new_text.contains("\"dependi\""),
+        "dependi key should be added"
+    );
+}
+
+fn extract_inserted_text(ops: &[DocumentChangeOperation]) -> String {
+    for op in ops {
+        if let DocumentChangeOperation::Edit(te) = op {
+            for edit in &te.edits {
+                if let OneOf::Left(t) = edit {
+                    return t.new_text.clone();
+                }
+            }
+        }
+    }
+    String::new()
+}
+
+fn extract_replace_text(edit: &WorkspaceEdit) -> String {
+    let dc = edit.document_changes.as_ref().expect("document_changes");
+    match dc {
+        DocumentChanges::Edits(edits) => {
+            let first = &edits[0].edits[0];
+            let OneOf::Left(te) = first else {
+                panic!("expected TextEdit")
+            };
+            te.new_text.clone()
+        }
+        _ => panic!("expected Edits variant on update"),
+    }
+}


### PR DESCRIPTION
## Summary

Closes #226. Adds a quick-fix `CodeAction` "Ignore package \"<name>\"" on every dependency, which appends the package to `lsp.dependi.initialization_options.ignore` in the workspace `.zed/settings.json` (creating the file if missing, deduping if already listed, preserving any other settings).

Also makes diagnostics and "Update" code actions respect the `ignore` list — previously only inlay hints filtered by it, which was inconsistent.

## Architecture

Pure LSP `WorkspaceEdit` targeting `.zed/settings.json` (Approach A from the design spec). No Zed extension changes required — the server emits a standard `workspace/applyEdit` and Zed handles the file write.

- `dependi-lsp/src/config.rs` — new shared `is_package_ignored` helper (extracted from previously-inline backend logic, semantics preserved exactly).
- `dependi-lsp/src/settings_edit.rs` — new module: `build_ignore_workspace_edit` builds the `WorkspaceEdit`. Handles three cases: missing file (CreateFile + insert), partial JSON path (insert nested keys), existing list (append + dedupe).
- `dependi-lsp/src/providers/code_actions.rs` — new `create_ignore_action`, ignored deps filtered from Update actions.
- `dependi-lsp/src/providers/diagnostics.rs` — ignored deps filtered from diagnostics.
- `dependi-lsp/src/backend.rs` — async `find_workspace_root` (walks parents for `.zed/`), `code_action` reads settings.json via `tokio::fs`, `inlay_hint` refactored onto shared helper.

## Test plan

- [x] `cargo test --package dependi-lsp` — 648 passed, 21 ignored
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build --release --package dependi-lsp` — succeeds
- [x] Unit tests cover: helper pattern matching (9 tests inc. sharp edges), JSON merge (7 tests inc. invalid-JSON, dedupe, preserve-other-settings), code action emission (4 tests), filter behavior (3 diagnostics + 2 code_actions), workspace root detection (2 tests).
- [x] Integration test exercises the full create-then-append-then-dedupe lifecycle in a temp dir.
- [ ] Manual smoke test in Zed: load extension, add an outdated dep, verify "Ignore package" appears, verify clicking it creates/updates `.zed/settings.json`.

## Review feedback addressed

Four IMPORTANT issues raised by parallel reviewers (rust-reviewer, code-reviewer, security-reviewer, tdd-guide) addressed in commit \`88de277\`:

1. Off-by-one in `build_replace_edit` range end → use `u32::MAX, u32::MAX` (LSP "replace whole document" pattern).
2. Missing `CreateFileOptions` → added `overwrite: false, ignore_if_exists: true`.
3. Unnecessary `active_owned` clone in code_actions hot path → changed `create_update_all_action` signature to `&[&Dependency]`.
4. Sync `is_dir()` in async task → made `find_workspace_root` async, uses `tokio::fs::metadata`.

Plus: TOCTOU comment on settings.json read/apply window, strengthened workspace-root fallback test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-package "Ignore package" quick-fix that persists ignored packages to workspace settings with file creation and deduplication.
  * Diagnostics and update actions now consult the same ignore list for consistent behavior.

* **Bug Fixes**
  * Fixed settings create/update behavior and workspace-root detection when no workspace config exists.
  * Enabled ignore quick-fix for property-referenced dependencies while keeping them excluded from "Update all" counts.

* **Tests**
  * Added tests validating ignore matching, edits, and workspace scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an “Ignore package” quick-fix that writes the package to the workspace ignore list and makes diagnostics and update actions honor it for consistent silencing. Also improves workspace detection and edit safety to avoid stray writes or corrupted settings.

- **New Features**
  - Adds “Ignore package "<name>"” quick fix; appends to `lsp.dependi.initialization_options.ignore` in `.zed/settings.json` via LSP `WorkspaceEdit`.
  - Creates the file if missing, inserts nested keys, dedupes entries, and preserves other settings. Supports ignoring property-reference deps; “Update all” counts all non-ignored deps in the file.

- **Bug Fixes**
  - Diagnostics and Update/Update All now skip ignored packages.
  - Safer edits and workspace handling: full-document replace with safe `CreateFile` options to prevent JSON corruption, and `find_workspace_root` returns `None` when no `.zed/` ancestor to avoid stray writes; code actions drop map guards before awaits to prevent deadlocks.

<sup>Written for commit 66510aad81b37c68da31ff6825c52dd1df6ec871. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

