### PR TITLE
fix: limit OSV RustSec advisory concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Limit concurrent OSV RustSec advisory detail requests to 5 per batch to avoid
+  unbounded request bursts and reduce OSV API rate-limit risk
+  ([#229](https://github.com/mpiton/zed-dependi/issues/229)).
 - Lockfile reads are now capped at 50 MiB to prevent out-of-memory on hostile
   or corrupted inputs (both in CLI and LSP backend).
 - Bump transitive `rand` from 0.9.2 to 0.9.4 via `cargo update` to address [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) / [GHSA-cq8v-f236-94qc](https://github.com/rust-random/rand/security/advisories/GHSA-cq8v-f236-94qc) — unsoundness when the `log` and `thread_rng` features are combined with a custom logger that calls `rand::rng()` during a reseed cycle

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::stream::{self, StreamExt};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
@@ -13,6 +14,7 @@ use super::VulnerabilityQuery;
 use crate::registries::{Vulnerability, VulnerabilitySeverity};
 
 const OSV_API_BASE: &str = "https://api.osv.dev/v1";
+const RUSTSEC_ADVISORY_LOOKUP_CONCURRENCY: usize = 5;
 
 /// Result of a vulnerability query
 #[derive(Debug, Clone, Default)]
@@ -184,19 +186,16 @@ impl OsvClient {
             ids.len()
         );
 
-        // Spawn all tasks in parallel
-        let tasks: Vec<_> = ids
-            .iter()
+        let results: Vec<bool> = stream::iter(ids.iter().cloned())
             .map(|id| {
                 let url = format!("{}/vulns/{id}", self.base_url);
                 let client = Arc::clone(&self.client);
-                let id_clone = id.clone();
 
-                tokio::spawn(async move {
+                async move {
                     let response = match client.get(&url).send().await {
                         Ok(r) => r,
                         Err(e) => {
-                            tracing::warn!("Failed to fetch advisory {}: {}", id_clone, e);
+                            tracing::warn!("Failed to fetch advisory {}: {}", id, e);
                             return false;
                         }
                     };
@@ -204,7 +203,7 @@ impl OsvClient {
                     let details: Option<OsvVulnerabilityDetails> = match response.json().await {
                         Ok(d) => d,
                         Err(e) => {
-                            tracing::warn!("Failed to parse advisory {}: {}", id_clone, e);
+                            tracing::warn!("Failed to parse advisory {}: {}", id, e);
                             return false;
                         }
                     };
@@ -233,7 +232,7 @@ impl OsvClient {
                     if is_unmaintained {
                         tracing::info!(
                             "Advisory {} indicates unmaintained package: {}",
-                            id_clone,
+                            id,
                             details
                                 .as_ref()
                                 .and_then(|v| v.summary.as_ref())
@@ -242,15 +241,13 @@ impl OsvClient {
                     }
 
                     is_unmaintained
-                })
+                }
             })
-            .collect();
+            .buffer_unordered(RUSTSEC_ADVISORY_LOOKUP_CONCURRENCY)
+            .collect()
+            .await;
 
-        // Wait for ALL tasks to complete in parallel using join_all
-        let results = futures::future::join_all(tasks).await;
-
-        // Check if any task returned true (found unmaintained package)
-        results.into_iter().any(|r| r.unwrap_or(false))
+        results.into_iter().any(|is_unmaintained| is_unmaintained)
     }
 }
 
@@ -325,7 +322,57 @@ struct OsvDatabaseSpecific {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
     use crate::vulnerabilities::Ecosystem;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    async fn spawn_counting_osv_server(
+        active_requests: Arc<AtomicUsize>,
+        max_seen: Arc<AtomicUsize>,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("counting test server should bind");
+        let addr = listener
+            .local_addr()
+            .expect("counting test server should have local address");
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _peer)) = listener.accept().await else {
+                    break;
+                };
+                let active_requests = Arc::clone(&active_requests);
+                let max_seen = Arc::clone(&max_seen);
+
+                tokio::spawn(async move {
+                    let current = active_requests.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_seen.fetch_max(current, Ordering::SeqCst);
+
+                    let mut buffer = [0_u8; 2048];
+                    let _ = socket.read(&mut buffer).await;
+
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+
+                    let body =
+                        r#"{"id":"RUSTSEC-2099-0001","summary":"ordinary advisory","affected":[]}"#;
+                    let body_len = body.len();
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {body_len}\r\nconnection: close\r\n\r\n{body}"
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+
+                    active_requests.fetch_sub(1, Ordering::SeqCst);
+                });
+            }
+        });
+
+        format!("http://{addr}")
+    }
 
     #[test]
     fn test_parse_cvss_severity() {
@@ -449,6 +496,32 @@ mod tests {
         assert!(
             result.is_err(),
             "query to unreachable endpoint should error, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rustsec_advisory_lookup_limits_concurrency() {
+        const EXPECTED_LIMIT: usize = 5;
+
+        let active_requests = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+        let endpoint =
+            spawn_counting_osv_server(Arc::clone(&active_requests), Arc::clone(&max_seen)).await;
+        let client = OsvClient::with_endpoint(endpoint);
+        let ids: Vec<String> = (0..(EXPECTED_LIMIT * 2 + 3))
+            .map(|index| format!("RUSTSEC-2099-{index:04}"))
+            .collect();
+
+        let deprecated = client.check_rustsec_unmaintained(&ids).await;
+
+        assert!(
+            !deprecated,
+            "test advisories should not be marked as unmaintained"
+        );
+        assert!(
+            max_seen.load(Ordering::SeqCst) <= EXPECTED_LIMIT,
+            "expected at most {EXPECTED_LIMIT} concurrent advisory lookups, saw {}",
+            max_seen.load(Ordering::SeqCst)
         );
     }
 

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -247,7 +247,7 @@ impl OsvClient {
             .collect()
             .await;
 
-        results.into_iter().any(|is_unmaintained| is_unmaintained)
+        results.into_iter().any(std::convert::identity)
     }
 }
 
@@ -501,7 +501,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_rustsec_advisory_lookup_limits_concurrency() {
-        const EXPECTED_LIMIT: usize = 5;
+        const EXPECTED_LIMIT: usize = RUSTSEC_ADVISORY_LOOKUP_CONCURRENCY;
 
         let active_requests = Arc::new(AtomicUsize::new(0));
         let max_seen = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
## Summary

- Limit concurrent RustSec advisory detail lookups against OSV to 5 active requests per batch.
- Replace the unbounded `tokio::spawn` + `join_all` fan-out with a bounded `buffer_unordered` stream.
- Add a local regression test that observes active advisory requests and documents the security hardening in the changelog.

## Why

Fixes #229. A project with many RustSec advisories could previously trigger an unbounded burst of `GET /vulns/{id}` calls to OSV.dev, increasing rate-limit and service-blocking risk.

## Validation

- `rtk cargo test --manifest-path dependi-lsp/Cargo.toml test_rustsec_advisory_lookup_limits_concurrency -- --nocapture` -> 1 passed
- `rtk cargo test --manifest-path dependi-lsp/Cargo.toml --lib vulnerabilities::osv` -> 9 passed
- `rtk cargo test --manifest-path dependi-lsp/Cargo.toml --lib` -> 626 passed, 1 ignored
- `rtk cargo clippy --manifest-path dependi-lsp/Cargo.toml --all-targets -- -D warnings` -> no issues
- `rtk cargo fmt --manifest-path dependi-lsp/Cargo.toml --all -- --check`
- `rtk git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits concurrent OSV RustSec advisory lookups to 5 to prevent request bursts and reduce rate-limit risk. Switches to a bounded `futures` stream and adds a regression test to enforce the limit. Fixes #229.

- **Bug Fixes**
  - Replaced unbounded `tokio::spawn` + `join_all` with `futures::stream::iter(...).buffer_unordered(RUSTSEC_ADVISORY_LOOKUP_CONCURRENCY)`.
  - Added counting test server and `test_rustsec_advisory_lookup_limits_concurrency` to assert max concurrency ≤ 5.
  - Updated changelog under Security.

<sup>Written for commit 03d4e5fef0c152c4006eb135322eac3da5c7c17c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added a changelog entry: OSV RustSec advisory requests are now limited to 5 concurrent lookups per batch to prevent unbounded request bursts and reduce API rate-limit risk.
* **Tests**
  * Added tests that simulate advisory lookups and verify peak concurrency respects the configured limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->