### PR TITLE
document npm OSV vulnerability scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ dependi-zed/extension.wasm
 
 # Claude Code
 .claude/
+.codex
 CLAUDE.md
 
 # Local scripts

--- a/dependi-lsp/src/registries/npm.rs
+++ b/dependi-lsp/src/registries/npm.rs
@@ -373,7 +373,7 @@ impl Registry for NpmRegistry {
             homepage: pkg.homepage,
             repository,
             license: pkg.license.and_then(|l| l.as_string()),
-            vulnerabilities: vec![], // TODO: Integrate npm audit
+            vulnerabilities: vec![], // Filled by the shared OSV vulnerability scan.
             deprecated,
             yanked: false,
             yanked_versions: vec![], // Not applicable to npm

--- a/dependi-lsp/tests/scan_cli_test.rs
+++ b/dependi-lsp/tests/scan_cli_test.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-use wiremock::matchers::{body_json, method, path, path_regex};
+use wiremock::matchers::{method, path, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn dependi_lsp_bin() -> String {
@@ -21,32 +21,39 @@ async fn test_scan_queries_osv_npm_ecosystem_and_reports_direct_vulnerabilities(
 
     Mock::given(method("POST"))
         .and(path("/querybatch"))
-        .and(body_json(serde_json::json!({
-            "queries": [
-                {
-                    "package": { "name": "react", "ecosystem": "npm" },
-                    "version": "18.2.0"
-                },
-                {
-                    "package": { "name": "scheduler", "ecosystem": "npm" },
-                    "version": "0.23.0"
-                }
-            ]
-        })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "results": [
-                {
-                    "vulns": [{
-                        "id": "CVE-NPM-DIRECT-001",
-                        "modified": "2024-01-01T00:00:00Z",
-                        "summary": "direct react vulnerability",
-                        "severity": [{ "type": "CVSS_V3", "score": "9.8" }],
-                        "references": [{ "type": "WEB", "url": "https://example.test/CVE-NPM-DIRECT-001" }]
-                    }]
-                },
-                { "vulns": [] }
-            ]
-        })))
+        .respond_with(|request: &wiremock::Request| {
+            let body: serde_json::Value = request
+                .body_json()
+                .expect("querybatch request body should be valid JSON");
+            let queries = body["queries"]
+                .as_array()
+                .expect("querybatch.queries should be an array");
+            let results: Vec<serde_json::Value> = queries
+                .iter()
+                .map(|query| {
+                    if query["package"]["name"] == "react"
+                        && query["package"]["ecosystem"] == "npm"
+                        && query["version"] == "18.2.0"
+                    {
+                        serde_json::json!({
+                            "vulns": [{
+                                "id": "CVE-NPM-DIRECT-001",
+                                "modified": "2024-01-01T00:00:00Z",
+                                "summary": "direct react vulnerability",
+                                "severity": [{ "type": "CVSS_V3", "score": "9.8" }],
+                                "references": [{ "type": "WEB", "url": "https://example.test/CVE-NPM-DIRECT-001" }]
+                            }]
+                        })
+                    } else {
+                        serde_json::json!({ "vulns": [] })
+                    }
+                })
+                .collect();
+
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "results": results
+            }))
+        })
         .mount(&server)
         .await;
 
@@ -56,7 +63,7 @@ async fn test_scan_queries_osv_npm_ecosystem_and_reports_direct_vulnerabilities(
             "id": "CVE-NPM-DIRECT-001",
             "summary": "direct react vulnerability",
             "details": "test details",
-            "severity": [{ "type": "CVSS_V3", "score": "9.8" }],
+            "severity": [{ "type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" }],
             "references": []
         })))
         .mount(&server)
