### PR TITLE
fix(registries): sanitize repository and homepage URLs for npm and Packagist (#230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or corrupted inputs (both in CLI and LSP backend).
 - Bump transitive `rand` from 0.9.2 to 0.9.4 via `cargo update` to address [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) / [GHSA-cq8v-f236-94qc](https://github.com/rust-random/rand/security/advisories/GHSA-cq8v-f236-94qc) — unsoundness when the `log` and `thread_rng` features are combined with a custom logger that calls `rand::rng()` during a reseed cycle
 - Bump transitive `rustls-webpki` from 0.103.10 to 0.103.12 via `cargo update` to address [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098.html) / [GHSA-965h-392x-2mh5](https://github.com/rustls/webpki/security/advisories/GHSA-965h-392x-2mh5) (URI name constraints ignored) and [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099.html) / [GHSA-xgp8-3hg3-c2mh](https://github.com/rustls/webpki/security/advisories/GHSA-xgp8-3hg3-c2mh) (wildcard DNS name constraints bypass)
+- Reject non-`http(s)` repository URLs from npm and Packagist package
+  metadata. The previous substring-based `normalize_repo_url` allowed
+  `ssh`, `git+ssh`, `ftp`, `file`, `javascript`, `data`, `mailto`, and
+  other schemes to pass through to the IDE. The new shared
+  `sanitize_repo_url` (backed by the `url` crate) returns `None` for any
+  scheme outside the `{http, https}` allowlist
+  ([#230](https://github.com/mpiton/zed-dependi/issues/230), CWE-20).
 
 ## [1.7.0] - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,12 +100,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or corrupted inputs (both in CLI and LSP backend).
 - Bump transitive `rand` from 0.9.2 to 0.9.4 via `cargo update` to address [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) / [GHSA-cq8v-f236-94qc](https://github.com/rust-random/rand/security/advisories/GHSA-cq8v-f236-94qc) — unsoundness when the `log` and `thread_rng` features are combined with a custom logger that calls `rand::rng()` during a reseed cycle
 - Bump transitive `rustls-webpki` from 0.103.10 to 0.103.12 via `cargo update` to address [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098.html) / [GHSA-965h-392x-2mh5](https://github.com/rustls/webpki/security/advisories/GHSA-965h-392x-2mh5) (URI name constraints ignored) and [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099.html) / [GHSA-xgp8-3hg3-c2mh](https://github.com/rustls/webpki/security/advisories/GHSA-xgp8-3hg3-c2mh) (wildcard DNS name constraints bypass)
-- Reject non-`http(s)` repository URLs from npm and Packagist package
-  metadata. The previous substring-based `normalize_repo_url` allowed
-  `ssh`, `git+ssh`, `ftp`, `file`, `javascript`, `data`, `mailto`, and
-  other schemes to pass through to the IDE. The new shared
-  `sanitize_repo_url` (backed by the `url` crate) returns `None` for any
-  scheme outside the `{http, https}` allowlist
+- Reject non-`http(s)` repository and homepage URLs from npm and
+  Packagist package metadata. The previous substring-based
+  `normalize_repo_url` allowed `ssh`, `git+ssh`, `ftp`, `file`,
+  `javascript`, `data`, `mailto`, and other schemes to pass through to
+  the IDE; the `homepage` field was unsanitized entirely. The new
+  shared `sanitize_repo_url` and `sanitize_external_url` helpers
+  (backed by the `url` crate) drop any URL whose scheme falls outside
+  the `{http, https}` allowlist, contain embedded credentials, or
+  collapse to a bare host after stripping a trailing `.git`
   ([#230](https://github.com/mpiton/zed-dependi/issues/230), CWE-20).
 
 ## [1.7.0] - 2026-04-07

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -534,6 +534,7 @@ dependencies = [
  "tower-lsp",
  "tracing",
  "tracing-subscriber",
+ "url",
  "wiremock",
 ]
 

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -37,6 +37,7 @@ futures = "0.3.32"
 taplo = "0.14"
 hashbrown = { version = "0.17.0", features = ["serde"] }
 quick-xml = "0.38"
+url = "2.5"
 
 [dev-dependencies]
 serial_test = "3"

--- a/dependi-lsp/src/registries/mod.rs
+++ b/dependi-lsp/src/registries/mod.rs
@@ -241,7 +241,7 @@ pub mod packagist;
 pub mod pub_dev;
 pub mod pypi;
 pub mod rubygems;
-pub mod url_sanitizer;
+pub(crate) mod url_sanitizer;
 pub mod version_utils;
 
 #[cfg(test)]

--- a/dependi-lsp/src/registries/mod.rs
+++ b/dependi-lsp/src/registries/mod.rs
@@ -241,6 +241,7 @@ pub mod packagist;
 pub mod pub_dev;
 pub mod pypi;
 pub mod rubygems;
+pub mod url_sanitizer;
 pub mod version_utils;
 
 #[cfg(test)]

--- a/dependi-lsp/src/registries/npm.rs
+++ b/dependi-lsp/src/registries/npm.rs
@@ -74,7 +74,7 @@ use super::version_utils::is_prerelease_npm;
 use super::{Registry, VersionInfo};
 use crate::auth::fmt_redact_token;
 use crate::config::NpmRegistryConfig;
-use crate::registries::url_sanitizer::sanitize_repo_url;
+use crate::registries::url_sanitizer::{sanitize_external_url, sanitize_repo_url};
 
 /// Client for the npm registry
 pub struct NpmRegistry {
@@ -355,7 +355,7 @@ impl Registry for NpmRegistry {
             latest_prerelease,
             versions,
             description: pkg.description,
-            homepage: pkg.homepage,
+            homepage: pkg.homepage.as_deref().and_then(sanitize_external_url),
             repository,
             license: pkg.license.and_then(|l| l.as_string()),
             vulnerabilities: vec![], // Filled by the shared OSV vulnerability scan.

--- a/dependi-lsp/src/registries/npm.rs
+++ b/dependi-lsp/src/registries/npm.rs
@@ -74,6 +74,7 @@ use super::version_utils::is_prerelease_npm;
 use super::{Registry, VersionInfo};
 use crate::auth::fmt_redact_token;
 use crate::config::NpmRegistryConfig;
+use crate::registries::url_sanitizer::sanitize_repo_url;
 
 /// Client for the npm registry
 pub struct NpmRegistry {
@@ -227,8 +228,8 @@ enum Repository {
 impl Repository {
     fn url(&self) -> Option<String> {
         match self {
-            Repository::String(s) => Some(normalize_repo_url(s)),
-            Repository::Object { url } => url.as_ref().map(|u| normalize_repo_url(u)),
+            Repository::String(s) => sanitize_repo_url(s),
+            Repository::Object { url } => url.as_ref().and_then(|u| sanitize_repo_url(u)),
         }
     }
 }
@@ -258,22 +259,6 @@ struct DistTags {
 #[derive(Debug, Deserialize)]
 struct VersionMetadata {
     deprecated: Option<String>,
-}
-
-fn normalize_repo_url(url: &str) -> String {
-    // Convert git+https://github.com/user/repo.git to https://github.com/user/repo
-    let url = url
-        .strip_prefix("git+")
-        .unwrap_or(url)
-        .strip_suffix(".git")
-        .unwrap_or(url);
-
-    // Convert git://github.com to https://github.com
-    if url.starts_with("git://") {
-        return url.replace("git://", "https://");
-    }
-
-    url.to_string()
 }
 
 impl Registry for NpmRegistry {
@@ -398,33 +383,29 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_repo_url() {
-        assert_eq!(
-            normalize_repo_url("git+https://github.com/user/repo.git"),
-            "https://github.com/user/repo"
-        );
-        assert_eq!(
-            normalize_repo_url("git://github.com/user/repo"),
-            "https://github.com/user/repo"
-        );
-        assert_eq!(
-            normalize_repo_url("https://github.com/user/repo"),
-            "https://github.com/user/repo"
-        );
-    }
-
-    #[test]
-    fn test_repository_string_variant() {
+    fn test_repository_string_sanitization() {
         let repo = Repository::String("git+https://github.com/user/repo.git".to_string());
         assert_eq!(repo.url(), Some("https://github.com/user/repo".to_string()));
     }
 
     #[test]
-    fn test_repository_object_variant() {
-        let repo = Repository::Object {
-            url: Some("git://github.com/user/repo".to_string()),
-        };
+    fn test_repository_string_legacy_git_protocol() {
+        let repo = Repository::String("git://github.com/user/repo".to_string());
         assert_eq!(repo.url(), Some("https://github.com/user/repo".to_string()));
+    }
+
+    #[test]
+    fn test_repository_string_passthrough_https() {
+        let repo = Repository::String("https://github.com/user/repo".to_string());
+        assert_eq!(repo.url(), Some("https://github.com/user/repo".to_string()));
+    }
+
+    #[test]
+    fn test_repository_object_drops_invalid_scheme() {
+        let repo = Repository::Object {
+            url: Some("ssh://git@github.com/user/repo".to_string()),
+        };
+        assert_eq!(repo.url(), None);
     }
 
     #[test]

--- a/dependi-lsp/src/registries/packagist.rs
+++ b/dependi-lsp/src/registries/packagist.rs
@@ -71,6 +71,7 @@ use reqwest::Client;
 use serde::Deserialize;
 
 use super::http_client::create_shared_client;
+use super::url_sanitizer::sanitize_repo_url;
 use super::version_utils::is_prerelease_php;
 use super::{Registry, VersionInfo};
 
@@ -198,8 +199,8 @@ impl Registry for PackagistRegistry {
             .cloned();
         let repository = latest_entry
             .and_then(|e| e.source.as_ref())
-            .and_then(|s| s.url.clone())
-            .map(|url| normalize_repo_url(&url));
+            .and_then(|s| s.url.as_ref())
+            .and_then(|url| sanitize_repo_url(url));
 
         // Check if deprecated/abandoned (truthy value = abandoned)
         let deprecated = latest_entry
@@ -281,21 +282,6 @@ fn compare_version_strings(a: &str, b: &str) -> std::cmp::Ordering {
     parts_a.len().cmp(&parts_b.len())
 }
 
-/// Normalize repository URL
-fn normalize_repo_url(url: &str) -> String {
-    let url = url
-        .strip_prefix("git+")
-        .unwrap_or(url)
-        .strip_suffix(".git")
-        .unwrap_or(url);
-
-    if url.starts_with("git://") {
-        url.replace("git://", "https://")
-    } else {
-        url.to_string()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -335,18 +321,31 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_repo_url() {
+    fn test_sanitize_repo_url_strips_git_plus() {
         assert_eq!(
-            normalize_repo_url("git+https://github.com/user/repo.git"),
-            "https://github.com/user/repo"
+            sanitize_repo_url("git+https://github.com/user/repo.git"),
+            Some("https://github.com/user/repo".to_string())
         );
+    }
+
+    #[test]
+    fn test_sanitize_repo_url_legacy_git_protocol() {
         assert_eq!(
-            normalize_repo_url("git://github.com/user/repo"),
-            "https://github.com/user/repo"
+            sanitize_repo_url("git://github.com/user/repo"),
+            Some("https://github.com/user/repo".to_string())
         );
+    }
+
+    #[test]
+    fn test_sanitize_repo_url_passthrough_https() {
         assert_eq!(
-            normalize_repo_url("https://github.com/user/repo"),
-            "https://github.com/user/repo"
+            sanitize_repo_url("https://github.com/user/repo"),
+            Some("https://github.com/user/repo".to_string())
         );
+    }
+
+    #[test]
+    fn test_sanitize_repo_url_drops_ssh() {
+        assert_eq!(sanitize_repo_url("ssh://git@github.com/user/repo"), None);
     }
 }

--- a/dependi-lsp/src/registries/packagist.rs
+++ b/dependi-lsp/src/registries/packagist.rs
@@ -71,7 +71,7 @@ use reqwest::Client;
 use serde::Deserialize;
 
 use super::http_client::create_shared_client;
-use super::url_sanitizer::sanitize_repo_url;
+use super::url_sanitizer::{sanitize_external_url, sanitize_repo_url};
 use super::version_utils::is_prerelease_php;
 use super::{Registry, VersionInfo};
 
@@ -192,7 +192,9 @@ impl Registry for PackagistRegistry {
         let latest_entry = entries.first();
 
         let description = latest_entry.and_then(|e| e.description.clone());
-        let homepage = latest_entry.and_then(|e| e.homepage.clone());
+        let homepage = latest_entry
+            .and_then(|e| e.homepage.as_deref())
+            .and_then(sanitize_external_url);
         let license = latest_entry
             .and_then(|e| e.license.as_ref())
             .and_then(|l| l.first())

--- a/dependi-lsp/src/registries/url_sanitizer.rs
+++ b/dependi-lsp/src/registries/url_sanitizer.rs
@@ -13,7 +13,13 @@ pub(crate) fn sanitize_repo_url(raw: &str) -> Option<String> {
     let trimmed = raw.trim();
     let stripped = trimmed.strip_prefix("git+").unwrap_or(trimmed);
 
-    let mut parsed = url::Url::parse(stripped).ok()?;
+    let normalized = if let Some(rest) = stripped.strip_prefix("git://") {
+        format!("https://{rest}")
+    } else {
+        stripped.to_string()
+    };
+
+    let mut parsed = url::Url::parse(&normalized).ok()?;
 
     if !matches!(parsed.scheme(), "http" | "https") {
         return None;
@@ -60,6 +66,22 @@ mod tests {
         assert_eq!(
             sanitize_repo_url("git+http://example.com/repo.git"),
             Some("http://example.com/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn legacy_git_protocol_converted_to_https() {
+        assert_eq!(
+            sanitize_repo_url("git://github.com/user/repo"),
+            Some("https://github.com/user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn legacy_git_plus_git_protocol_converted_to_https() {
+        assert_eq!(
+            sanitize_repo_url("git+git://github.com/user/repo.git"),
+            Some("https://github.com/user/repo".to_string())
         );
     }
 }

--- a/dependi-lsp/src/registries/url_sanitizer.rs
+++ b/dependi-lsp/src/registries/url_sanitizer.rs
@@ -53,13 +53,34 @@ fn validate_external_url(parsed: &url::Url) -> Option<()> {
 }
 
 /// Strip the `git+` prefix and rewrite legacy `git://` to `https://`.
+///
+/// Prefix matching is ASCII-case-insensitive because URL schemes are
+/// case-insensitive per RFC 3986 §3.1, so inputs like `GIT+https://`
+/// and `Git://` must be normalised the same way as their lowercase
+/// counterparts.
+///
+/// Note: the `git://` -> `https://` rewrite assumes the remote host
+/// also serves the same path over HTTPS. This holds for GitHub, GitLab
+/// and Bitbucket (the overwhelming majority of package metadata), but
+/// is not guaranteed for self-hosted or legacy registries. Carryover
+/// from the previous per-registry helper, kept for compatibility.
 fn normalize_compound_scheme(input: &str) -> String {
-    let without_prefix = input.strip_prefix("git+").unwrap_or(input);
-    if let Some(rest) = without_prefix.strip_prefix("git://") {
+    let without_prefix = strip_prefix_ascii_case(input, "git+").unwrap_or(input);
+    if let Some(rest) = strip_prefix_ascii_case(without_prefix, "git://") {
         format!("https://{rest}")
     } else {
         without_prefix.to_string()
     }
+}
+
+/// Like `str::strip_prefix`, but matches the prefix case-insensitively
+/// across the ASCII range. The returned slice preserves the original
+/// case of the remainder.
+fn strip_prefix_ascii_case<'a>(input: &'a str, prefix: &str) -> Option<&'a str> {
+    input
+        .get(..prefix.len())
+        .filter(|head| head.eq_ignore_ascii_case(prefix))
+        .map(|_| &input[prefix.len()..])
 }
 
 /// Remove a trailing `.git` from the URL path, in place.
@@ -248,6 +269,37 @@ mod tests {
         assert_eq!(
             sanitize_repo_url("https://user:pass@github.com/user/repo"),
             None
+        );
+    }
+
+    #[test]
+    fn preserves_percent_encoding_when_stripping_dot_git() {
+        // Regression guard: `url::Url::set_path` must not double-encode
+        // pre-existing `%XX` sequences in the path (e.g. `my%20repo`
+        // must stay `my%20repo`, not become `my%2520repo`).
+        assert_eq!(
+            sanitize_repo_url("https://github.com/user/my%20repo.git"),
+            Some("https://github.com/user/my%20repo".to_string())
+        );
+    }
+
+    #[test]
+    fn accepts_uppercase_git_plus_prefix() {
+        // URL schemes are case-insensitive per RFC 3986; an upper-cased
+        // `GIT+https://` prefix must be normalised the same way as `git+`.
+        assert_eq!(
+            sanitize_repo_url("GIT+https://github.com/user/repo.git"),
+            Some("https://github.com/user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn accepts_uppercase_legacy_git_protocol() {
+        // Same case-insensitivity rule applies to the legacy `git://`
+        // scheme that we rewrite to `https://`.
+        assert_eq!(
+            sanitize_repo_url("GIT://github.com/user/repo"),
+            Some("https://github.com/user/repo".to_string())
         );
     }
 

--- a/dependi-lsp/src/registries/url_sanitizer.rs
+++ b/dependi-lsp/src/registries/url_sanitizer.rs
@@ -140,4 +140,44 @@ mod tests {
     fn rejects_garbage() {
         assert_eq!(sanitize_repo_url("not a url"), None);
     }
+
+    #[test]
+    fn strips_dot_git_suffix() {
+        assert_eq!(
+            sanitize_repo_url("https://github.com/user/repo.git"),
+            Some("https://github.com/user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn preserves_path_without_dot_git() {
+        assert_eq!(
+            sanitize_repo_url("https://gitlab.com/user/repo/subgroup"),
+            Some("https://gitlab.com/user/repo/subgroup".to_string())
+        );
+    }
+
+    #[test]
+    fn preserves_query_and_fragment() {
+        assert_eq!(
+            sanitize_repo_url("https://example.com/r?ref=v1#section"),
+            Some("https://example.com/r?ref=v1#section".to_string())
+        );
+    }
+
+    #[test]
+    fn case_insensitive_scheme() {
+        assert_eq!(
+            sanitize_repo_url("HTTPS://github.com/user/repo"),
+            Some("https://github.com/user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace() {
+        assert_eq!(
+            sanitize_repo_url("  https://example.com/r  "),
+            Some("https://example.com/r".to_string())
+        );
+    }
 }

--- a/dependi-lsp/src/registries/url_sanitizer.rs
+++ b/dependi-lsp/src/registries/url_sanitizer.rs
@@ -1,0 +1,19 @@
+//! Repository URL sanitization shared by registry adapters.
+//!
+//! Allows only `http`/`https` URLs after stripping common package-manager
+//! prefixes (`git+`) and suffixes (`.git`). Any other scheme is dropped.
+
+/// Sanitize a repository URL from package metadata.
+///
+/// Returns `Some(url)` only if the resulting scheme is `http` or `https`
+/// after stripping known package-manager prefixes (`git+`) and suffixes
+/// (`.git`). Returns `None` for any other scheme, empty input, or
+/// unparseable input.
+pub(crate) fn sanitize_repo_url(_raw: &str) -> Option<String> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+}

--- a/dependi-lsp/src/registries/url_sanitizer.rs
+++ b/dependi-lsp/src/registries/url_sanitizer.rs
@@ -10,11 +10,21 @@
 /// (`.git`). Returns `None` for any other scheme, empty input, or
 /// unparseable input.
 pub(crate) fn sanitize_repo_url(raw: &str) -> Option<String> {
-    let parsed = url::Url::parse(raw.trim()).ok()?;
-    match parsed.scheme() {
-        "http" | "https" => Some(parsed.to_string()),
-        _ => None,
+    let trimmed = raw.trim();
+    let stripped = trimmed.strip_prefix("git+").unwrap_or(trimmed);
+
+    let mut parsed = url::Url::parse(stripped).ok()?;
+
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
     }
+
+    let path = parsed.path().to_string();
+    if let Some(without_git) = path.strip_suffix(".git") {
+        parsed.set_path(without_git);
+    }
+
+    Some(parsed.to_string())
 }
 
 #[cfg(test)]
@@ -33,6 +43,22 @@ mod tests {
     fn accepts_http() {
         assert_eq!(
             sanitize_repo_url("http://example.com/repo"),
+            Some("http://example.com/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn strips_git_plus_https() {
+        assert_eq!(
+            sanitize_repo_url("git+https://github.com/user/repo.git"),
+            Some("https://github.com/user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn strips_git_plus_http() {
+        assert_eq!(
+            sanitize_repo_url("git+http://example.com/repo.git"),
             Some("http://example.com/repo".to_string())
         );
     }

--- a/dependi-lsp/src/registries/url_sanitizer.rs
+++ b/dependi-lsp/src/registries/url_sanitizer.rs
@@ -125,4 +125,19 @@ mod tests {
     fn rejects_mailto() {
         assert_eq!(sanitize_repo_url("mailto:foo@bar.com"), None);
     }
+
+    #[test]
+    fn rejects_empty_string() {
+        assert_eq!(sanitize_repo_url(""), None);
+    }
+
+    #[test]
+    fn rejects_whitespace_only() {
+        assert_eq!(sanitize_repo_url("   "), None);
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert_eq!(sanitize_repo_url("not a url"), None);
+    }
 }

--- a/dependi-lsp/src/registries/url_sanitizer.rs
+++ b/dependi-lsp/src/registries/url_sanitizer.rs
@@ -26,8 +26,14 @@ pub(crate) fn sanitize_repo_url(raw: &str) -> Option<String> {
         return None;
     }
 
-    strip_dot_git_suffix(&mut parsed);
-    Some(parsed.to_string())
+    // Embedded credentials (`https://user:pass@host/...`) in package
+    // metadata are never legitimate and would leak via the IDE surface.
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return None;
+    }
+
+    strip_dot_git_suffix(&mut parsed)?;
+    Some(parsed.as_str().to_owned())
 }
 
 /// Strip the `git+` prefix and rewrite legacy `git://` to `https://`.
@@ -41,11 +47,20 @@ fn normalize_compound_scheme(input: &str) -> String {
 }
 
 /// Remove a trailing `.git` from the URL path, in place.
-fn strip_dot_git_suffix(url: &mut url::Url) {
+///
+/// Returns `Some(())` on success, or `None` when stripping `.git` would
+/// collapse the entire path (e.g. `/.git`) — that input is pathological
+/// metadata and should be dropped rather than silently rewritten to a
+/// bare host URL.
+fn strip_dot_git_suffix(url: &mut url::Url) -> Option<()> {
     let path = url.path().to_string();
     if let Some(without_git) = path.strip_suffix(".git") {
+        if without_git.is_empty() || without_git == "/" {
+            return None;
+        }
         url.set_path(without_git);
     }
+    Some(())
 }
 
 #[cfg(test)]
@@ -193,6 +208,30 @@ mod tests {
         assert_eq!(
             sanitize_repo_url("  https://example.com/r  "),
             Some("https://example.com/r".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_bare_dot_git_path() {
+        // path of `/.git` would otherwise strip to `/` and leak a bogus
+        // root URL — return None instead.
+        assert_eq!(sanitize_repo_url("https://github.com/.git"), None);
+    }
+
+    #[test]
+    fn preserves_non_default_port() {
+        assert_eq!(
+            sanitize_repo_url("https://example.com:8443/user/repo"),
+            Some("https://example.com:8443/user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_userinfo_in_url() {
+        // credentials embedded in a metadata URL are never legitimate; drop them.
+        assert_eq!(
+            sanitize_repo_url("https://user:pass@github.com/user/repo"),
+            None
         );
     }
 }

--- a/dependi-lsp/src/registries/url_sanitizer.rs
+++ b/dependi-lsp/src/registries/url_sanitizer.rs
@@ -3,34 +3,49 @@
 //! Allows only `http`/`https` URLs after stripping common package-manager
 //! prefixes (`git+`) and suffixes (`.git`). Any other scheme is dropped.
 
+const ALLOWED_SCHEMES: &[&str] = &["http", "https"];
+
 /// Sanitize a repository URL from package metadata.
 ///
-/// Returns `Some(url)` only if the resulting scheme is `http` or `https`
-/// after stripping known package-manager prefixes (`git+`) and suffixes
-/// (`.git`). Returns `None` for any other scheme, empty input, or
-/// unparseable input.
+/// Accepted input shapes:
+///   * `https://...`, `http://...`
+///   * `git+https://...`, `git+http://...` (the `git+` prefix is stripped)
+///   * `git://...`, `git+git://...` (rewritten to `https://` for legacy compat)
+///
+/// Anything else (`ssh`, `git+ssh`, `ftp`, `file`, `javascript`, `data`,
+/// `mailto`, unparseable input, empty/whitespace input) returns `None`.
+///
+/// A trailing `.git` is stripped from the path; query and fragment are
+/// preserved. The scheme is normalized to lowercase by the underlying URL
+/// parser.
 pub(crate) fn sanitize_repo_url(raw: &str) -> Option<String> {
-    let trimmed = raw.trim();
-    let stripped = trimmed.strip_prefix("git+").unwrap_or(trimmed);
-
-    let normalized = if let Some(rest) = stripped.strip_prefix("git://") {
-        format!("https://{rest}")
-    } else {
-        stripped.to_string()
-    };
-
+    let normalized = normalize_compound_scheme(raw.trim());
     let mut parsed = url::Url::parse(&normalized).ok()?;
 
-    if !matches!(parsed.scheme(), "http" | "https") {
+    if !ALLOWED_SCHEMES.contains(&parsed.scheme()) {
         return None;
     }
 
-    let path = parsed.path().to_string();
-    if let Some(without_git) = path.strip_suffix(".git") {
-        parsed.set_path(without_git);
-    }
-
+    strip_dot_git_suffix(&mut parsed);
     Some(parsed.to_string())
+}
+
+/// Strip the `git+` prefix and rewrite legacy `git://` to `https://`.
+fn normalize_compound_scheme(input: &str) -> String {
+    let without_prefix = input.strip_prefix("git+").unwrap_or(input);
+    if let Some(rest) = without_prefix.strip_prefix("git://") {
+        format!("https://{rest}")
+    } else {
+        without_prefix.to_string()
+    }
+}
+
+/// Remove a trailing `.git` from the URL path, in place.
+fn strip_dot_git_suffix(url: &mut url::Url) {
+    let path = url.path().to_string();
+    if let Some(without_git) = path.strip_suffix(".git") {
+        url.set_path(without_git);
+    }
 }
 
 #[cfg(test)]

--- a/dependi-lsp/src/registries/url_sanitizer.rs
+++ b/dependi-lsp/src/registries/url_sanitizer.rs
@@ -84,4 +84,45 @@ mod tests {
             Some("https://github.com/user/repo".to_string())
         );
     }
+
+    #[test]
+    fn rejects_ssh() {
+        assert_eq!(sanitize_repo_url("ssh://git@github.com/user/repo"), None);
+    }
+
+    #[test]
+    fn rejects_git_plus_ssh() {
+        assert_eq!(
+            sanitize_repo_url("git+ssh://git@github.com/user/repo.git"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_ftp() {
+        assert_eq!(sanitize_repo_url("ftp://example.com/repo"), None);
+    }
+
+    #[test]
+    fn rejects_file() {
+        assert_eq!(sanitize_repo_url("file:///etc/passwd"), None);
+    }
+
+    #[test]
+    fn rejects_javascript() {
+        assert_eq!(sanitize_repo_url("javascript:alert(1)"), None);
+    }
+
+    #[test]
+    fn rejects_data_uri() {
+        assert_eq!(
+            sanitize_repo_url("data:text/html,<script>alert(1)</script>"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_mailto() {
+        assert_eq!(sanitize_repo_url("mailto:foo@bar.com"), None);
+    }
 }

--- a/dependi-lsp/src/registries/url_sanitizer.rs
+++ b/dependi-lsp/src/registries/url_sanitizer.rs
@@ -21,19 +21,35 @@ const ALLOWED_SCHEMES: &[&str] = &["http", "https"];
 pub(crate) fn sanitize_repo_url(raw: &str) -> Option<String> {
     let normalized = normalize_compound_scheme(raw.trim());
     let mut parsed = url::Url::parse(&normalized).ok()?;
+    validate_external_url(&parsed)?;
+    strip_dot_git_suffix(&mut parsed)?;
+    Some(parsed.as_str().to_owned())
+}
 
+/// Sanitize a generic external URL from package metadata (e.g. `homepage`,
+/// `documentation`).
+///
+/// Same allowlist semantics as [`sanitize_repo_url`] — only `http` and
+/// `https` schemes are accepted, and embedded userinfo is rejected — but
+/// without the repository-specific `git+` prefix stripping or `.git`
+/// suffix removal. A homepage URL whose path legitimately ends in `.git`
+/// must not be rewritten.
+pub(crate) fn sanitize_external_url(raw: &str) -> Option<String> {
+    let parsed = url::Url::parse(raw.trim()).ok()?;
+    validate_external_url(&parsed)?;
+    Some(parsed.as_str().to_owned())
+}
+
+/// Apply the allowlist + userinfo rejection check shared by both
+/// `sanitize_repo_url` and `sanitize_external_url`.
+fn validate_external_url(parsed: &url::Url) -> Option<()> {
     if !ALLOWED_SCHEMES.contains(&parsed.scheme()) {
         return None;
     }
-
-    // Embedded credentials (`https://user:pass@host/...`) in package
-    // metadata are never legitimate and would leak via the IDE surface.
     if !parsed.username().is_empty() || parsed.password().is_some() {
         return None;
     }
-
-    strip_dot_git_suffix(&mut parsed)?;
-    Some(parsed.as_str().to_owned())
+    Some(())
 }
 
 /// Strip the `git+` prefix and rewrite legacy `git://` to `https://`.
@@ -233,5 +249,76 @@ mod tests {
             sanitize_repo_url("https://user:pass@github.com/user/repo"),
             None
         );
+    }
+
+    // sanitize_external_url — variant for non-repository fields (homepage,
+    // documentation links). Same allowlist, but no `git+` strip and no
+    // `.git` suffix removal because those are repository-specific.
+
+    #[test]
+    fn external_accepts_https() {
+        assert_eq!(
+            sanitize_external_url("https://example.com/"),
+            Some("https://example.com/".to_string())
+        );
+    }
+
+    #[test]
+    fn external_accepts_http() {
+        assert_eq!(
+            sanitize_external_url("http://example.com/docs"),
+            Some("http://example.com/docs".to_string())
+        );
+    }
+
+    #[test]
+    fn external_rejects_javascript() {
+        assert_eq!(sanitize_external_url("javascript:alert(1)"), None);
+    }
+
+    #[test]
+    fn external_rejects_file() {
+        assert_eq!(sanitize_external_url("file:///etc/passwd"), None);
+    }
+
+    #[test]
+    fn external_rejects_data_uri() {
+        assert_eq!(
+            sanitize_external_url("data:text/html,<script>alert(1)</script>"),
+            None
+        );
+    }
+
+    #[test]
+    fn external_rejects_ssh() {
+        assert_eq!(sanitize_external_url("ssh://git@example.com/x"), None);
+    }
+
+    #[test]
+    fn external_rejects_userinfo() {
+        assert_eq!(
+            sanitize_external_url("https://user:pass@example.com/"),
+            None
+        );
+    }
+
+    #[test]
+    fn external_does_not_strip_git_suffix() {
+        // unlike sanitize_repo_url, the homepage variant must not rewrite
+        // a path that happens to end in `.git`.
+        assert_eq!(
+            sanitize_external_url("https://example.com/foo.git"),
+            Some("https://example.com/foo.git".to_string())
+        );
+    }
+
+    #[test]
+    fn external_rejects_empty() {
+        assert_eq!(sanitize_external_url(""), None);
+    }
+
+    #[test]
+    fn external_rejects_garbage() {
+        assert_eq!(sanitize_external_url("not a url"), None);
     }
 }

--- a/dependi-lsp/src/registries/url_sanitizer.rs
+++ b/dependi-lsp/src/registries/url_sanitizer.rs
@@ -9,11 +9,31 @@
 /// after stripping known package-manager prefixes (`git+`) and suffixes
 /// (`.git`). Returns `None` for any other scheme, empty input, or
 /// unparseable input.
-pub(crate) fn sanitize_repo_url(_raw: &str) -> Option<String> {
-    None
+pub(crate) fn sanitize_repo_url(raw: &str) -> Option<String> {
+    let parsed = url::Url::parse(raw.trim()).ok()?;
+    match parsed.scheme() {
+        "http" | "https" => Some(parsed.to_string()),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn accepts_https() {
+        assert_eq!(
+            sanitize_repo_url("https://github.com/user/repo"),
+            Some("https://github.com/user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn accepts_http() {
+        assert_eq!(
+            sanitize_repo_url("http://example.com/repo"),
+            Some("http://example.com/repo".to_string())
+        );
+    }
 }


### PR DESCRIPTION
## Summary

• Fixes CWE-20 (Improper Input Validation) by implementing strict URL scheme allowlisting
• Adds shared `url_sanitizer` module using battle-tested `url` crate v2.5
• Protects both repository and homepage fields in npm and Packagist registries
• Rejects non-http(s) URLs (ssh, ftp, file, javascript, data, mailto schemes)
• Rejects embedded credentials (userinfo) in URLs
• Strips git+ prefix and legacy git:// protocol conversions
• Removes .git suffix from repository paths (non-repository URLs preserved)
• Rejects pathological bare-host paths (e.g., `https://github.com/.git`)
• All changes validated with 34 comprehensive unit tests

## Changes

### New Module
- **dependi-lsp/src/registries/url_sanitizer.rs**: Shared sanitization functions
  - `sanitize_repo_url()`: Repository-specific (handles git+, converts git://, strips .git)
  - `sanitize_external_url()`: Generic URL validation (homepage, docs, etc.)
  - Shared `validate_external_url()` with allowlist + userinfo rejection
  - Helper functions for scheme normalization and .git suffix removal
  - 34 unit tests covering all edge cases

### Updated Registries
- **npm.rs**: Uses shared `sanitize_repo_url()` for repository URLs and `sanitize_external_url()` for homepage
- **packagist.rs**: Uses shared `sanitize_repo_url()` for repository URLs and `sanitize_external_url()` for homepage

### Dependencies
- Added `url = "2.5"` to dependi-lsp/Cargo.toml

### Documentation
- Updated CHANGELOG.md under [Unreleased] > Security section

## Validation

All tests passing: 664 lib tests + 8 integration tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes repository and homepage URLs in `npm` and `Packagist` to allow only http/https and drop unsafe schemes or embedded credentials (CWE-20, Issue #230). Adds a shared sanitizer with repo-specific handling for git+ prefixes, legacy git:// → https, .git stripping, case-insensitive prefix matching, and preserves percent-encoded paths.

- **Bug Fixes**
  - Validate URLs via a shared sanitizer; reject `ssh`, `ftp`, `file`, `javascript`, `data`, `mailto`, and any with userinfo.
  - Repository URLs: strip `git+`, convert `git://` to `https://`, remove trailing `.git`; drop `https://host/.git`; match `git+`/`git://` case-insensitively; preserve `%XX` encoding when stripping.
  - Apply sanitization to both `repository` and `homepage` fields in `npm` and `Packagist`.

- **Dependencies**
  - Add `url = "2.5"`.

<sup>Written for commit 9a1fc39589287c3cfeb8b35f1718d66ed26a5520. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enhanced URL sanitization for repository and homepage metadata from npm and Packagist to prevent unsafe links reaching the IDE.
  * Now drops unsupported schemes and URLs containing embedded credentials, and avoids unsafe path normalization that could produce misleading hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->