@@ -70,6 +77,37 @@ async fn test_scan_queries_osv_npm_ecosystem_and_reports_direct_vulnerabilities(
         .arg(&fixture)
         .output()
         .expect("failed to run dependi-lsp");
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("failed to collect mock server requests");
+    let querybatch = requests
+        .iter()
+        .find(|request| request.url.path() == "/querybatch")
+        .expect("expected POST /querybatch");
+    let querybatch_body: serde_json::Value = querybatch
+        .body_json()
+        .expect("querybatch body should be valid JSON");
+    let queries = querybatch_body["queries"]
+        .as_array()
+        .expect("querybatch.queries should be an array");
+    let has_npm_query = |package_name: &str, version: &str| {
+        queries.iter().any(|query| {
+            query["package"]["name"] == package_name
+                && query["package"]["ecosystem"] == "npm"
+                && query["version"] == version
+        })
+    };
+
+    assert!(
+        has_npm_query("react", "18.2.0"),
+        "expected npm OSV query for react@18.2.0"
+    );
+    assert!(
+        has_npm_query("scheduler", "0.23.0"),
+        "expected npm OSV query for scheduler@0.23.0"
+    );
 
     assert_eq!(
         output.status.code(),

--- a/dependi-lsp/tests/scan_cli_test.rs
+++ b/dependi-lsp/tests/scan_cli_test.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-use wiremock::matchers::{method, path, path_regex};
+use wiremock::matchers::{body_json, method, path, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn dependi_lsp_bin() -> String {
@@ -13,6 +13,90 @@ fn fixture_path(rel: &str) -> PathBuf {
         .join("tests")
         .join("fixtures")
         .join(rel)
+}
+
+#[tokio::test]
+async fn test_scan_queries_osv_npm_ecosystem_and_reports_direct_vulnerabilities() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/querybatch"))
+        .and(body_json(serde_json::json!({
+            "queries": [
+                {
+                    "package": { "name": "react", "ecosystem": "npm" },
+                    "version": "18.2.0"
+                },
+                {
+                    "package": { "name": "scheduler", "ecosystem": "npm" },
+                    "version": "0.23.0"
+                }
+            ]
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [
+                {
+                    "vulns": [{
+                        "id": "CVE-NPM-DIRECT-001",
+                        "modified": "2024-01-01T00:00:00Z",
+                        "summary": "direct react vulnerability",
+                        "severity": [{ "type": "CVSS_V3", "score": "9.8" }],
+                        "references": [{ "type": "WEB", "url": "https://example.test/CVE-NPM-DIRECT-001" }]
+                    }]
+                },
+                { "vulns": [] }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/vulns/.+"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "CVE-NPM-DIRECT-001",
+            "summary": "direct react vulnerability",
+            "details": "test details",
+            "severity": [{ "type": "CVSS_V3", "score": "9.8" }],
+            "references": []
+        })))
+        .mount(&server)
+        .await;
+
+    let fixture = fixture_path("npm-project-with-lockfile/package.json");
+
+    let output = Command::new(dependi_lsp_bin())
+        .env("OSV_ENDPOINT", server.uri())
+        .args(["scan", "--output", "json", "--file"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run dependi-lsp");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "dependi-lsp must exit 1 when npm direct vulnerabilities are found\nstdout=\n{}\nstderr=\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("scan output should be valid JSON");
+    let direct = report["direct"]
+        .as_array()
+        .expect("direct vulnerabilities should be an array");
+    assert_eq!(direct.len(), 1, "expected one direct vulnerability");
+    assert_eq!(direct[0]["package"], "react");
+    assert_eq!(direct[0]["version"], "18.2.0");
+    assert_eq!(direct[0]["id"], "CVE-NPM-DIRECT-001");
+    assert_eq!(direct[0]["severity"], "critical");
+    assert_eq!(
+        report["transitive"]
+            .as_array()
+            .expect("transitive vulnerabilities should be an array")
+            .len(),
+        0,
+        "direct npm vulnerability should not be reported as transitive",
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Add CLI coverage proving npm scans query OSV with the `npm` ecosystem and report direct vulnerabilities.
- Replace the misleading npm registry TODO with a comment pointing to the shared OSV vulnerability scan.
- Ignore local `.codex` metadata in `.gitignore`.

## Why

Issue #228 reported missing npm vulnerability scanning from the npm registry client TODO. The feature already lives in the shared OSV scan path rather than inside registry clients, so this PR documents that architecture and adds a regression test around the npm OSV request/response behavior.

Resolves #228.

## Validation

- `rtk cargo test --manifest-path dependi-lsp/Cargo.toml --test scan_cli_test` -> 5 passed
- `rtk cargo fmt --manifest-path dependi-lsp/Cargo.toml --all -- --check`
- `rtk git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CLI test that proves `npm` scans go through OSV (ecosystem `npm`), asserting queries for `react@18.2.0` and `scheduler@0.23.0`, and that a direct vulnerability triggers exit code 1, resolving #228. Replace the misleading registry TODO with a comment noting vulnerabilities are filled by the shared OSV scan, and ignore local `.codex` metadata.

<sup>Written for commit b97ec102f49710668ac35da2d7eb9946bc7671f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration CLI test that validates npm vulnerability scanning, ensuring JSON output, correct classification of direct vs. transitive findings, and expected non-zero exit behavior.
* **Chores**
  * Updated ignore patterns to include an additional local tool directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->