### PR TITLE
perf(cache): make ReadCache/WriteCache async, offload SQLite to spawn_blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Cache traits (`ReadCache`, `WriteCache`) are now async (AFIT). The SQLite cache offloads blocking `rusqlite` work to `tokio::task::spawn_blocking`, keeping the LSP event loop responsive under load. Reduces tail latency on operations that hit the persistent cache. (#235)
 - Bump `hashbrown` from 0.16.1 to 0.17.0 (purely additive release, hashbrown MSRV 1.85 ≤ project MSRV 1.94)
 - Bump `tokio` constraint from 1.50 to 1.52 in `dependi-lsp/Cargo.toml` (lockfile resolves 1.52.1; patch + minor, backwards compatible)
 - Bump `actions/github-script` from v8 to v9 in `contributor-experience.yml` workflow (Octokit v7; inline scripts unaffected — no `require()` or `getOctokit` shadowing)

--- a/dependi-lsp/benches/benchmarks.rs
+++ b/dependi-lsp/benches/benchmarks.rs
@@ -474,6 +474,9 @@ fn bench_parsers(c: &mut Criterion) {
 // =============================================================================
 
 fn bench_memory_cache(c: &mut Criterion) {
+    use tokio::runtime::Runtime;
+
+    let rt = Runtime::new().unwrap();
     let mut group = c.benchmark_group("cache/memory");
 
     for entry_count in [100, 1000, 10000] {
@@ -482,7 +485,7 @@ fn bench_memory_cache(c: &mut Criterion) {
         // Pre-populate cache
         for i in 0..entry_count {
             let info = create_version_info();
-            cache.insert(format!("package_{i}"), info);
+            rt.block_on(cache.insert(format!("package_{i}"), info));
         }
 
         group.bench_with_input(
@@ -490,7 +493,7 @@ fn bench_memory_cache(c: &mut Criterion) {
             &cache,
             |b, cache| {
                 b.iter(|| {
-                    black_box(cache.get("package_500"));
+                    black_box(rt.block_on(cache.get("package_500")));
                 });
             },
         );
@@ -500,7 +503,7 @@ fn bench_memory_cache(c: &mut Criterion) {
             &cache,
             |b, cache| {
                 b.iter(|| {
-                    black_box(cache.get("nonexistent_package"));
+                    black_box(rt.block_on(cache.get("nonexistent_package")));
                 });
             },
         );
@@ -511,7 +514,7 @@ fn bench_memory_cache(c: &mut Criterion) {
             |b, cache| {
                 let mut i = entry_count;
                 b.iter(|| {
-                    cache.insert(format!("new_package_{i}"), create_version_info());
+                    rt.block_on(cache.insert(format!("new_package_{i}"), create_version_info()));
                     i += 1;
                 });
             },
@@ -523,7 +526,9 @@ fn bench_memory_cache(c: &mut Criterion) {
 
 fn bench_sqlite_cache(c: &mut Criterion) {
     use std::path::PathBuf;
+    use tokio::runtime::Runtime;
 
+    let rt = Runtime::new().unwrap();
     let mut group = c.benchmark_group("cache/sqlite");
 
     // Use a temporary file for benchmarks since in_memory() is cfg(test) only
@@ -539,10 +544,10 @@ fn bench_sqlite_cache(c: &mut Criterion) {
 
     for entry_count in [100, 1000] {
         // Clear and pre-populate cache
-        cache.clear();
+        rt.block_on(cache.clear());
         for i in 0..entry_count {
             let info = create_version_info();
-            cache.insert(format!("package_{i}"), info);
+            rt.block_on(cache.insert(format!("package_{i}"), info));
         }
 
         group.bench_with_input(
@@ -550,7 +555,7 @@ fn bench_sqlite_cache(c: &mut Criterion) {
             &entry_count,
             |b, _| {
                 b.iter(|| {
-                    black_box(cache.get("package_500"));
+                    black_box(rt.block_on(cache.get("package_500")));
                 });
             },
         );
@@ -560,7 +565,7 @@ fn bench_sqlite_cache(c: &mut Criterion) {
             &entry_count,
             |b, _| {
                 b.iter(|| {
-                    black_box(cache.get("nonexistent_package"));
+                    black_box(rt.block_on(cache.get("nonexistent_package")));
                 });
             },
         );
@@ -571,10 +576,10 @@ fn bench_sqlite_cache(c: &mut Criterion) {
             &entry_count,
             |b, _| {
                 b.iter(|| {
-                    cache.insert(
+                    rt.block_on(cache.insert(
                         format!("new_package_{insert_counter}"),
                         create_version_info(),
-                    );
+                    ));
                     insert_counter += 1;
                 });
             },

--- a/dependi-lsp/benches/benchmarks.rs
+++ b/dependi-lsp/benches/benchmarks.rs
@@ -488,12 +488,17 @@ fn bench_memory_cache(c: &mut Criterion) {
             rt.block_on(cache.insert(format!("package_{i}"), info));
         }
 
+        // Use a key guaranteed to exist for the current parameter set so the
+        // benchmark always exercises the hit path (`package_500` is missing
+        // when `entry_count == 100`).
+        let hit_key = format!("package_{}", entry_count / 2);
+
         group.bench_with_input(
             BenchmarkId::new("get_hit", entry_count),
             &cache,
             |b, cache| {
                 b.iter(|| {
-                    black_box(rt.block_on(cache.get("package_500")));
+                    black_box(rt.block_on(cache.get(&hit_key)));
                 });
             },
         );
@@ -550,12 +555,16 @@ fn bench_sqlite_cache(c: &mut Criterion) {
             rt.block_on(cache.insert(format!("package_{i}"), info));
         }
 
+        // Use a key guaranteed to exist for the current parameter set so the
+        // benchmark always exercises the hit path.
+        let hit_key = format!("package_{}", entry_count / 2);
+
         group.bench_with_input(
             BenchmarkId::new("get_hit", entry_count),
             &entry_count,
             |b, _| {
                 b.iter(|| {
-                    black_box(rt.block_on(cache.get("package_500")));
+                    black_box(rt.block_on(cache.get(&hit_key)));
                 });
             },
         );

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -1927,21 +1927,23 @@ impl LanguageServer for DependiBackend {
         };
 
         // Pre-fetch all cache values asynchronously before the sync iterator chain.
+        // Bound the fan-out so a large file or canceled inlay-hint request can't
+        // enqueue an unbounded number of `spawn_blocking` SQLite jobs (which are
+        // not cancelable: a dropped future may still complete the underlying op).
+        const PREFETCH_CONCURRENCY: usize = 8;
+        let cache_keys: Vec<String> = visible_deps
+            .iter()
+            .map(|dep| dep_cache_key(dep, file_type))
+            .collect();
         let cache_values: HashMap<String, Option<crate::registries::VersionInfo>> = {
-            let futures: Vec<_> = visible_deps
-                .iter()
-                .map(|dep| {
-                    let cache_key = dep_cache_key(dep, file_type);
-                    async move {
-                        let value = self.version_cache.get(&cache_key).await;
-                        (cache_key, value)
-                    }
-                })
-                .collect();
-            futures::future::join_all(futures)
-                .await
-                .into_iter()
-                .collect()
+            use futures::stream::{self, StreamExt};
+            stream::iter(cache_keys.into_iter().map(|cache_key| async move {
+                let value = self.version_cache.get(&cache_key).await;
+                (cache_key, value)
+            }))
+            .buffer_unordered(PREFETCH_CONCURRENCY)
+            .collect()
+            .await
         };
 
         let hints: Vec<InlayHint> = visible_deps

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -642,7 +642,7 @@ impl ProcessingContext {
                 let cache = Arc::clone(&cache);
                 async move {
                     // Check cache first
-                    if cache.get(&cache_key).is_some() {
+                    if cache.get(&cache_key).await.is_some() {
                         tracing::debug!("Cache hit for '{name}' (key: {cache_key})");
                         return;
                     }
@@ -676,7 +676,7 @@ impl ProcessingContext {
                     };
                     match result {
                         Ok(info) => {
-                            cache.insert(cache_key, info);
+                            cache.insert(cache_key, info).await;
                         }
                         Err(e) => {
                             tracing::error!(
@@ -773,7 +773,8 @@ impl ProcessingContext {
                 file_type,
                 &empty_transitives,
                 &ignored_packages,
-            );
+            )
+            .await;
 
             self.client
                 .publish_diagnostics(uri.clone(), diagnostics, None)
@@ -1001,7 +1002,7 @@ impl DependiBackend {
         };
 
         // Check cache first
-        if let Some(cached) = self.version_cache.get(&cache_key) {
+        if let Some(cached) = self.version_cache.get(&cache_key).await {
             return Some(cached);
         }
 
@@ -1042,7 +1043,7 @@ impl DependiBackend {
 
         match result {
             Ok(info) => {
-                self.version_cache.insert(cache_key, info.clone());
+                self.version_cache.insert(cache_key, info.clone()).await;
                 Some(info)
             }
             Err(e) => {
@@ -1174,7 +1175,7 @@ impl DependiBackend {
                         .get(&dep.name)
                         .cloned()
                         .unwrap_or_else(|| file_type.cache_key(&dep.name));
-                    if let Some(mut info) = cache.get(&cache_key) {
+                    if let Some(mut info) = cache.get(&cache_key).await {
                         info.vulnerabilities = result.vulnerabilities.clone();
                         info.deprecated = result.deprecated;
                         if result.deprecated {
@@ -1191,7 +1192,7 @@ impl DependiBackend {
                             result.vulnerabilities.len(),
                             result.deprecated
                         );
-                        cache.insert(cache_key, info);
+                        cache.insert(cache_key, info).await;
                         updated_count += 1;
                     } else {
                         tracing::warn!(
@@ -1455,7 +1456,7 @@ impl DependiBackend {
 
         for dep in &dependencies {
             let cache_key = dep_cache_key(dep, file_type);
-            if let Some(info) = self.version_cache.get(&cache_key) {
+            if let Some(info) = self.version_cache.get(&cache_key).await {
                 for vuln in &info.vulnerabilities {
                     summary.total += 1;
                     match vuln.severity {
@@ -1891,35 +1892,61 @@ impl LanguageServer for DependiBackend {
     }
 
     async fn inlay_hint(&self, params: InlayHintParams) -> Result<Option<Vec<InlayHint>>> {
-        let Ok(config) = self.config.read() else {
-            return Ok(Some(vec![]));
+        // Read config values and drop the guard immediately so it doesn't cross await points.
+        let (show_up_to_date, ignored_packages) = {
+            let Ok(config) = self.config.read() else {
+                return Ok(Some(vec![]));
+            };
+            if !config.inlay_hints.enabled {
+                return Ok(Some(vec![]));
+            }
+            (config.inlay_hints.show_up_to_date, config.ignore.clone())
         };
-        if !config.inlay_hints.enabled {
-            return Ok(Some(vec![]));
-        }
-        let show_up_to_date = config.inlay_hints.show_up_to_date;
-        let ignored_packages = config.ignore.clone();
-        drop(config);
 
         let uri = &params.text_document.uri;
 
-        let Some(doc) = self.documents.get(uri) else {
-            return Ok(Some(vec![]));
+        // Clone doc data out of DashMap before any await points to avoid holding
+        // the non-Send DashMap Ref guard across await boundaries.
+        let (file_type, visible_deps) = {
+            let Some(doc) = self.documents.get(uri) else {
+                return Ok(Some(vec![]));
+            };
+            let file_type = doc.file_type;
+            let visible_deps: Vec<_> = doc
+                .dependencies
+                .iter()
+                .filter(|dep| {
+                    // Only show hints for dependencies in the visible range
+                    (params.range.start.line..=params.range.end.line)
+                        .contains(&dep.version_span.line)
+                })
+                .filter(|dep| !crate::config::is_package_ignored(&dep.name, &ignored_packages))
+                .cloned()
+                .collect();
+            (file_type, visible_deps)
         };
 
-        let file_type = doc.file_type;
-        let hints: Vec<InlayHint> = doc
-            .dependencies
-            .iter()
-            .filter(|dep| {
-                // Only show hints for dependencies in the visible range
-                (params.range.start.line..=params.range.end.line).contains(&dep.version_span.line)
-            })
-            .filter(|dep| !crate::config::is_package_ignored(&dep.name, &ignored_packages))
+        // Pre-fetch all cache values asynchronously before the sync iterator chain.
+        let cache_values: HashMap<String, Option<crate::registries::VersionInfo>> = {
+            let futures: Vec<_> = visible_deps
+                .iter()
+                .map(|dep| {
+                    let cache_key = dep_cache_key(dep, file_type);
+                    async move {
+                        let value = self.version_cache.get(&cache_key).await;
+                        (cache_key, value)
+                    }
+                })
+                .collect();
+            futures::future::join_all(futures).await.into_iter().collect()
+        };
+
+        let hints: Vec<InlayHint> = visible_deps
+            .into_iter()
             .filter_map(|dep| {
-                let cache_key = dep_cache_key(dep, file_type);
-                let version_info = self.version_cache.get(&cache_key);
-                let hint = create_inlay_hint(dep, version_info.as_ref(), file_type);
+                let cache_key = dep_cache_key(&dep, file_type);
+                let version_info = cache_values.get(&cache_key).and_then(|v| v.as_ref());
+                let hint = create_inlay_hint(&dep, version_info, file_type);
 
                 // Optionally filter out up-to-date hints
                 if !show_up_to_date {
@@ -2080,7 +2107,8 @@ impl LanguageServer for DependiBackend {
             &ignored_packages,
             workspace_root.as_deref(),
             current_settings.as_deref(),
-        );
+        )
+        .await;
 
         Ok(Some(actions))
     }
@@ -2105,7 +2133,8 @@ impl LanguageServer for DependiBackend {
                     .get(name)
                     .cloned()
                     .unwrap_or_else(|| file_type.cache_key(name))
-            });
+            })
+            .await;
 
         match completions {
             Some(items) => Ok(Some(CompletionResponse::Array(items))),

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -2120,24 +2120,30 @@ impl LanguageServer for DependiBackend {
         let uri = &params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
 
-        let Some(doc) = self.documents.get(uri) else {
-            return Ok(Some(CompletionResponse::Array(vec![])));
+        // Snapshot everything we need from the document state, then drop the
+        // DashMap guard before any .await — holding a guard across .await can
+        // block other tasks waiting on the same key.
+        let (file_type, dependencies, cache_key_map) = {
+            let Some(doc) = self.documents.get(uri) else {
+                return Ok(Some(CompletionResponse::Array(vec![])));
+            };
+            let file_type = doc.file_type;
+            let dependencies = doc.dependencies.clone();
+            let cache_key_map: HashMap<String, String> = doc
+                .dependencies
+                .iter()
+                .map(|dep| (dep.name.clone(), dep_cache_key(dep, file_type)))
+                .collect();
+            (file_type, dependencies, cache_key_map)
         };
 
-        let file_type = doc.file_type;
-        let cache_key_map: HashMap<String, String> = doc
-            .dependencies
-            .iter()
-            .map(|dep| (dep.name.clone(), dep_cache_key(dep, file_type)))
-            .collect();
-        let completions =
-            get_completions(&doc.dependencies, position, &self.version_cache, |name| {
-                cache_key_map
-                    .get(name)
-                    .cloned()
-                    .unwrap_or_else(|| file_type.cache_key(name))
-            })
-            .await;
+        let completions = get_completions(&dependencies, position, &self.version_cache, |name| {
+            cache_key_map
+                .get(name)
+                .cloned()
+                .unwrap_or_else(|| file_type.cache_key(name))
+        })
+        .await;
 
         match completions {
             Some(items) => Ok(Some(CompletionResponse::Array(items))),

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -1938,7 +1938,10 @@ impl LanguageServer for DependiBackend {
                     }
                 })
                 .collect();
-            futures::future::join_all(futures).await.into_iter().collect()
+            futures::future::join_all(futures)
+                .await
+                .into_iter()
+                .collect()
         };
 
         let hints: Vec<InlayHint> = visible_deps

--- a/dependi-lsp/src/cache/CLAUDE.md
+++ b/dependi-lsp/src/cache/CLAUDE.md
@@ -7,6 +7,7 @@
 |----|------|---|-------|------|
 | #1911 | 12:30 PM | 🔵 | Complete Configuration and Parser Code Exploration Findings | ~625 |
 | #1910 | " | 🔵 | Cache Architecture with String Key-Value Storage | ~487 |
+
 </claude-mem-context>
 
 ## Async cache API (issue #235)

--- a/dependi-lsp/src/cache/CLAUDE.md
+++ b/dependi-lsp/src/cache/CLAUDE.md
@@ -1,0 +1,27 @@
+<claude-mem-context>
+# Recent Activity
+
+### Feb 9, 2026
+
+| ID | Time | T | Title | Read |
+|----|------|---|-------|------|
+| #1911 | 12:30 PM | 🔵 | Complete Configuration and Parser Code Exploration Findings | ~625 |
+| #1910 | " | 🔵 | Cache Architecture with String Key-Value Storage | ~487 |
+</claude-mem-context>
+
+## Async cache API (issue #235)
+
+The `ReadCache` and `WriteCache` traits are async (AFIT, `#[allow(async_fn_in_trait)]`),
+matching the `crate::registries::Registry` pattern.
+
+`SqliteCache` impls wrap rusqlite work in `tokio::task::spawn_blocking` so blocking
+DB calls do not stall the tokio runtime. `MemoryCache` and `HybridCache` are async
+in signature but do no blocking work internally.
+
+Notes:
+- `spawn_blocking` tasks are NOT cancelable. A dropped future may still complete
+  the underlying DB operation.
+- `init_schema`, `pool_state`, `cache_dir`, and the `SqliteCache` constructors
+  remain synchronous (called once at startup or for cheap monitoring).
+- Tests use `#[tokio::test]`. Tests that need a multi-threaded runtime use
+  `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`.

--- a/dependi-lsp/src/cache/mod.rs
+++ b/dependi-lsp/src/cache/mod.rs
@@ -375,8 +375,12 @@ mod tests {
     async fn test_memory_cache_cleanup_expired() {
         let cache = MemoryCache::with_ttl(Duration::from_millis(10));
 
-        cache.insert("key1".to_string(), create_test_version_info()).await;
-        cache.insert("key2".to_string(), create_test_version_info()).await;
+        cache
+            .insert("key1".to_string(), create_test_version_info())
+            .await;
+        cache
+            .insert("key2".to_string(), create_test_version_info())
+            .await;
 
         assert_eq!(cache.len(), 2);
 
@@ -392,13 +396,17 @@ mod tests {
     async fn test_memory_cache_cleanup_partial() {
         let cache = MemoryCache::with_ttl(Duration::from_millis(200));
 
-        cache.insert("key1".to_string(), create_test_version_info()).await;
+        cache
+            .insert("key1".to_string(), create_test_version_info())
+            .await;
 
         // Wait for first entry to almost expire
         std::thread::sleep(Duration::from_millis(150));
 
         // Insert second entry
-        cache.insert("key2".to_string(), create_test_version_info()).await;
+        cache
+            .insert("key2".to_string(), create_test_version_info())
+            .await;
 
         // Wait for first to expire but not second
         std::thread::sleep(Duration::from_millis(100));
@@ -413,8 +421,12 @@ mod tests {
     async fn test_memory_cache_stats() {
         let cache = MemoryCache::with_ttl(Duration::from_millis(100));
 
-        cache.insert("key1".to_string(), create_test_version_info()).await;
-        cache.insert("key2".to_string(), create_test_version_info()).await;
+        cache
+            .insert("key1".to_string(), create_test_version_info())
+            .await;
+        cache
+            .insert("key2".to_string(), create_test_version_info())
+            .await;
 
         let stats = cache.stats();
         assert_eq!(stats.total_entries, 2);
@@ -447,7 +459,9 @@ mod tests {
     async fn test_memory_cache_is_empty() {
         let cache = MemoryCache::with_ttl(Duration::from_secs(60));
         assert!(cache.is_empty());
-        cache.insert("key".to_string(), create_test_version_info()).await;
+        cache
+            .insert("key".to_string(), create_test_version_info())
+            .await;
         assert!(!cache.is_empty());
     }
 
@@ -460,7 +474,9 @@ mod tests {
         let cache = MemoryCache::new();
         assert!(!assert_contains_via_trait(&cache, "key").await);
 
-        cache.insert("key".to_string(), create_test_version_info()).await;
+        cache
+            .insert("key".to_string(), create_test_version_info())
+            .await;
         assert!(assert_contains_via_trait(&cache, "key").await);
     }
 
@@ -488,8 +504,12 @@ mod tests {
         }
 
         let cache = MemoryCache::new();
-        cache.insert("key1".to_string(), create_test_version_info()).await;
-        cache.insert("key2".to_string(), create_test_version_info()).await;
+        cache
+            .insert("key1".to_string(), create_test_version_info())
+            .await;
+        cache
+            .insert("key2".to_string(), create_test_version_info())
+            .await;
         assert_eq!(cache.len(), 2);
 
         clear_via_trait(&cache).await;

--- a/dependi-lsp/src/cache/mod.rs
+++ b/dependi-lsp/src/cache/mod.rs
@@ -293,7 +293,7 @@ impl HybridCache {
                 }
 
                 if let Some(ref sqlite) = sqlite
-                    && let Ok(rows) = sqlite.cleanup_expired()
+                    && let Ok(rows) = sqlite.cleanup_expired().await
                     && rows > 0
                 {
                     tracing::info!(
@@ -307,18 +307,18 @@ impl HybridCache {
 }
 
 impl ReadCache for HybridCache {
-    fn get(&self, key: &str) -> Option<VersionInfo> {
+    async fn get(&self, key: &str) -> Option<VersionInfo> {
         // Fast path: check memory cache first
-        if let Some(value) = self.memory.get(key) {
+        if let Some(value) = self.memory.get(key).await {
             return Some(value);
         }
 
         // Slow path: check SQLite cache
         if let Some(ref sqlite) = self.sqlite
-            && let Some(value) = sqlite.get(key)
+            && let Some(value) = sqlite.get(key).await
         {
             // Populate memory cache for future fast access
-            self.memory.insert(key.to_string(), value.clone());
+            self.memory.insert(key.to_string(), value.clone()).await;
             return Some(value);
         }
 
@@ -327,24 +327,24 @@ impl ReadCache for HybridCache {
 }
 
 impl WriteCache for HybridCache {
-    fn insert(&self, key: String, value: VersionInfo) {
-        self.memory.insert(key.clone(), value.clone());
+    async fn insert(&self, key: String, value: VersionInfo) {
+        self.memory.insert(key.clone(), value.clone()).await;
         if let Some(ref sqlite) = self.sqlite {
-            sqlite.insert(key, value);
+            sqlite.insert(key, value).await;
         }
     }
 
-    fn remove(&self, key: &str) {
-        self.memory.remove(key);
+    async fn remove(&self, key: &str) {
+        self.memory.remove(key).await;
         if let Some(ref sqlite) = self.sqlite {
-            sqlite.remove(key);
+            sqlite.remove(key).await;
         }
     }
 
-    fn clear(&self) {
-        self.memory.clear();
+    async fn clear(&self) {
+        self.memory.clear().await;
         if let Some(ref sqlite) = self.sqlite {
-            sqlite.clear();
+            sqlite.clear().await;
         }
     }
 }

--- a/dependi-lsp/src/cache/mod.rs
+++ b/dependi-lsp/src/cache/mod.rs
@@ -371,12 +371,12 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_memory_cache_cleanup_expired() {
+    #[tokio::test]
+    async fn test_memory_cache_cleanup_expired() {
         let cache = MemoryCache::with_ttl(Duration::from_millis(10));
 
-        cache.insert("key1".to_string(), create_test_version_info());
-        cache.insert("key2".to_string(), create_test_version_info());
+        cache.insert("key1".to_string(), create_test_version_info()).await;
+        cache.insert("key2".to_string(), create_test_version_info()).await;
 
         assert_eq!(cache.len(), 2);
 
@@ -388,17 +388,17 @@ mod tests {
         assert_eq!(cache.len(), 0);
     }
 
-    #[test]
-    fn test_memory_cache_cleanup_partial() {
+    #[tokio::test]
+    async fn test_memory_cache_cleanup_partial() {
         let cache = MemoryCache::with_ttl(Duration::from_millis(200));
 
-        cache.insert("key1".to_string(), create_test_version_info());
+        cache.insert("key1".to_string(), create_test_version_info()).await;
 
         // Wait for first entry to almost expire
         std::thread::sleep(Duration::from_millis(150));
 
         // Insert second entry
-        cache.insert("key2".to_string(), create_test_version_info());
+        cache.insert("key2".to_string(), create_test_version_info()).await;
 
         // Wait for first to expire but not second
         std::thread::sleep(Duration::from_millis(100));
@@ -406,15 +406,15 @@ mod tests {
         let removed = cache.cleanup_expired();
         assert_eq!(removed, 1);
         assert_eq!(cache.len(), 1);
-        assert!(cache.get("key2").is_some());
+        assert!(cache.get("key2").await.is_some());
     }
 
-    #[test]
-    fn test_memory_cache_stats() {
+    #[tokio::test]
+    async fn test_memory_cache_stats() {
         let cache = MemoryCache::with_ttl(Duration::from_millis(100));
 
-        cache.insert("key1".to_string(), create_test_version_info());
-        cache.insert("key2".to_string(), create_test_version_info());
+        cache.insert("key1".to_string(), create_test_version_info()).await;
+        cache.insert("key2".to_string(), create_test_version_info()).await;
 
         let stats = cache.stats();
         assert_eq!(stats.total_entries, 2);
@@ -443,46 +443,56 @@ mod tests {
         assert!(display.contains("valid: 7"));
     }
 
-    #[test]
-    fn test_memory_cache_is_empty() {
+    #[tokio::test]
+    async fn test_memory_cache_is_empty() {
         let cache = MemoryCache::with_ttl(Duration::from_secs(60));
         assert!(cache.is_empty());
-        cache.insert("key".to_string(), create_test_version_info());
+        cache.insert("key".to_string(), create_test_version_info()).await;
         assert!(!cache.is_empty());
     }
 
-    #[test]
-    fn test_read_cache_contains() {
-        let cache = MemoryCache::new();
-        let cache_ref: &dyn ReadCache = &cache;
+    #[tokio::test]
+    async fn test_read_cache_contains() {
+        async fn assert_contains_via_trait<C: ReadCache>(cache: &C, key: &str) -> bool {
+            cache.contains(key).await
+        }
 
-        assert!(!cache_ref.contains("key"));
-        cache.insert("key".to_string(), create_test_version_info());
-        assert!(cache_ref.contains("key"));
+        let cache = MemoryCache::new();
+        assert!(!assert_contains_via_trait(&cache, "key").await);
+
+        cache.insert("key".to_string(), create_test_version_info()).await;
+        assert!(assert_contains_via_trait(&cache, "key").await);
     }
 
-    #[test]
-    fn test_write_cache_remove() {
+    #[tokio::test]
+    async fn test_write_cache_remove() {
+        async fn insert_via_trait<C: WriteCache>(cache: &C, key: String, v: VersionInfo) {
+            cache.insert(key, v).await;
+        }
+        async fn remove_via_trait<C: WriteCache>(cache: &C, key: &str) {
+            cache.remove(key).await;
+        }
+
         let cache = MemoryCache::new();
-        let cache_ref: &dyn WriteCache = &cache;
+        insert_via_trait(&cache, "key".to_string(), create_test_version_info()).await;
+        assert!(cache.get("key").await.is_some());
 
-        cache_ref.insert("key".to_string(), create_test_version_info());
-        assert!(cache.get("key").is_some());
-
-        cache_ref.remove("key");
-        assert!(cache.get("key").is_none());
+        remove_via_trait(&cache, "key").await;
+        assert!(cache.get("key").await.is_none());
     }
 
-    #[test]
-    fn test_write_cache_clear() {
-        let cache = MemoryCache::new();
-        let cache_ref: &dyn WriteCache = &cache;
+    #[tokio::test]
+    async fn test_write_cache_clear() {
+        async fn clear_via_trait<C: WriteCache>(cache: &C) {
+            cache.clear().await;
+        }
 
-        cache_ref.insert("key1".to_string(), create_test_version_info());
-        cache_ref.insert("key2".to_string(), create_test_version_info());
+        let cache = MemoryCache::new();
+        cache.insert("key1".to_string(), create_test_version_info()).await;
+        cache.insert("key2".to_string(), create_test_version_info()).await;
         assert_eq!(cache.len(), 2);
 
-        cache_ref.clear();
+        clear_via_trait(&cache).await;
         assert!(cache.is_empty());
     }
 }

--- a/dependi-lsp/src/cache/mod.rs
+++ b/dependi-lsp/src/cache/mod.rs
@@ -292,14 +292,21 @@ impl HybridCache {
                     );
                 }
 
-                if let Some(ref sqlite) = sqlite
-                    && let Ok(rows) = sqlite.cleanup_expired().await
-                    && rows > 0
-                {
-                    tracing::info!(
-                        "Background cleanup: removed {} expired entries from SQLite cache",
-                        rows
-                    );
+                if let Some(ref sqlite) = sqlite {
+                    match sqlite.cleanup_expired().await {
+                        Ok(rows) if rows > 0 => {
+                            tracing::info!(
+                                "Background cleanup: removed {} expired entries from SQLite cache",
+                                rows
+                            );
+                        }
+                        Ok(_) => {}
+                        Err(err) => {
+                            tracing::error!(
+                                "Background cleanup: SQLite cleanup_expired failed: {err}"
+                            );
+                        }
+                    }
                 }
             }
         });

--- a/dependi-lsp/src/cache/mod.rs
+++ b/dependi-lsp/src/cache/mod.rs
@@ -29,15 +29,19 @@ pub use sqlite::SqliteCache;
 /// This trait defines the minimal interface for reading cached values.
 /// Implementations can provide additional write operations via the
 /// [`WriteCache`] trait.
+///
+/// Note: `async_fn_in_trait` is allowed because this trait is internal and
+/// already bounds `Send + Sync`. Pattern matches `crate::registries::Registry`.
+#[allow(async_fn_in_trait)]
 pub trait ReadCache: Send + Sync {
-    /// Get a value from the cache
+    /// Get a value from the cache.
     ///
     /// Returns `None` if the key doesn't exist or the entry is expired.
-    fn get(&self, key: &str) -> Option<VersionInfo>;
+    async fn get(&self, key: &str) -> Option<VersionInfo>;
 
-    /// Check if a key exists in the cache (without fetching the value)
-    fn contains(&self, key: &str) -> bool {
-        self.get(key).is_some()
+    /// Check if a key exists in the cache (without fetching the value).
+    async fn contains(&self, key: &str) -> bool {
+        self.get(key).await.is_some()
     }
 }
 
@@ -46,40 +50,41 @@ pub trait ReadCache: Send + Sync {
 /// This trait extends [`ReadCache`] with the ability to insert and update
 /// cache entries. Caches that support both read and write operations should
 /// implement this trait.
+#[allow(async_fn_in_trait)]
 pub trait WriteCache: ReadCache {
-    /// Insert a value into the cache
+    /// Insert a value into the cache.
     ///
     /// If a value with the same key already exists, it will be overwritten.
-    fn insert(&self, key: String, value: VersionInfo);
+    async fn insert(&self, key: String, value: VersionInfo);
 
-    /// Remove a value from the cache
-    fn remove(&self, key: &str);
+    /// Remove a value from the cache.
+    async fn remove(&self, key: &str);
 
-    /// Clear all entries from the cache
-    fn clear(&self);
+    /// Clear all entries from the cache.
+    async fn clear(&self);
 }
 
 impl<T: ReadCache> ReadCache for Arc<T> {
-    fn get(&self, key: &str) -> Option<VersionInfo> {
-        (**self).get(key)
+    async fn get(&self, key: &str) -> Option<VersionInfo> {
+        (**self).get(key).await
     }
 
-    fn contains(&self, key: &str) -> bool {
-        (**self).contains(key)
+    async fn contains(&self, key: &str) -> bool {
+        (**self).contains(key).await
     }
 }
 
 impl<T: WriteCache> WriteCache for Arc<T> {
-    fn insert(&self, key: String, value: VersionInfo) {
-        (**self).insert(key, value)
+    async fn insert(&self, key: String, value: VersionInfo) {
+        (**self).insert(key, value).await
     }
 
-    fn remove(&self, key: &str) {
-        (**self).remove(key)
+    async fn remove(&self, key: &str) {
+        (**self).remove(key).await
     }
 
-    fn clear(&self) {
-        (**self).clear()
+    async fn clear(&self) {
+        (**self).clear().await
     }
 }
 

--- a/dependi-lsp/src/cache/mod.rs
+++ b/dependi-lsp/src/cache/mod.rs
@@ -129,7 +129,7 @@ impl MemoryCache {
 }
 
 impl ReadCache for MemoryCache {
-    fn get(&self, key: &str) -> Option<VersionInfo> {
+    async fn get(&self, key: &str) -> Option<VersionInfo> {
         self.entries.get(key).and_then(|entry| {
             if entry.is_expired() {
                 None
@@ -141,7 +141,7 @@ impl ReadCache for MemoryCache {
 }
 
 impl WriteCache for MemoryCache {
-    fn insert(&self, key: String, value: VersionInfo) {
+    async fn insert(&self, key: String, value: VersionInfo) {
         self.entries.insert(
             key,
             CacheEntry {
@@ -152,11 +152,11 @@ impl WriteCache for MemoryCache {
         );
     }
 
-    fn remove(&self, key: &str) {
+    async fn remove(&self, key: &str) {
         self.entries.remove(key);
     }
 
-    fn clear(&self) {
+    async fn clear(&self) {
         self.entries.clear();
     }
 }

--- a/dependi-lsp/src/cache/sqlite.rs
+++ b/dependi-lsp/src/cache/sqlite.rs
@@ -96,10 +96,10 @@ impl SqliteCache {
         {
             let conn = cache.pool.get()?;
             let now = current_timestamp();
-            let _ = conn.execute(
+            conn.execute(
                 "DELETE FROM packages WHERE inserted_at + ttl_secs < ?",
                 [now],
-            );
+            )?;
         }
 
         let state = cache.pool_state();
@@ -649,8 +649,10 @@ mod tests {
             let cache = Arc::clone(&cache);
             let info = create_test_version_info();
             let fut = cache.insert("dropme".to_string(), info);
-            // Drop the future before awaiting. spawn_blocking task may still complete
-            // because the closure was already submitted.
+            // Drop the future without ever polling it. Because spawn_blocking is only
+            // called when the future is first polled, no blocking task is submitted in
+            // this scenario. This test verifies that a never-started insert leaves the
+            // cache in a clean state and that subsequent operations work normally.
             drop(fut);
         }
 

--- a/dependi-lsp/src/cache/sqlite.rs
+++ b/dependi-lsp/src/cache/sqlite.rs
@@ -91,7 +91,16 @@ impl SqliteCache {
         };
 
         cache.init_schema()?;
-        cache.cleanup_expired()?;
+        // cleanup_expired is async; perform the initial cleanup synchronously
+        // here since we are still in a sync constructor (no tokio executor yet).
+        {
+            let conn = cache.pool.get()?;
+            let now = current_timestamp();
+            let _ = conn.execute(
+                "DELETE FROM packages WHERE inserted_at + ttl_secs < ?",
+                [now],
+            );
+        }
 
         let state = cache.pool_state();
         tracing::debug!(
@@ -188,116 +197,164 @@ impl SqliteCache {
 }
 
 impl ReadCache for SqliteCache {
-    fn get(&self, key: &str) -> Option<VersionInfo> {
-        let conn = self.get_conn()?;
-        let now = current_timestamp();
-
-        let result: Result<(String, i64, i64), _> = conn.query_row(
-            "SELECT data, inserted_at, ttl_secs FROM packages WHERE key = ?",
-            [key],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        );
-
-        match result {
-            Ok((data, inserted_at, ttl_secs)) => {
-                if now > inserted_at + ttl_secs {
-                    let _ = conn.execute("DELETE FROM packages WHERE key = ?", [key]);
-                    None
-                } else {
-                    serde_json::from_str(&data).ok()
+    async fn get(&self, key: &str) -> Option<VersionInfo> {
+        let pool = Arc::clone(&self.pool);
+        let key = key.to_string();
+        // spawn_blocking offloads the blocking rusqlite work to the dedicated
+        // blocking thread pool, keeping the tokio event loop responsive.
+        // Note: spawn_blocking tasks are not cancelable; if the future is
+        // dropped, the closure still runs to completion. Acceptable here:
+        // DB ops are short and worst-case is a stale entry being deleted.
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get().ok()?;
+            let now = current_timestamp();
+            let result: Result<(String, i64, i64), _> = conn.query_row(
+                "SELECT data, inserted_at, ttl_secs FROM packages WHERE key = ?",
+                [key.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            );
+            match result {
+                Ok((data, inserted_at, ttl_secs)) => {
+                    if now > inserted_at + ttl_secs {
+                        let _ = conn.execute(
+                            "DELETE FROM packages WHERE key = ?",
+                            [key.as_str()],
+                        );
+                        None
+                    } else {
+                        serde_json::from_str(&data).ok()
+                    }
                 }
+                Err(_) => None,
             }
-            Err(_) => None,
-        }
+        })
+        .await
+        .ok()
+        .flatten()
     }
 }
 
 impl WriteCache for SqliteCache {
-    fn insert(&self, key: String, value: VersionInfo) {
-        let Some(conn) = self.get_conn() else {
-            return;
-        };
-        let now = current_timestamp();
-        let data = match serde_json::to_string(&value) {
-            Ok(d) => d,
-            Err(_) => return,
-        };
-
-        let _ = conn.execute(
-            "INSERT OR REPLACE INTO packages (key, data, inserted_at, ttl_secs) VALUES (?, ?, ?, ?)",
-            params![key, data, now, self.ttl_secs],
-        );
+    async fn insert(&self, key: String, value: VersionInfo) {
+        let pool = Arc::clone(&self.pool);
+        let ttl_secs = self.ttl_secs;
+        let _ = tokio::task::spawn_blocking(move || {
+            let Some(conn) = pool.get().ok() else {
+                return;
+            };
+            let now = current_timestamp();
+            let data = match serde_json::to_string(&value) {
+                Ok(d) => d,
+                Err(_) => return,
+            };
+            let _ = conn.execute(
+                "INSERT OR REPLACE INTO packages (key, data, inserted_at, ttl_secs) VALUES (?, ?, ?, ?)",
+                params![key, data, now, ttl_secs],
+            );
+        })
+        .await;
     }
 
-    fn remove(&self, key: &str) {
-        let Some(conn) = self.get_conn() else {
-            return;
-        };
-        let _ = conn.execute("DELETE FROM packages WHERE key = ?", [key]);
+    async fn remove(&self, key: &str) {
+        let pool = Arc::clone(&self.pool);
+        let key = key.to_string();
+        let _ = tokio::task::spawn_blocking(move || {
+            let Some(conn) = pool.get().ok() else {
+                return;
+            };
+            let _ = conn.execute("DELETE FROM packages WHERE key = ?", [key.as_str()]);
+        })
+        .await;
     }
 
-    fn clear(&self) {
-        let Some(conn) = self.get_conn() else {
-            return;
-        };
-        let _ = conn.execute("DELETE FROM packages", []);
+    async fn clear(&self) {
+        let pool = Arc::clone(&self.pool);
+        let _ = tokio::task::spawn_blocking(move || {
+            let Some(conn) = pool.get().ok() else {
+                return;
+            };
+            let _ = conn.execute("DELETE FROM packages", []);
+        })
+        .await;
     }
 }
 
 impl SqliteCache {
     /// Insert multiple values in a single transaction
     #[cfg(test)]
-    pub fn insert_batch(&self, entries: Vec<(String, VersionInfo)>) -> anyhow::Result<usize> {
+    pub async fn insert_batch(&self, entries: Vec<(String, VersionInfo)>) -> anyhow::Result<usize> {
         if entries.is_empty() {
             return Ok(0);
         }
 
-        let mut conn = self.pool.get()?;
-        let tx = conn.transaction()?;
-        let now = current_timestamp();
-        let mut count = 0;
+        let pool = Arc::clone(&self.pool);
+        let ttl_secs = self.ttl_secs;
+        tokio::task::spawn_blocking(move || -> anyhow::Result<usize> {
+            let mut conn = pool.get()?;
+            let tx = conn.transaction()?;
+            let now = current_timestamp();
+            let mut count = 0;
 
-        for (key, value) in entries {
-            let data = serde_json::to_string(&value)?;
-            tx.execute(
-                "INSERT OR REPLACE INTO packages (key, data, inserted_at, ttl_secs) VALUES (?, ?, ?, ?)",
-                params![key, data, now, self.ttl_secs],
-            )?;
-            count += 1;
-        }
+            for (key, value) in entries {
+                let data = serde_json::to_string(&value)?;
+                tx.execute(
+                    "INSERT OR REPLACE INTO packages (key, data, inserted_at, ttl_secs) VALUES (?, ?, ?, ?)",
+                    params![key, data, now, ttl_secs],
+                )?;
+                count += 1;
+            }
 
-        tx.commit()?;
-        Ok(count)
+            tx.commit()?;
+            Ok(count)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e}"))?
     }
 
     /// Remove a value from the cache, returning whether it existed
     #[cfg(test)]
-    pub fn remove_with_result(&self, key: &str) -> bool {
-        let Some(conn) = self.get_conn() else {
-            return false;
-        };
-        conn.execute("DELETE FROM packages WHERE key = ?", [key])
-            .map(|rows| rows > 0)
-            .unwrap_or(false)
+    pub async fn remove_with_result(&self, key: &str) -> bool {
+        let pool = Arc::clone(&self.pool);
+        let key = key.to_string();
+        tokio::task::spawn_blocking(move || -> bool {
+            let Some(conn) = pool.get().ok() else {
+                return false;
+            };
+            conn.execute("DELETE FROM packages WHERE key = ?", [key.as_str()])
+                .map(|rows| rows > 0)
+                .unwrap_or(false)
+        })
+        .await
+        .unwrap_or(false)
     }
 
     /// Clear all entries from the cache, returning the count
     #[cfg(test)]
-    pub fn clear_with_count(&self) -> anyhow::Result<usize> {
-        let conn = self.pool.get()?;
-        let rows = conn.execute("DELETE FROM packages", [])?;
-        Ok(rows)
+    pub async fn clear_with_count(&self) -> anyhow::Result<usize> {
+        let pool = Arc::clone(&self.pool);
+        tokio::task::spawn_blocking(move || -> anyhow::Result<usize> {
+            let conn = pool.get()?;
+            let rows = conn.execute("DELETE FROM packages", [])?;
+            Ok(rows)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e}"))?
     }
 
     /// Remove expired entries from the cache
-    pub fn cleanup_expired(&self) -> anyhow::Result<usize> {
-        let conn = self.pool.get()?;
-        let now = current_timestamp();
-        let rows = conn.execute(
-            "DELETE FROM packages WHERE inserted_at + ttl_secs < ?",
-            [now],
-        )?;
-        Ok(rows)
+    pub async fn cleanup_expired(&self) -> anyhow::Result<usize> {
+        let pool = Arc::clone(&self.pool);
+        tokio::task::spawn_blocking(move || -> anyhow::Result<usize> {
+            let conn = pool.get()?;
+            let now = current_timestamp();
+            let rows = conn.execute(
+                "DELETE FROM packages WHERE inserted_at + ttl_secs < ?",
+                [now],
+            )?;
+            Ok(rows)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e}"))?
     }
 
     /// Get pool statistics for monitoring

--- a/dependi-lsp/src/cache/sqlite.rs
+++ b/dependi-lsp/src/cache/sqlite.rs
@@ -97,8 +97,8 @@ impl SqliteCache {
             let conn = cache.pool.get()?;
             let now = current_timestamp();
             conn.execute(
-                "DELETE FROM packages WHERE inserted_at + ttl_secs < ?",
-                [now],
+                "DELETE FROM packages WHERE inserted_at + ttl_secs * ? < ?",
+                params![NANOS_PER_SEC, now],
             )?;
         }
 
@@ -210,7 +210,7 @@ impl ReadCache for SqliteCache {
             );
             match result {
                 Ok((data, inserted_at, ttl_secs)) => {
-                    if now > inserted_at + ttl_secs {
+                    if now > inserted_at + ttl_secs * NANOS_PER_SEC {
                         let _ = conn.execute("DELETE FROM packages WHERE key = ?", [key.as_str()]);
                         None
                     } else {
@@ -241,7 +241,7 @@ impl ReadCache for SqliteCache {
                 |row| Ok((row.get(0)?, row.get(1)?)),
             );
             match result {
-                Ok((inserted_at, ttl_secs)) => now <= inserted_at + ttl_secs,
+                Ok((inserted_at, ttl_secs)) => now <= inserted_at + ttl_secs * NANOS_PER_SEC,
                 Err(_) => false,
             }
         })
@@ -258,7 +258,9 @@ impl WriteCache for SqliteCache {
         // so concurrent inserts carry their actual submission time. The UPSERT
         // below only overwrites when the new timestamp is at least as recent as
         // the stored one, preventing late/older writes from clobbering newer
-        // values that completed first.
+        // values that completed first. `current_timestamp()` is nanosecond
+        // resolution, so same-instant ties between writes for the same key
+        // are extremely unlikely in practice.
         let now = current_timestamp();
         let _ = tokio::task::spawn_blocking(move || {
             let Some(conn) = pool.get().ok() else {
@@ -374,8 +376,8 @@ impl SqliteCache {
             let conn = pool.get()?;
             let now = current_timestamp();
             let rows = conn.execute(
-                "DELETE FROM packages WHERE inserted_at + ttl_secs < ?",
-                [now],
+                "DELETE FROM packages WHERE inserted_at + ttl_secs * ? < ?",
+                params![NANOS_PER_SEC, now],
             )?;
             Ok(rows)
         })
@@ -402,12 +404,23 @@ pub struct PoolState {
     pub idle_connections: u32,
 }
 
-/// Get current Unix timestamp
+/// Nanoseconds in one second — used to convert `ttl_secs` to the same unit as
+/// `inserted_at` when computing expiration in SQL queries.
+const NANOS_PER_SEC: i64 = 1_000_000_000;
+
+/// Current Unix time in nanoseconds.
+///
+/// Nanosecond resolution makes same-instant collisions on the `inserted_at`
+/// column effectively impossible in practice, which keeps the conditional
+/// UPSERT in `insert()` (`excluded.inserted_at >= packages.inserted_at`) from
+/// allowing a late-finishing older write to clobber a newer value that landed
+/// first. i64 nanoseconds since UNIX_EPOCH overflow at year 2262.
 fn current_timestamp() -> i64 {
-    SystemTime::now()
+    let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    nanos.min(i64::MAX as u128) as i64
 }
 
 #[cfg(test)]

--- a/dependi-lsp/src/cache/sqlite.rs
+++ b/dependi-lsp/src/cache/sqlite.rs
@@ -406,13 +406,13 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_insert_and_get() {
+    #[tokio::test]
+    async fn test_insert_and_get() {
         let cache = SqliteCache::in_memory().unwrap();
         let info = create_test_version_info();
 
-        cache.insert("test:package".to_string(), info.clone());
-        let retrieved = cache.get("test:package");
+        cache.insert("test:package".to_string(), info.clone()).await;
+        let retrieved = cache.get("test:package").await;
 
         assert!(retrieved.is_some());
         let retrieved = retrieved.unwrap();
@@ -420,15 +420,15 @@ mod tests {
         assert_eq!(retrieved.versions, info.versions);
     }
 
-    #[test]
-    fn test_get_nonexistent() {
+    #[tokio::test]
+    async fn test_get_nonexistent() {
         let cache = SqliteCache::in_memory().unwrap();
-        let retrieved = cache.get("nonexistent");
+        let retrieved = cache.get("nonexistent").await;
         assert!(retrieved.is_none());
     }
 
-    #[test]
-    fn test_overwrite() {
+    #[tokio::test]
+    async fn test_overwrite() {
         let cache = SqliteCache::in_memory().unwrap();
 
         let info1 = VersionInfo {
@@ -440,10 +440,10 @@ mod tests {
             ..create_test_version_info()
         };
 
-        cache.insert("test:package".to_string(), info1);
-        cache.insert("test:package".to_string(), info2);
+        cache.insert("test:package".to_string(), info1).await;
+        cache.insert("test:package".to_string(), info2).await;
 
-        let retrieved = cache.get("test:package").unwrap();
+        let retrieved = cache.get("test:package").await.unwrap();
         assert_eq!(retrieved.latest, Some("2.0.0".to_string()));
     }
 
@@ -454,41 +454,41 @@ mod tests {
         assert!(state.connections > 0);
     }
 
-    #[test]
-    fn test_remove() {
+    #[tokio::test]
+    async fn test_remove() {
         let cache = SqliteCache::in_memory().unwrap();
         let info = create_test_version_info();
 
-        cache.insert("test:package".to_string(), info);
-        assert!(cache.get("test:package").is_some());
+        cache.insert("test:package".to_string(), info).await;
+        assert!(cache.get("test:package").await.is_some());
 
-        let removed = cache.remove_with_result("test:package");
+        let removed = cache.remove_with_result("test:package").await;
         assert!(removed);
-        assert!(cache.get("test:package").is_none());
+        assert!(cache.get("test:package").await.is_none());
 
-        let removed_again = cache.remove_with_result("test:package");
+        let removed_again = cache.remove_with_result("test:package").await;
         assert!(!removed_again);
     }
 
-    #[test]
-    fn test_clear() {
+    #[tokio::test]
+    async fn test_clear() {
         let cache = SqliteCache::in_memory().unwrap();
         let info = create_test_version_info();
 
-        cache.insert("pkg1".to_string(), info.clone());
-        cache.insert("pkg2".to_string(), info.clone());
-        cache.insert("pkg3".to_string(), info);
+        cache.insert("pkg1".to_string(), info.clone()).await;
+        cache.insert("pkg2".to_string(), info.clone()).await;
+        cache.insert("pkg3".to_string(), info).await;
 
-        let cleared = cache.clear_with_count().unwrap();
+        let cleared = cache.clear_with_count().await.unwrap();
         assert_eq!(cleared, 3);
 
-        assert!(cache.get("pkg1").is_none());
-        assert!(cache.get("pkg2").is_none());
-        assert!(cache.get("pkg3").is_none());
+        assert!(cache.get("pkg1").await.is_none());
+        assert!(cache.get("pkg2").await.is_none());
+        assert!(cache.get("pkg3").await.is_none());
     }
 
-    #[test]
-    fn test_insert_batch() {
+    #[tokio::test]
+    async fn test_insert_batch() {
         let cache = SqliteCache::in_memory().unwrap();
 
         let entries: Vec<(String, VersionInfo)> = (0..10)
@@ -499,128 +499,20 @@ mod tests {
             })
             .collect();
 
-        let count = cache.insert_batch(entries).unwrap();
+        let count = cache.insert_batch(entries).await.unwrap();
         assert_eq!(count, 10);
 
         for i in 0..10 {
-            let retrieved = cache.get(&format!("pkg{i}")).unwrap();
+            let retrieved = cache.get(&format!("pkg{i}")).await.unwrap();
             assert_eq!(retrieved.latest, Some(format!("{i}.0.0")));
         }
     }
 
-    #[test]
-    fn test_insert_batch_empty() {
+    #[tokio::test]
+    async fn test_insert_batch_empty() {
         let cache = SqliteCache::in_memory().unwrap();
-        let count = cache.insert_batch(vec![]).unwrap();
+        let count = cache.insert_batch(vec![]).await.unwrap();
         assert_eq!(count, 0);
-    }
-
-    #[test]
-    fn test_concurrent_reads() {
-        use std::sync::Arc;
-        use std::thread;
-
-        let cache = Arc::new(SqliteCache::in_memory().unwrap());
-
-        for i in 0..20 {
-            let mut info = create_test_version_info();
-            info.latest = Some(format!("{i}.0.0"));
-            cache.insert(format!("pkg{i}"), info);
-        }
-
-        let handles: Vec<_> = (0..10)
-            .map(|thread_id| {
-                let cache = Arc::clone(&cache);
-                thread::spawn(move || {
-                    for i in 0..20 {
-                        let key = format!("pkg{i}");
-                        let result = cache.get(&key);
-                        assert!(result.is_some(), "Thread {thread_id} failed to read {key}");
-                    }
-                })
-            })
-            .collect();
-
-        for handle in handles {
-            handle.join().expect("Thread panicked");
-        }
-    }
-
-    #[test]
-    fn test_concurrent_writes() {
-        use std::sync::Arc;
-        use std::thread;
-
-        let cache = Arc::new(SqliteCache::in_memory().unwrap());
-
-        let handles: Vec<_> = (0..5)
-            .map(|thread_id| {
-                let cache = Arc::clone(&cache);
-                thread::spawn(move || {
-                    for i in 0..10 {
-                        let key = format!("thread{thread_id}:pkg{i}");
-                        let mut info = create_test_version_info();
-                        info.latest = Some(format!("{thread_id}.{i}.0"));
-                        cache.insert(key, info);
-                    }
-                })
-            })
-            .collect();
-
-        for handle in handles {
-            handle.join().expect("Thread panicked");
-        }
-
-        for thread_id in 0..5 {
-            for i in 0..10 {
-                let key = format!("thread{thread_id}:pkg{i}");
-                let result = cache.get(&key);
-                assert!(result.is_some(), "Missing key: {key}");
-            }
-        }
-    }
-
-    #[test]
-    fn test_concurrent_mixed_operations() {
-        use std::sync::Arc;
-        use std::thread;
-
-        let cache = Arc::new(SqliteCache::in_memory().unwrap());
-
-        for i in 0..50 {
-            let mut info = create_test_version_info();
-            info.latest = Some(format!("{i}.0.0"));
-            cache.insert(format!("pkg{i}"), info);
-        }
-
-        let handles: Vec<_> = (0..10)
-            .map(|thread_id| {
-                let cache = Arc::clone(&cache);
-                thread::spawn(move || {
-                    for i in 0..50 {
-                        match thread_id % 3 {
-                            0 => {
-                                let _ = cache.get(&format!("pkg{i}"));
-                            }
-                            1 => {
-                                let mut info = create_test_version_info();
-                                info.latest = Some(format!("updated-{thread_id}-{i}"));
-                                cache.insert(format!("pkg{i}"), info);
-                            }
-                            _ => {
-                                let mut info = create_test_version_info();
-                                info.latest = Some(format!("new-{thread_id}-{i}"));
-                                cache.insert(format!("new-pkg-{thread_id}-{i}"), info);
-                            }
-                        }
-                    }
-                })
-            })
-            .collect();
-
-        for handle in handles {
-            handle.join().expect("Thread panicked");
-        }
     }
 
     #[test]

--- a/dependi-lsp/src/cache/sqlite.rs
+++ b/dependi-lsp/src/cache/sqlite.rs
@@ -578,9 +578,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_get_does_not_block_runtime() {
-        use std::sync::Arc;
-        use std::time::Duration;
-
         let cache = Arc::new(SqliteCache::in_memory().unwrap());
         cache.insert("k".to_string(), create_test_version_info()).await;
 

--- a/dependi-lsp/src/cache/sqlite.rs
+++ b/dependi-lsp/src/cache/sqlite.rs
@@ -575,4 +575,25 @@ mod tests {
         assert_eq!(config.cache_size_kb, 64000);
         assert_eq!(config.ttl_secs, DEFAULT_TTL_SECS);
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_get_does_not_block_runtime() {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        let cache = Arc::new(SqliteCache::in_memory().unwrap());
+        cache.insert("k".to_string(), create_test_version_info()).await;
+
+        let cache_clone = Arc::clone(&cache);
+        let read_task = tokio::spawn(async move { cache_clone.get("k").await });
+
+        let timer_ok = tokio::time::timeout(
+            Duration::from_millis(500),
+            tokio::time::sleep(Duration::from_millis(20)),
+        )
+        .await;
+
+        assert!(timer_ok.is_ok(), "tokio runtime appears blocked while SQLite read in flight");
+        assert!(read_task.await.unwrap().is_some(), "expected cache hit on key 'k'");
+    }
 }

--- a/dependi-lsp/src/cache/sqlite.rs
+++ b/dependi-lsp/src/cache/sqlite.rs
@@ -224,23 +224,57 @@ impl ReadCache for SqliteCache {
         .ok()
         .flatten()
     }
+
+    async fn contains(&self, key: &str) -> bool {
+        // Cheap existence check: avoid loading and deserializing the payload.
+        // Mirrors `get`'s expiration policy but only reads `inserted_at`/`ttl_secs`.
+        let pool = Arc::clone(&self.pool);
+        let key = key.to_string();
+        tokio::task::spawn_blocking(move || {
+            let Ok(conn) = pool.get() else {
+                return false;
+            };
+            let now = current_timestamp();
+            let result: Result<(i64, i64), _> = conn.query_row(
+                "SELECT inserted_at, ttl_secs FROM packages WHERE key = ? LIMIT 1",
+                [key.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            );
+            match result {
+                Ok((inserted_at, ttl_secs)) => now <= inserted_at + ttl_secs,
+                Err(_) => false,
+            }
+        })
+        .await
+        .unwrap_or(false)
+    }
 }
 
 impl WriteCache for SqliteCache {
     async fn insert(&self, key: String, value: VersionInfo) {
         let pool = Arc::clone(&self.pool);
         let ttl_secs = self.ttl_secs;
+        // Compute the submission timestamp BEFORE handing off to spawn_blocking
+        // so concurrent inserts carry their actual submission time. The UPSERT
+        // below only overwrites when the new timestamp is at least as recent as
+        // the stored one, preventing late/older writes from clobbering newer
+        // values that completed first.
+        let now = current_timestamp();
         let _ = tokio::task::spawn_blocking(move || {
             let Some(conn) = pool.get().ok() else {
                 return;
             };
-            let now = current_timestamp();
             let data = match serde_json::to_string(&value) {
                 Ok(d) => d,
                 Err(_) => return,
             };
             let _ = conn.execute(
-                "INSERT OR REPLACE INTO packages (key, data, inserted_at, ttl_secs) VALUES (?, ?, ?, ?)",
+                "INSERT INTO packages (key, data, inserted_at, ttl_secs) VALUES (?, ?, ?, ?) \
+                 ON CONFLICT(key) DO UPDATE SET \
+                   data = excluded.data, \
+                   inserted_at = excluded.inserted_at, \
+                   ttl_secs = excluded.ttl_secs \
+                 WHERE excluded.inserted_at >= packages.inserted_at",
                 params![key, data, now, ttl_secs],
             );
         })

--- a/dependi-lsp/src/cache/sqlite.rs
+++ b/dependi-lsp/src/cache/sqlite.rs
@@ -537,4 +537,140 @@ mod tests {
         assert!(timer_ok.is_ok(), "tokio runtime appears blocked while SQLite read in flight");
         assert!(read_task.await.unwrap().is_some(), "expected cache hit on key 'k'");
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_reads_async() {
+        let cache = Arc::new(SqliteCache::in_memory().unwrap());
+
+        for i in 0..20 {
+            let mut info = create_test_version_info();
+            info.latest = Some(format!("{i}.0.0"));
+            cache.insert(format!("pkg{i}"), info).await;
+        }
+
+        let mut handles = Vec::new();
+        for thread_id in 0..10 {
+            let cache = Arc::clone(&cache);
+            handles.push(tokio::spawn(async move {
+                for i in 0..20 {
+                    let key = format!("pkg{i}");
+                    let result = cache.get(&key).await;
+                    assert!(result.is_some(), "Task {thread_id} failed to read {key}");
+                }
+            }));
+        }
+
+        for h in handles {
+            h.await.expect("task panicked");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_writes_async() {
+        let cache = Arc::new(SqliteCache::in_memory().unwrap());
+
+        let mut handles = Vec::new();
+        for thread_id in 0..5 {
+            let cache = Arc::clone(&cache);
+            handles.push(tokio::spawn(async move {
+                for i in 0..10 {
+                    let key = format!("thread{thread_id}:pkg{i}");
+                    let mut info = create_test_version_info();
+                    info.latest = Some(format!("{thread_id}.{i}.0"));
+                    cache.insert(key, info).await;
+                }
+            }));
+        }
+
+        for h in handles {
+            h.await.expect("task panicked");
+        }
+
+        for thread_id in 0..5 {
+            for i in 0..10 {
+                let key = format!("thread{thread_id}:pkg{i}");
+                let result = cache.get(&key).await;
+                assert!(result.is_some(), "Missing key: {key}");
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_mixed_async() {
+        let cache = Arc::new(SqliteCache::in_memory().unwrap());
+
+        for i in 0..50 {
+            let mut info = create_test_version_info();
+            info.latest = Some(format!("{i}.0.0"));
+            cache.insert(format!("pkg{i}"), info).await;
+        }
+
+        let mut handles = Vec::new();
+        for thread_id in 0..10 {
+            let cache = Arc::clone(&cache);
+            handles.push(tokio::spawn(async move {
+                for i in 0..50 {
+                    match thread_id % 3 {
+                        0 => {
+                            let _ = cache.get(&format!("pkg{i}")).await;
+                        }
+                        1 => {
+                            let mut info = create_test_version_info();
+                            info.latest = Some(format!("updated-{thread_id}-{i}"));
+                            cache.insert(format!("pkg{i}"), info).await;
+                        }
+                        _ => {
+                            let mut info = create_test_version_info();
+                            info.latest = Some(format!("new-{thread_id}-{i}"));
+                            cache.insert(format!("new-pkg-{thread_id}-{i}"), info).await;
+                        }
+                    }
+                }
+            }));
+        }
+
+        for h in handles {
+            h.await.expect("task panicked");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dropped_future_does_not_corrupt_cache() {
+        use std::time::Duration;
+
+        let cache = Arc::new(SqliteCache::in_memory().unwrap());
+
+        {
+            let cache = Arc::clone(&cache);
+            let info = create_test_version_info();
+            let fut = cache.insert("dropme".to_string(), info);
+            // Drop the future before awaiting. spawn_blocking task may still complete
+            // because the closure was already submitted.
+            drop(fut);
+        }
+
+        // Allow any in-flight blocking task to settle.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Cache must remain consistent (key may or may not be present, but no panic).
+        let _ = cache.get("dropme").await;
+
+        // A subsequent insert + get must work normally.
+        cache.insert("k".to_string(), create_test_version_info()).await;
+        assert!(cache.get("k").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_blocking_panic_yields_join_error() {
+        // Documents the pattern used by SqliteCache: a panic inside the closure
+        // surfaces as JoinError, which is downgraded to None via .ok().flatten().
+        let result: Option<i32> = tokio::task::spawn_blocking(|| -> Option<i32> {
+            panic!("simulated rusqlite failure");
+        })
+        .await
+        .ok()
+        .flatten();
+
+        assert!(result.is_none(), "panic must downgrade to None via fail-soft pattern");
+    }
 }

--- a/dependi-lsp/src/cache/sqlite.rs
+++ b/dependi-lsp/src/cache/sqlite.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use super::sqlite_manager::SqliteConnectionManager;
-use r2d2::{Pool, PooledConnection};
+use r2d2::Pool;
 use rusqlite::params;
 
 use crate::cache::{ReadCache, WriteCache};
@@ -162,11 +162,6 @@ impl SqliteCache {
         let cache_dir = dirs::cache_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not determine cache directory"))?;
         Ok(cache_dir.join("dependi"))
-    }
-
-    /// Get a connection from the pool, returning None if unavailable
-    fn get_conn(&self) -> Option<PooledConnection<SqliteConnectionManager>> {
-        self.pool.get().ok()
     }
 
     /// Initialize the database schema with WAL mode

--- a/dependi-lsp/src/cache/sqlite.rs
+++ b/dependi-lsp/src/cache/sqlite.rs
@@ -211,10 +211,7 @@ impl ReadCache for SqliteCache {
             match result {
                 Ok((data, inserted_at, ttl_secs)) => {
                     if now > inserted_at + ttl_secs {
-                        let _ = conn.execute(
-                            "DELETE FROM packages WHERE key = ?",
-                            [key.as_str()],
-                        );
+                        let _ = conn.execute("DELETE FROM packages WHERE key = ?", [key.as_str()]);
                         None
                     } else {
                         serde_json::from_str(&data).ok()
@@ -523,7 +520,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_get_does_not_block_runtime() {
         let cache = Arc::new(SqliteCache::in_memory().unwrap());
-        cache.insert("k".to_string(), create_test_version_info()).await;
+        cache
+            .insert("k".to_string(), create_test_version_info())
+            .await;
 
         let cache_clone = Arc::clone(&cache);
         let read_task = tokio::spawn(async move { cache_clone.get("k").await });
@@ -534,8 +533,14 @@ mod tests {
         )
         .await;
 
-        assert!(timer_ok.is_ok(), "tokio runtime appears blocked while SQLite read in flight");
-        assert!(read_task.await.unwrap().is_some(), "expected cache hit on key 'k'");
+        assert!(
+            timer_ok.is_ok(),
+            "tokio runtime appears blocked while SQLite read in flight"
+        );
+        assert!(
+            read_task.await.unwrap().is_some(),
+            "expected cache hit on key 'k'"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -656,7 +661,9 @@ mod tests {
         let _ = cache.get("dropme").await;
 
         // A subsequent insert + get must work normally.
-        cache.insert("k".to_string(), create_test_version_info()).await;
+        cache
+            .insert("k".to_string(), create_test_version_info())
+            .await;
         assert!(cache.get("k").await.is_some());
     }
 
@@ -671,6 +678,9 @@ mod tests {
         .ok()
         .flatten();
 
-        assert!(result.is_none(), "panic must downgrade to None via fail-soft pattern");
+        assert!(
+            result.is_none(),
+            "panic must downgrade to None via fail-soft pattern"
+        );
     }
 }

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -272,12 +272,11 @@ async fn create_update_all_action(
     let mut outdated_deps: Vec<(&Dependency, String)> = Vec::new();
     for dep in dependencies.iter().copied().filter(|dep| !is_property_reference(dep)) {
         let cache_key = cache_key_fn(&dep.name);
-        if let Some(version_info) = cache.get(&cache_key).await {
-            if let VersionStatus::UpdateAvailable(new_version) =
+        if let Some(version_info) = cache.get(&cache_key).await
+            && let VersionStatus::UpdateAvailable(new_version) =
                 compare_versions(dep.effective_version(), &version_info)
-            {
-                outdated_deps.push((dep, new_version));
-            }
+        {
+            outdated_deps.push((dep, new_version));
         }
     }
 

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -92,7 +92,7 @@ fn normalize_version(version: &str) -> String {
     clippy::too_many_arguments,
     reason = "LSP context requires passing doc state, cache, range, ignore list, and workspace metadata together; refactoring into a struct is tracked for a follow-up."
 )]
-pub fn create_code_actions(
+pub async fn create_code_actions(
     dependencies: &[Dependency],
     cache: &impl ReadCache,
     uri: &Url,
@@ -130,7 +130,8 @@ pub fn create_code_actions(
     let mut actions: Vec<CodeActionOrCommand> = Vec::new();
 
     for dep in &update_candidates {
-        if let Some(update) = create_update_action(dep, cache, uri, file_type, &cache_key_fn) {
+        if let Some(update) = create_update_action(dep, cache, uri, file_type, &cache_key_fn).await
+        {
             actions.push(update);
         }
     }
@@ -144,7 +145,7 @@ pub fn create_code_actions(
     }
 
     if let Some(update_all) =
-        create_update_all_action(&non_ignored, cache, uri, file_type, &cache_key_fn)
+        create_update_all_action(&non_ignored, cache, uri, file_type, &cache_key_fn).await
     {
         actions.insert(0, update_all);
     }
@@ -170,7 +171,7 @@ fn extract_python_operator(version: &str) -> Option<&str> {
 }
 
 /// Create an "Update to X.Y.Z" code action for a dependency
-fn create_update_action(
+async fn create_update_action(
     dep: &Dependency,
     cache: &impl ReadCache,
     uri: &Url,
@@ -179,7 +180,7 @@ fn create_update_action(
 ) -> Option<CodeActionOrCommand> {
     let dep_name = &*dep.name;
     let cache_key = cache_key_fn(dep_name);
-    let version_info = cache.get(&cache_key)?;
+    let version_info = cache.get(&cache_key).await?;
 
     match compare_versions(dep.effective_version(), &version_info) {
         VersionStatus::UpdateAvailable(new_version) => {
@@ -261,27 +262,24 @@ fn create_ignore_action(
 }
 
 /// Create an "Update All Dependencies" code action when 2+ updates are available
-fn create_update_all_action(
+async fn create_update_all_action(
     dependencies: &[&Dependency],
     cache: &impl ReadCache,
     uri: &Url,
     file_type: FileType,
     cache_key_fn: impl Fn(&str) -> String,
 ) -> Option<CodeActionOrCommand> {
-    let outdated_deps: Vec<(&Dependency, String)> = dependencies
-        .iter()
-        .copied()
-        .filter(|dep| !is_property_reference(dep))
-        .filter_map(|dep| {
-            let cache_key = cache_key_fn(&dep.name);
-            let version_info = cache.get(&cache_key)?;
-
-            match compare_versions(dep.effective_version(), &version_info) {
-                VersionStatus::UpdateAvailable(new_version) => Some((dep, new_version)),
-                _ => None,
+    let mut outdated_deps: Vec<(&Dependency, String)> = Vec::new();
+    for dep in dependencies.iter().copied().filter(|dep| !is_property_reference(dep)) {
+        let cache_key = cache_key_fn(&dep.name);
+        if let Some(version_info) = cache.get(&cache_key).await {
+            if let VersionStatus::UpdateAvailable(new_version) =
+                compare_versions(dep.effective_version(), &version_info)
+            {
+                outdated_deps.push((dep, new_version));
             }
-        })
-        .collect();
+        }
+    }
 
     if outdated_deps.len() < 2 {
         return None;
@@ -414,8 +412,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_create_update_action() {
+    #[tokio::test]
+    async fn test_create_update_action() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:serde".to_string(),
@@ -423,7 +421,7 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
@@ -448,7 +446,7 @@ mod tests {
             &[],
             None,
             None,
-        );
+        ).await;
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -460,8 +458,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_no_action_when_up_to_date() {
+    #[tokio::test]
+    async fn test_no_action_when_up_to_date() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:serde".to_string(),
@@ -469,7 +467,7 @@ mod tests {
                 latest: Some("1.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
@@ -494,7 +492,7 @@ mod tests {
             &[],
             None,
             None,
-        );
+        ).await;
 
         assert_eq!(actions.len(), 0);
     }
@@ -508,8 +506,8 @@ mod tests {
         assert_eq!(format_version("v1.0.0", FileType::Go), "v1.0.0");
     }
 
-    #[test]
-    fn test_update_all_action_with_multiple_outdated() {
+    #[tokio::test]
+    async fn test_update_all_action_with_multiple_outdated() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:serde".to_string(),
@@ -517,21 +515,21 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
         cache.insert(
             "test:tokio".to_string(),
             VersionInfo {
                 latest: Some("1.36.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
         cache.insert(
             "test:reqwest".to_string(),
             VersionInfo {
                 latest: Some("0.12.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![
             create_test_dependency("serde", "1.0.0", 5),
@@ -560,7 +558,7 @@ mod tests {
             &[],
             None,
             None,
-        );
+        ).await;
 
         assert_eq!(actions.len(), 4);
         match &actions[0] {
@@ -584,8 +582,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_update_all_action_not_shown_for_single_outdated() {
+    #[tokio::test]
+    async fn test_update_all_action_not_shown_for_single_outdated() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:serde".to_string(),
@@ -593,14 +591,14 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
         cache.insert(
             "test:tokio".to_string(),
             VersionInfo {
                 latest: Some("1.35.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![
             create_test_dependency("serde", "1.0.0", 5),
@@ -628,7 +626,7 @@ mod tests {
             &[],
             None,
             None,
-        );
+        ).await;
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -640,8 +638,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_update_all_action_not_shown_when_all_up_to_date() {
+    #[tokio::test]
+    async fn test_update_all_action_not_shown_when_all_up_to_date() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:serde".to_string(),
@@ -649,14 +647,14 @@ mod tests {
                 latest: Some("1.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
         cache.insert(
             "test:tokio".to_string(),
             VersionInfo {
                 latest: Some("1.35.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![
             create_test_dependency("serde", "1.0.0", 5),
@@ -684,7 +682,7 @@ mod tests {
             &[],
             None,
             None,
-        );
+        ).await;
 
         assert_eq!(actions.len(), 0);
     }
@@ -752,8 +750,8 @@ mod tests {
         assert_eq!(update_type, VersionUpdateType::Patch);
     }
 
-    #[test]
-    fn test_code_action_title_with_major_update() {
+    #[tokio::test]
+    async fn test_code_action_title_with_major_update() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:serde".to_string(),
@@ -761,7 +759,7 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
@@ -786,7 +784,7 @@ mod tests {
             &[],
             None,
             None,
-        );
+        ).await;
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -799,8 +797,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_code_action_title_with_minor_update() {
+    #[tokio::test]
+    async fn test_code_action_title_with_minor_update() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:tokio".to_string(),
@@ -808,7 +806,7 @@ mod tests {
                 latest: Some("1.36.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![create_test_dependency("tokio", "1.35.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
@@ -833,7 +831,7 @@ mod tests {
             &[],
             None,
             None,
-        );
+        ).await;
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -846,8 +844,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_code_action_title_with_patch_update() {
+    #[tokio::test]
+    async fn test_code_action_title_with_patch_update() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:reqwest".to_string(),
@@ -855,7 +853,7 @@ mod tests {
                 latest: Some("0.12.1".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![create_test_dependency("reqwest", "0.12.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
@@ -880,7 +878,7 @@ mod tests {
             &[],
             None,
             None,
-        );
+        ).await;
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -971,8 +969,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_python_compatible_release_code_action() {
+    #[tokio::test]
+    async fn test_python_compatible_release_code_action() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:rich".to_string(),
@@ -980,7 +978,7 @@ mod tests {
                 latest: Some("14.3.3".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         // ~=14.2 with latest 14.3.3: compare_versions returns UpdateAvailable("14.3")
         let deps = vec![create_test_dependency("rich", "~=14.2", 5)];
@@ -1006,7 +1004,7 @@ mod tests {
             &[],
             None,
             None,
-        );
+        ).await;
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -1024,8 +1022,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_python_compatible_release_up_to_date_no_action() {
+    #[tokio::test]
+    async fn test_python_compatible_release_up_to_date_no_action() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:rich".to_string(),
@@ -1033,7 +1031,7 @@ mod tests {
                 latest: Some("14.3.3".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         // ~=14.3 with latest 14.3.3: should be UpToDate, no code action
         let deps = vec![create_test_dependency("rich", "~=14.3", 5)];
@@ -1059,13 +1057,13 @@ mod tests {
             &[],
             None,
             None,
-        );
+        ).await;
 
         assert_eq!(actions.len(), 0);
     }
 
-    #[test]
-    fn test_filter_deps_outside_range() {
+    #[tokio::test]
+    async fn test_filter_deps_outside_range() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:serde".to_string(),
@@ -1073,7 +1071,7 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 50)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
@@ -1098,13 +1096,13 @@ mod tests {
             &[],
             None,
             None,
-        );
+        ).await;
 
         assert_eq!(actions.len(), 0);
     }
 
-    #[test]
-    fn test_no_action_when_cache_empty() {
+    #[tokio::test]
+    async fn test_no_action_when_cache_empty() {
         let cache = MemoryCache::new();
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
@@ -1130,13 +1128,13 @@ mod tests {
             &[],
             None,
             None,
-        );
+        ).await;
 
         assert_eq!(actions.len(), 0);
     }
 
-    #[test]
-    fn test_update_action_skipped_for_ignored_package() {
+    #[tokio::test]
+    async fn test_update_action_skipped_for_ignored_package() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:lodash".to_string(),
@@ -1144,7 +1142,7 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
         let range = Range {
@@ -1169,7 +1167,7 @@ mod tests {
             &ignored,
             None,
             None,
-        );
+        ).await;
 
         assert!(
             actions.is_empty(),
@@ -1177,8 +1175,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_update_action_emitted_when_not_ignored() {
+    #[tokio::test]
+    async fn test_update_action_emitted_when_not_ignored() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:react".to_string(),
@@ -1186,7 +1184,7 @@ mod tests {
                 latest: Some("18.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
         let deps = vec![create_test_dependency("react", "17.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
         let range = Range {
@@ -1211,7 +1209,7 @@ mod tests {
             &ignored,
             None,
             None,
-        );
+        ).await;
 
         assert!(
             !actions.is_empty(),
@@ -1219,8 +1217,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_ignore_action_emitted_when_workspace_root_provided() {
+    #[tokio::test]
+    async fn test_ignore_action_emitted_when_workspace_root_provided() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:lodash".to_string(),
@@ -1228,7 +1226,7 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
         let range = Range {
@@ -1253,7 +1251,7 @@ mod tests {
             &[],
             Some(&workspace),
             None,
-        );
+        ).await;
 
         // Expect at least 2 actions: Update + Ignore
         assert!(
@@ -1273,8 +1271,8 @@ mod tests {
         assert!(titles.iter().any(|t| t.contains("\"lodash\"")));
     }
 
-    #[test]
-    fn test_ignore_action_skipped_when_no_workspace_root() {
+    #[tokio::test]
+    async fn test_ignore_action_skipped_when_no_workspace_root() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:lodash".to_string(),
@@ -1282,7 +1280,7 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
         let range = Range {
@@ -1306,7 +1304,7 @@ mod tests {
             &[],
             None,
             None,
-        );
+        ).await;
 
         let titles: Vec<String> = actions
             .iter()
@@ -1321,8 +1319,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_ignore_action_emitted_even_when_up_to_date() {
+    #[tokio::test]
+    async fn test_ignore_action_emitted_even_when_up_to_date() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:lodash".to_string(),
@@ -1330,7 +1328,7 @@ mod tests {
                 latest: Some("1.0.0".to_string()), // up-to-date
                 ..Default::default()
             },
-        );
+        ).await;
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
         let range = Range {
@@ -1355,7 +1353,7 @@ mod tests {
             &[],
             Some(&workspace),
             None,
-        );
+        ).await;
 
         let titles: Vec<String> = actions
             .iter()
@@ -1370,8 +1368,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_property_reference_gets_ignore_action_but_not_update() {
+    #[tokio::test]
+    async fn test_property_reference_gets_ignore_action_but_not_update() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:my-pkg".to_string(),
@@ -1379,7 +1377,7 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
         // Create a dep whose version is a Maven-style property reference.
         let dep = create_test_dependency("my-pkg", "${my.version}", 5);
         let deps = vec![dep];
@@ -1406,7 +1404,7 @@ mod tests {
             &[],
             Some(&workspace),
             None,
-        );
+        ).await;
 
         let titles: Vec<String> = actions
             .iter()
@@ -1427,8 +1425,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_ignore_action_kind_and_preference() {
+    #[tokio::test]
+    async fn test_ignore_action_kind_and_preference() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:lodash".to_string(),
@@ -1436,7 +1434,7 @@ mod tests {
                 latest: Some("1.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
         let range = Range {
@@ -1461,7 +1459,7 @@ mod tests {
             &[],
             Some(&workspace),
             None,
-        );
+        ).await;
 
         let ignore = actions
             .iter()

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -270,7 +270,11 @@ async fn create_update_all_action(
     cache_key_fn: impl Fn(&str) -> String,
 ) -> Option<CodeActionOrCommand> {
     let mut outdated_deps: Vec<(&Dependency, String)> = Vec::new();
-    for dep in dependencies.iter().copied().filter(|dep| !is_property_reference(dep)) {
+    for dep in dependencies
+        .iter()
+        .copied()
+        .filter(|dep| !is_property_reference(dep))
+    {
         let cache_key = cache_key_fn(&dep.name);
         if let Some(version_info) = cache.get(&cache_key).await
             && let VersionStatus::UpdateAvailable(new_version) =
@@ -414,13 +418,15 @@ mod tests {
     #[tokio::test]
     async fn test_create_update_action() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
@@ -445,7 +451,8 @@ mod tests {
             &[],
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -460,13 +467,15 @@ mod tests {
     #[tokio::test]
     async fn test_no_action_when_up_to_date() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("1.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
@@ -491,7 +500,8 @@ mod tests {
             &[],
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert_eq!(actions.len(), 0);
     }
@@ -508,27 +518,33 @@ mod tests {
     #[tokio::test]
     async fn test_update_all_action_with_multiple_outdated() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
-        cache.insert(
-            "test:tokio".to_string(),
-            VersionInfo {
-                latest: Some("1.36.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
-        cache.insert(
-            "test:reqwest".to_string(),
-            VersionInfo {
-                latest: Some("0.12.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
+        cache
+            .insert(
+                "test:tokio".to_string(),
+                VersionInfo {
+                    latest: Some("1.36.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
+        cache
+            .insert(
+                "test:reqwest".to_string(),
+                VersionInfo {
+                    latest: Some("0.12.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![
             create_test_dependency("serde", "1.0.0", 5),
@@ -557,7 +573,8 @@ mod tests {
             &[],
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert_eq!(actions.len(), 4);
         match &actions[0] {
@@ -584,20 +601,24 @@ mod tests {
     #[tokio::test]
     async fn test_update_all_action_not_shown_for_single_outdated() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
-        cache.insert(
-            "test:tokio".to_string(),
-            VersionInfo {
-                latest: Some("1.35.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
+        cache
+            .insert(
+                "test:tokio".to_string(),
+                VersionInfo {
+                    latest: Some("1.35.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![
             create_test_dependency("serde", "1.0.0", 5),
@@ -625,7 +646,8 @@ mod tests {
             &[],
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -640,20 +662,24 @@ mod tests {
     #[tokio::test]
     async fn test_update_all_action_not_shown_when_all_up_to_date() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("1.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
-        cache.insert(
-            "test:tokio".to_string(),
-            VersionInfo {
-                latest: Some("1.35.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
+        cache
+            .insert(
+                "test:tokio".to_string(),
+                VersionInfo {
+                    latest: Some("1.35.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![
             create_test_dependency("serde", "1.0.0", 5),
@@ -681,7 +707,8 @@ mod tests {
             &[],
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert_eq!(actions.len(), 0);
     }
@@ -752,13 +779,15 @@ mod tests {
     #[tokio::test]
     async fn test_code_action_title_with_major_update() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
@@ -783,7 +812,8 @@ mod tests {
             &[],
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -799,13 +829,15 @@ mod tests {
     #[tokio::test]
     async fn test_code_action_title_with_minor_update() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:tokio".to_string(),
-            VersionInfo {
-                latest: Some("1.36.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:tokio".to_string(),
+                VersionInfo {
+                    latest: Some("1.36.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![create_test_dependency("tokio", "1.35.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
@@ -830,7 +862,8 @@ mod tests {
             &[],
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -846,13 +879,15 @@ mod tests {
     #[tokio::test]
     async fn test_code_action_title_with_patch_update() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:reqwest".to_string(),
-            VersionInfo {
-                latest: Some("0.12.1".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:reqwest".to_string(),
+                VersionInfo {
+                    latest: Some("0.12.1".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![create_test_dependency("reqwest", "0.12.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
@@ -877,7 +912,8 @@ mod tests {
             &[],
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -971,13 +1007,15 @@ mod tests {
     #[tokio::test]
     async fn test_python_compatible_release_code_action() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:rich".to_string(),
-            VersionInfo {
-                latest: Some("14.3.3".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:rich".to_string(),
+                VersionInfo {
+                    latest: Some("14.3.3".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         // ~=14.2 with latest 14.3.3: compare_versions returns UpdateAvailable("14.3")
         let deps = vec![create_test_dependency("rich", "~=14.2", 5)];
@@ -1003,7 +1041,8 @@ mod tests {
             &[],
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
@@ -1024,13 +1063,15 @@ mod tests {
     #[tokio::test]
     async fn test_python_compatible_release_up_to_date_no_action() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:rich".to_string(),
-            VersionInfo {
-                latest: Some("14.3.3".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:rich".to_string(),
+                VersionInfo {
+                    latest: Some("14.3.3".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         // ~=14.3 with latest 14.3.3: should be UpToDate, no code action
         let deps = vec![create_test_dependency("rich", "~=14.3", 5)];
@@ -1056,7 +1097,8 @@ mod tests {
             &[],
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert_eq!(actions.len(), 0);
     }
@@ -1064,13 +1106,15 @@ mod tests {
     #[tokio::test]
     async fn test_filter_deps_outside_range() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 50)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
@@ -1095,7 +1139,8 @@ mod tests {
             &[],
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert_eq!(actions.len(), 0);
     }
@@ -1127,7 +1172,8 @@ mod tests {
             &[],
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert_eq!(actions.len(), 0);
     }
@@ -1135,13 +1181,15 @@ mod tests {
     #[tokio::test]
     async fn test_update_action_skipped_for_ignored_package() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:lodash".to_string(),
-            VersionInfo {
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:lodash".to_string(),
+                VersionInfo {
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
         let range = Range {
@@ -1166,7 +1214,8 @@ mod tests {
             &ignored,
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert!(
             actions.is_empty(),
@@ -1177,13 +1226,15 @@ mod tests {
     #[tokio::test]
     async fn test_update_action_emitted_when_not_ignored() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:react".to_string(),
-            VersionInfo {
-                latest: Some("18.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:react".to_string(),
+                VersionInfo {
+                    latest: Some("18.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
         let deps = vec![create_test_dependency("react", "17.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
         let range = Range {
@@ -1208,7 +1259,8 @@ mod tests {
             &ignored,
             None,
             None,
-        ).await;
+        )
+        .await;
 
         assert!(
             !actions.is_empty(),
@@ -1219,13 +1271,15 @@ mod tests {
     #[tokio::test]
     async fn test_ignore_action_emitted_when_workspace_root_provided() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:lodash".to_string(),
-            VersionInfo {
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:lodash".to_string(),
+                VersionInfo {
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
         let range = Range {
@@ -1250,7 +1304,8 @@ mod tests {
             &[],
             Some(&workspace),
             None,
-        ).await;
+        )
+        .await;
 
         // Expect at least 2 actions: Update + Ignore
         assert!(
@@ -1273,13 +1328,15 @@ mod tests {
     #[tokio::test]
     async fn test_ignore_action_skipped_when_no_workspace_root() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:lodash".to_string(),
-            VersionInfo {
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:lodash".to_string(),
+                VersionInfo {
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
         let range = Range {
@@ -1303,7 +1360,8 @@ mod tests {
             &[],
             None,
             None,
-        ).await;
+        )
+        .await;
 
         let titles: Vec<String> = actions
             .iter()
@@ -1321,13 +1379,15 @@ mod tests {
     #[tokio::test]
     async fn test_ignore_action_emitted_even_when_up_to_date() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:lodash".to_string(),
-            VersionInfo {
-                latest: Some("1.0.0".to_string()), // up-to-date
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:lodash".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.0".to_string()), // up-to-date
+                    ..Default::default()
+                },
+            )
+            .await;
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
         let range = Range {
@@ -1352,7 +1412,8 @@ mod tests {
             &[],
             Some(&workspace),
             None,
-        ).await;
+        )
+        .await;
 
         let titles: Vec<String> = actions
             .iter()
@@ -1370,13 +1431,15 @@ mod tests {
     #[tokio::test]
     async fn test_property_reference_gets_ignore_action_but_not_update() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:my-pkg".to_string(),
-            VersionInfo {
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:my-pkg".to_string(),
+                VersionInfo {
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
         // Create a dep whose version is a Maven-style property reference.
         let dep = create_test_dependency("my-pkg", "${my.version}", 5);
         let deps = vec![dep];
@@ -1403,7 +1466,8 @@ mod tests {
             &[],
             Some(&workspace),
             None,
-        ).await;
+        )
+        .await;
 
         let titles: Vec<String> = actions
             .iter()
@@ -1427,13 +1491,15 @@ mod tests {
     #[tokio::test]
     async fn test_ignore_action_kind_and_preference() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:lodash".to_string(),
-            VersionInfo {
-                latest: Some("1.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:lodash".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let uri = Url::parse("file:///test/Cargo.toml").unwrap();
         let range = Range {
@@ -1458,7 +1524,8 @@ mod tests {
             &[],
             Some(&workspace),
             None,
-        ).await;
+        )
+        .await;
 
         let ignore = actions
             .iter()

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -1,6 +1,6 @@
 //! Code actions provider for updating dependencies
 
-use futures::future::join_all;
+use futures::stream::{self, StreamExt};
 use tower_lsp::lsp_types::*;
 
 use crate::cache::ReadCache;
@@ -270,22 +270,27 @@ async fn create_update_all_action(
     file_type: FileType,
     cache_key_fn: impl Fn(&str) -> String,
 ) -> Option<CodeActionOrCommand> {
-    // Fan out all cache reads concurrently, then process results in order.
+    // Fan out cache reads with bounded concurrency to avoid enqueuing an unbounded
+    // number of `spawn_blocking` SQLite jobs (which are not cancelable). Tag each
+    // future with its index so we can stitch results back to the right Dependency.
+    const PREFETCH_CONCURRENCY: usize = 8;
     let filtered: Vec<&Dependency> = dependencies
         .iter()
         .copied()
         .filter(|dep| !is_property_reference(dep))
         .collect();
 
-    let cache_lookups: Vec<_> = filtered
-        .iter()
-        .map(|dep| {
-            let key = cache_key_fn(&dep.name);
-            async move { cache.get(&key).await }
-        })
-        .collect();
+    let cache_keys: Vec<String> = filtered.iter().map(|dep| cache_key_fn(&dep.name)).collect();
 
-    let cache_results = join_all(cache_lookups).await;
+    let mut cache_results: Vec<Option<crate::registries::VersionInfo>> = vec![None; filtered.len()];
+    let lookups = cache_keys
+        .into_iter()
+        .enumerate()
+        .map(|(idx, key)| async move { (idx, cache.get(&key).await) });
+    let mut tagged = stream::iter(lookups).buffer_unordered(PREFETCH_CONCURRENCY);
+    while let Some((idx, value)) = tagged.next().await {
+        cache_results[idx] = value;
+    }
 
     let mut outdated_deps: Vec<(&Dependency, String)> = Vec::new();
     for (dep, version_info) in filtered.iter().zip(cache_results) {

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -1,5 +1,6 @@
 //! Code actions provider for updating dependencies
 
+use futures::future::join_all;
 use tower_lsp::lsp_types::*;
 
 use crate::cache::ReadCache;
@@ -269,16 +270,30 @@ async fn create_update_all_action(
     file_type: FileType,
     cache_key_fn: impl Fn(&str) -> String,
 ) -> Option<CodeActionOrCommand> {
-    let mut outdated_deps: Vec<(&Dependency, String)> = Vec::new();
-    for dep in dependencies
+    // Fan out all cache reads concurrently, then process results in order.
+    let filtered: Vec<&Dependency> = dependencies
         .iter()
         .copied()
         .filter(|dep| !is_property_reference(dep))
-    {
-        let cache_key = cache_key_fn(&dep.name);
-        if let Some(version_info) = cache.get(&cache_key).await
-            && let VersionStatus::UpdateAvailable(new_version) =
-                compare_versions(dep.effective_version(), &version_info)
+        .collect();
+
+    let cache_lookups: Vec<_> = filtered
+        .iter()
+        .map(|dep| {
+            let key = cache_key_fn(&dep.name);
+            async move { cache.get(&key).await }
+        })
+        .collect();
+
+    let cache_results = join_all(cache_lookups).await;
+
+    let mut outdated_deps: Vec<(&Dependency, String)> = Vec::new();
+    for (dep, version_info) in filtered.iter().zip(cache_results) {
+        let Some(version_info) = version_info else {
+            continue;
+        };
+        if let VersionStatus::UpdateAvailable(new_version) =
+            compare_versions(dep.effective_version(), &version_info)
         {
             outdated_deps.push((dep, new_version));
         }

--- a/dependi-lsp/src/providers/completion.rs
+++ b/dependi-lsp/src/providers/completion.rs
@@ -265,18 +265,20 @@ mod tests {
     #[tokio::test]
     async fn test_get_completions() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("1.0.200".to_string()),
-                versions: vec![
-                    "1.0.200".to_string(),
-                    "1.0.199".to_string(),
-                    "1.0.198".to_string(),
-                ],
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.200".to_string()),
+                    versions: vec![
+                        "1.0.200".to_string(),
+                        "1.0.199".to_string(),
+                        "1.0.198".to_string(),
+                    ],
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         // Position inside the version field
@@ -285,7 +287,8 @@ mod tests {
             character: 13, // Within version_start to version_end
         };
 
-        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
+        let completions =
+            get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
 
         assert!(completions.is_some());
         let items = completions.unwrap();
@@ -302,19 +305,21 @@ mod tests {
         release_dates.insert("1.0.200".to_string(), now - Duration::days(2));
         release_dates.insert("1.0.199".to_string(), now - Duration::days(10));
 
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("1.0.200".to_string()),
-                versions: vec![
-                    "1.0.200".to_string(),
-                    "1.0.199".to_string(),
-                    "1.0.198".to_string(),
-                ],
-                release_dates,
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.200".to_string()),
+                    versions: vec![
+                        "1.0.200".to_string(),
+                        "1.0.199".to_string(),
+                        "1.0.198".to_string(),
+                    ],
+                    release_dates,
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let position = Position {
@@ -322,7 +327,8 @@ mod tests {
             character: 13,
         };
 
-        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
+        let completions =
+            get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
 
         assert!(completions.is_some());
         let items = completions.unwrap();
@@ -344,14 +350,16 @@ mod tests {
     #[tokio::test]
     async fn test_no_completions_outside_version() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("1.0.200".to_string()),
-                versions: vec!["1.0.200".to_string()],
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.200".to_string()),
+                    versions: vec!["1.0.200".to_string()],
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         // Position outside the version field
@@ -360,7 +368,8 @@ mod tests {
             character: 0, // At the start, not in version
         };
 
-        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
+        let completions =
+            get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
 
         assert!(completions.is_none());
     }
@@ -368,14 +377,16 @@ mod tests {
     #[tokio::test]
     async fn test_no_completions_wrong_line() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("1.0.200".to_string()),
-                versions: vec!["1.0.200".to_string()],
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.200".to_string()),
+                    versions: vec!["1.0.200".to_string()],
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let position = Position {
@@ -383,7 +394,8 @@ mod tests {
             character: 13,
         };
 
-        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
+        let completions =
+            get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
 
         assert!(completions.is_none());
     }
@@ -397,7 +409,8 @@ mod tests {
             character: 13,
         };
 
-        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
+        let completions =
+            get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
 
         assert!(completions.is_none());
     }
@@ -446,14 +459,16 @@ mod tests {
     async fn test_completions_many_versions() {
         let cache = MemoryCache::new();
         let versions: Vec<String> = (0..20).map(|i| format!("1.0.{}", 20 - i)).collect();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("1.0.20".to_string()),
-                versions,
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.20".to_string()),
+                    versions,
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let position = Position {
@@ -461,7 +476,8 @@ mod tests {
             character: 13,
         };
 
-        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
+        let completions =
+            get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
 
         assert!(completions.is_some());
         let items = completions.unwrap();

--- a/dependi-lsp/src/providers/completion.rs
+++ b/dependi-lsp/src/providers/completion.rs
@@ -72,7 +72,7 @@ pub fn fmt_release_age(released_at: DateTime<Utc>) -> impl fmt::Display + fmt::D
 }
 
 /// Get completions for a position in the document
-pub fn get_completions(
+pub async fn get_completions(
     dependencies: &[Dependency],
     position: Position,
     cache: &impl ReadCache,
@@ -84,7 +84,7 @@ pub fn get_completions(
         .find(|d| d.version_span.contains_lsp_position(&position))?;
 
     let cache_key = cache_key_fn(&dep.name);
-    let version_info = cache.get(&cache_key)?;
+    let version_info = cache.get(&cache_key).await?;
 
     // Return the last 10 versions as completions
     let items: Vec<CompletionItem> = version_info
@@ -262,8 +262,8 @@ mod tests {
         assert_eq!(format_release_age(near_future), "just now");
     }
 
-    #[test]
-    fn test_get_completions() {
+    #[tokio::test]
+    async fn test_get_completions() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:serde".to_string(),
@@ -276,7 +276,7 @@ mod tests {
                 ],
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         // Position inside the version field
@@ -285,7 +285,7 @@ mod tests {
             character: 13, // Within version_start to version_end
         };
 
-        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}"));
+        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
 
         assert!(completions.is_some());
         let items = completions.unwrap();
@@ -294,8 +294,8 @@ mod tests {
         assert_eq!(items[1].label, "1.0.199");
     }
 
-    #[test]
-    fn test_get_completions_with_release_dates() {
+    #[tokio::test]
+    async fn test_get_completions_with_release_dates() {
         let cache = MemoryCache::new();
         let now = Utc::now();
         let mut release_dates = HashMap::new();
@@ -314,7 +314,7 @@ mod tests {
                 release_dates,
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let position = Position {
@@ -322,7 +322,7 @@ mod tests {
             character: 13,
         };
 
-        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}"));
+        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
 
         assert!(completions.is_some());
         let items = completions.unwrap();
@@ -341,8 +341,8 @@ mod tests {
         assert_eq!(items[2].detail.as_ref().unwrap(), "Version 1.0.198");
     }
 
-    #[test]
-    fn test_no_completions_outside_version() {
+    #[tokio::test]
+    async fn test_no_completions_outside_version() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:serde".to_string(),
@@ -351,7 +351,7 @@ mod tests {
                 versions: vec!["1.0.200".to_string()],
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         // Position outside the version field
@@ -360,13 +360,13 @@ mod tests {
             character: 0, // At the start, not in version
         };
 
-        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}"));
+        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
 
         assert!(completions.is_none());
     }
 
-    #[test]
-    fn test_no_completions_wrong_line() {
+    #[tokio::test]
+    async fn test_no_completions_wrong_line() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:serde".to_string(),
@@ -375,7 +375,7 @@ mod tests {
                 versions: vec!["1.0.200".to_string()],
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let position = Position {
@@ -383,13 +383,13 @@ mod tests {
             character: 13,
         };
 
-        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}"));
+        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
 
         assert!(completions.is_none());
     }
 
-    #[test]
-    fn test_no_completions_no_cache() {
+    #[tokio::test]
+    async fn test_no_completions_no_cache() {
         let cache = MemoryCache::new();
         let deps = vec![create_test_dependency("unknown", "1.0.0", 5)];
         let position = Position {
@@ -397,7 +397,7 @@ mod tests {
             character: 13,
         };
 
-        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}"));
+        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
 
         assert!(completions.is_none());
     }
@@ -442,8 +442,8 @@ mod tests {
         assert_eq!(age, "just now");
     }
 
-    #[test]
-    fn test_completions_many_versions() {
+    #[tokio::test]
+    async fn test_completions_many_versions() {
         let cache = MemoryCache::new();
         let versions: Vec<String> = (0..20).map(|i| format!("1.0.{}", 20 - i)).collect();
         cache.insert(
@@ -453,7 +453,7 @@ mod tests {
                 versions,
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let position = Position {
@@ -461,7 +461,7 @@ mod tests {
             character: 13,
         };
 
-        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}"));
+        let completions = get_completions(&deps, position, &cache, |name| format!("test:{name}")).await;
 
         assert!(completions.is_some());
         let items = completions.unwrap();

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -500,13 +500,15 @@ mod tests {
     #[tokio::test]
     async fn test_create_diagnostic_outdated() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let diagnostics = create_diagnostics(
@@ -517,7 +519,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("2.0.0"));
@@ -527,13 +530,15 @@ mod tests {
     #[tokio::test]
     async fn test_no_diagnostic_up_to_date() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                latest: Some("1.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let diagnostics = create_diagnostics(
@@ -544,7 +549,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -561,7 +567,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -590,15 +597,17 @@ mod tests {
     async fn test_deprecated_diagnostic() {
         let deps = vec![create_test_dependency("old-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:old-dep".to_string(),
-            VersionInfo {
-                deprecated: true,
-                latest: Some("2.0.0".to_string()),
-                homepage: Some("https://example.com".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:old-dep".to_string(),
+                VersionInfo {
+                    deprecated: true,
+                    latest: Some("2.0.0".to_string()),
+                    homepage: Some("https://example.com".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -608,7 +617,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let deprecation_diags: Vec<_> = diagnostics
             .iter()
@@ -636,14 +646,16 @@ mod tests {
     async fn test_no_deprecated_diagnostic_for_active() {
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                deprecated: false,
-                latest: Some("1.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    deprecated: false,
+                    latest: Some("1.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -653,7 +665,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let deprecation_diags: Vec<_> = diagnostics
             .iter()
@@ -675,19 +688,21 @@ mod tests {
     async fn test_deprecated_with_vulnerabilities() {
         let deps = vec![create_test_dependency("vuln-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:vuln-dep".to_string(),
-            VersionInfo {
-                deprecated: true,
-                vulnerabilities: vec![Vulnerability {
-                    id: "CVE-2024-1234".to_string(),
-                    severity: VulnerabilitySeverity::High,
-                    description: "Test vulnerability".to_string(),
-                    url: None,
-                }],
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:vuln-dep".to_string(),
+                VersionInfo {
+                    deprecated: true,
+                    vulnerabilities: vec![Vulnerability {
+                        id: "CVE-2024-1234".to_string(),
+                        severity: VulnerabilitySeverity::High,
+                        description: "Test vulnerability".to_string(),
+                        url: None,
+                    }],
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -697,7 +712,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let deprecation_diags: Vec<_> = diagnostics
             .iter()
@@ -737,14 +753,16 @@ mod tests {
     async fn test_yanked_diagnostic() {
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                yanked_versions: vec!["1.0.0".to_string()],
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    yanked_versions: vec!["1.0.0".to_string()],
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -754,7 +772,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let yanked_diags: Vec<_> = diagnostics
             .iter()
@@ -778,14 +797,16 @@ mod tests {
     async fn test_no_yanked_diagnostic_for_non_yanked() {
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                yanked_versions: vec!["0.9.0".to_string()],
-                latest: Some("1.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    yanked_versions: vec!["0.9.0".to_string()],
+                    latest: Some("1.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -795,7 +816,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let yanked_diags: Vec<_> = diagnostics
             .iter()
@@ -817,15 +839,17 @@ mod tests {
     async fn test_yanked_priority_over_deprecated_diagnostic() {
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                yanked_versions: vec!["1.0.0".to_string()],
-                deprecated: true,
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    yanked_versions: vec!["1.0.0".to_string()],
+                    deprecated: true,
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -835,7 +859,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let yanked_diags: Vec<_> = diagnostics
             .iter()
@@ -875,20 +900,22 @@ mod tests {
     async fn test_yanked_priority_over_vulnerabilities_diagnostic() {
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                yanked_versions: vec!["1.0.0".to_string()],
-                vulnerabilities: vec![Vulnerability {
-                    id: "CVE-2024-1234".to_string(),
-                    severity: VulnerabilitySeverity::High,
-                    description: "Test vulnerability".to_string(),
-                    url: None,
-                }],
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    yanked_versions: vec!["1.0.0".to_string()],
+                    vulnerabilities: vec![Vulnerability {
+                        id: "CVE-2024-1234".to_string(),
+                        severity: VulnerabilitySeverity::High,
+                        description: "Test vulnerability".to_string(),
+                        url: None,
+                    }],
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -898,7 +925,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let yanked_diags: Vec<_> = diagnostics
             .iter()
@@ -947,7 +975,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("Local"));
@@ -958,27 +987,29 @@ mod tests {
     async fn test_vulnerability_summary_diagnostic() {
         let deps = vec![create_test_dependency("vuln-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:vuln-dep".to_string(),
-            VersionInfo {
-                latest: Some("1.0.0".to_string()),
-                vulnerabilities: vec![
-                    Vulnerability {
-                        id: "CVE-2024-1234".to_string(),
-                        severity: VulnerabilitySeverity::High,
-                        description: "High severity vulnerability".to_string(),
-                        url: Some("https://osv.dev/CVE-2024-1234".to_string()),
-                    },
-                    Vulnerability {
-                        id: "CVE-2024-5678".to_string(),
-                        severity: VulnerabilitySeverity::Medium,
-                        description: "Medium severity vulnerability".to_string(),
-                        url: None,
-                    },
-                ],
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:vuln-dep".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.0".to_string()),
+                    vulnerabilities: vec![
+                        Vulnerability {
+                            id: "CVE-2024-1234".to_string(),
+                            severity: VulnerabilitySeverity::High,
+                            description: "High severity vulnerability".to_string(),
+                            url: Some("https://osv.dev/CVE-2024-1234".to_string()),
+                        },
+                        Vulnerability {
+                            id: "CVE-2024-5678".to_string(),
+                            severity: VulnerabilitySeverity::Medium,
+                            description: "Medium severity vulnerability".to_string(),
+                            url: None,
+                        },
+                    ],
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -988,7 +1019,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1009,27 +1041,29 @@ mod tests {
     async fn test_vulnerability_severity_filtering() {
         let deps = vec![create_test_dependency("vuln-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:vuln-dep".to_string(),
-            VersionInfo {
-                latest: Some("1.0.0".to_string()),
-                vulnerabilities: vec![
-                    Vulnerability {
-                        id: "CVE-2024-LOW".to_string(),
-                        severity: VulnerabilitySeverity::Low,
-                        description: "Low severity".to_string(),
-                        url: None,
-                    },
-                    Vulnerability {
-                        id: "CVE-2024-HIGH".to_string(),
-                        severity: VulnerabilitySeverity::High,
-                        description: "High severity".to_string(),
-                        url: None,
-                    },
-                ],
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:vuln-dep".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.0".to_string()),
+                    vulnerabilities: vec![
+                        Vulnerability {
+                            id: "CVE-2024-LOW".to_string(),
+                            severity: VulnerabilitySeverity::Low,
+                            description: "Low severity".to_string(),
+                            url: None,
+                        },
+                        Vulnerability {
+                            id: "CVE-2024-HIGH".to_string(),
+                            severity: VulnerabilitySeverity::High,
+                            description: "High severity".to_string(),
+                            url: None,
+                        },
+                    ],
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1039,7 +1073,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1058,15 +1093,17 @@ mod tests {
     async fn test_deprecation_diagnostic_with_repository() {
         let deps = vec![create_test_dependency("old-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:old-dep".to_string(),
-            VersionInfo {
-                deprecated: true,
-                latest: Some("2.0.0".to_string()),
-                repository: Some("https://github.com/user/old-dep".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:old-dep".to_string(),
+                VersionInfo {
+                    deprecated: true,
+                    latest: Some("2.0.0".to_string()),
+                    repository: Some("https://github.com/user/old-dep".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1076,7 +1113,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let deprecation_diags: Vec<_> = diagnostics
             .iter()
@@ -1097,15 +1135,17 @@ mod tests {
     async fn test_yanked_diagnostic_with_repository() {
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:serde".to_string(),
-            VersionInfo {
-                yanked_versions: vec!["1.0.0".to_string()],
-                latest: Some("2.0.0".to_string()),
-                repository: Some("https://github.com/serde-rs/serde".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:serde".to_string(),
+                VersionInfo {
+                    yanked_versions: vec!["1.0.0".to_string()],
+                    latest: Some("2.0.0".to_string()),
+                    repository: Some("https://github.com/serde-rs/serde".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1115,7 +1155,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let yanked_diags: Vec<_> = diagnostics
             .iter()
@@ -1185,19 +1226,21 @@ mod tests {
     async fn test_vulnerability_low_severity_hint() {
         let deps = vec![create_test_dependency("vuln-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:vuln-dep".to_string(),
-            VersionInfo {
-                latest: Some("1.0.0".to_string()),
-                vulnerabilities: vec![Vulnerability {
-                    id: "CVE-2024-LOW".to_string(),
-                    severity: VulnerabilitySeverity::Low,
-                    description: "Low severity".to_string(),
-                    url: None,
-                }],
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:vuln-dep".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.0".to_string()),
+                    vulnerabilities: vec![Vulnerability {
+                        id: "CVE-2024-LOW".to_string(),
+                        severity: VulnerabilitySeverity::Low,
+                        description: "Low severity".to_string(),
+                        url: None,
+                    }],
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1207,7 +1250,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1226,19 +1270,21 @@ mod tests {
     async fn test_vulnerability_medium_severity_warning() {
         let deps = vec![create_test_dependency("vuln-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:vuln-dep".to_string(),
-            VersionInfo {
-                latest: Some("1.0.0".to_string()),
-                vulnerabilities: vec![Vulnerability {
-                    id: "CVE-2024-MED".to_string(),
-                    severity: VulnerabilitySeverity::Medium,
-                    description: "Medium severity".to_string(),
-                    url: None,
-                }],
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:vuln-dep".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.0".to_string()),
+                    vulnerabilities: vec![Vulnerability {
+                        id: "CVE-2024-MED".to_string(),
+                        severity: VulnerabilitySeverity::Medium,
+                        description: "Medium severity".to_string(),
+                        url: None,
+                    }],
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1248,7 +1294,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1267,19 +1314,21 @@ mod tests {
     async fn test_vulnerability_critical_severity_error() {
         let deps = vec![create_test_dependency("vuln-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:vuln-dep".to_string(),
-            VersionInfo {
-                latest: Some("1.0.0".to_string()),
-                vulnerabilities: vec![Vulnerability {
-                    id: "CVE-2024-CRIT".to_string(),
-                    severity: VulnerabilitySeverity::Critical,
-                    description: "Critical severity".to_string(),
-                    url: None,
-                }],
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:vuln-dep".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.0".to_string()),
+                    vulnerabilities: vec![Vulnerability {
+                        id: "CVE-2024-CRIT".to_string(),
+                        severity: VulnerabilitySeverity::Critical,
+                        description: "Critical severity".to_string(),
+                        url: None,
+                    }],
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1289,7 +1338,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1308,14 +1358,16 @@ mod tests {
     async fn test_yanked_diagnostic_uses_registry_name_npm() {
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:lodash".to_string(),
-            VersionInfo {
-                yanked_versions: vec!["1.0.0".to_string()],
-                latest: Some("4.17.21".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:lodash".to_string(),
+                VersionInfo {
+                    yanked_versions: vec!["1.0.0".to_string()],
+                    latest: Some("4.17.21".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1325,7 +1377,8 @@ mod tests {
             FileType::Npm,
             &hashbrown::HashMap::new(),
             &[],
-        ).await;
+        )
+        .await;
 
         let yanked_diags: Vec<_> = diagnostics
             .iter()
@@ -1357,13 +1410,15 @@ mod tests {
 
         let deps = vec![create_test_dependency("my-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:my-dep".to_string(),
-            VersionInfo {
-                latest: Some("1.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:my-dep".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         // Transitive vulns are now stored per-document, not in version_cache.
         let mut doc_transitives: hashbrown::HashMap<String, Vec<TransitiveVuln>> =
@@ -1390,7 +1445,8 @@ mod tests {
             FileType::Cargo,
             &doc_transitives,
             &[],
-        ).await;
+        )
+        .await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1423,13 +1479,15 @@ mod tests {
     async fn test_transitive_vulns_respect_min_severity() {
         let deps = vec![create_test_dependency("my-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:my-dep".to_string(),
-            VersionInfo {
-                latest: Some("1.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:my-dep".to_string(),
+                VersionInfo {
+                    latest: Some("1.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
 
         let mut doc_transitives: hashbrown::HashMap<String, Vec<TransitiveVuln>> =
             hashbrown::HashMap::new();
@@ -1467,7 +1525,8 @@ mod tests {
             FileType::Cargo,
             &doc_transitives,
             &[],
-        ).await;
+        )
+        .await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1498,13 +1557,15 @@ mod tests {
     #[tokio::test]
     async fn test_diagnostic_skipped_for_ignored_package() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:lodash".to_string(),
-            VersionInfo {
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:lodash".to_string(),
+                VersionInfo {
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let ignored = vec!["lodash".to_string()];
 
@@ -1516,7 +1577,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &ignored,
-        ).await;
+        )
+        .await;
 
         assert!(
             diagnostics.is_empty(),
@@ -1527,13 +1589,15 @@ mod tests {
     #[tokio::test]
     async fn test_diagnostic_skipped_for_wildcard_match() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:@internal/utils".to_string(),
-            VersionInfo {
-                latest: Some("2.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:@internal/utils".to_string(),
+                VersionInfo {
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
         let deps = vec![create_test_dependency("@internal/utils", "1.0.0", 5)];
         let ignored = vec!["@internal/*".to_string()];
 
@@ -1545,7 +1609,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &ignored,
-        ).await;
+        )
+        .await;
 
         assert!(
             diagnostics.is_empty(),
@@ -1556,13 +1621,15 @@ mod tests {
     #[tokio::test]
     async fn test_diagnostic_emitted_when_not_ignored() {
         let cache = MemoryCache::new();
-        cache.insert(
-            "test:react".to_string(),
-            VersionInfo {
-                latest: Some("18.0.0".to_string()),
-                ..Default::default()
-            },
-        ).await;
+        cache
+            .insert(
+                "test:react".to_string(),
+                VersionInfo {
+                    latest: Some("18.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
         let deps = vec![create_test_dependency("react", "17.0.0", 5)];
         let ignored = vec!["lodash".to_string()];
 
@@ -1574,7 +1641,8 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &ignored,
-        ).await;
+        )
+        .await;
 
         assert_eq!(
             diagnostics.len(),

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -15,7 +15,7 @@ use crate::utils::fmt_truncate_string;
 ///
 /// The `min_severity` parameter filters vulnerabilities to only show those
 /// at or above the specified severity level.
-pub fn create_diagnostics(
+pub async fn create_diagnostics(
     dependencies: &[Dependency],
     cache: &impl ReadCache,
     cache_key_fn: impl Fn(&str) -> String,
@@ -39,12 +39,12 @@ pub fn create_diagnostics(
         }
 
         // Add outdated version diagnostic
-        if let Some(diag) = create_outdated_diagnostic(dep, cache, &cache_key_fn) {
+        if let Some(diag) = create_outdated_diagnostic(dep, cache, &cache_key_fn).await {
             diagnostics.push(diag);
         }
 
         let cache_key = cache_key_fn(&dep.name);
-        if let Some(version_info) = cache.get(&cache_key) {
+        if let Some(version_info) = cache.get(&cache_key).await {
             // Add yanked version diagnostic (highest priority)
             if version_info.is_version_yanked(dep.effective_version()) {
                 tracing::debug!(
@@ -112,13 +112,13 @@ fn meets_severity_threshold(severity: &VulnerabilitySeverity, min: &Vulnerabilit
 }
 
 /// Create a diagnostic for an outdated dependency
-fn create_outdated_diagnostic(
+async fn create_outdated_diagnostic(
     dep: &Dependency,
     cache: &impl ReadCache,
     cache_key_fn: impl Fn(&str) -> String,
 ) -> Option<Diagnostic> {
     let cache_key = cache_key_fn(&dep.name);
-    let version_info = cache.get(&cache_key)?;
+    let version_info = cache.get(&cache_key).await?;
 
     match compare_versions(dep.effective_version(), &version_info) {
         VersionStatus::UpdateAvailable(new_version) => Some(Diagnostic {
@@ -497,8 +497,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_create_diagnostic_outdated() {
+    #[tokio::test]
+    async fn test_create_diagnostic_outdated() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:serde".to_string(),
@@ -506,7 +506,7 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let diagnostics = create_diagnostics(
@@ -517,15 +517,15 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("2.0.0"));
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::HINT));
     }
 
-    #[test]
-    fn test_no_diagnostic_up_to_date() {
+    #[tokio::test]
+    async fn test_no_diagnostic_up_to_date() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:serde".to_string(),
@@ -533,7 +533,7 @@ mod tests {
                 latest: Some("1.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let diagnostics = create_diagnostics(
@@ -544,13 +544,13 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         assert_eq!(diagnostics.len(), 0);
     }
 
-    #[test]
-    fn test_no_diagnostic_no_cache() {
+    #[tokio::test]
+    async fn test_no_diagnostic_no_cache() {
         let cache = MemoryCache::new();
         let deps = vec![create_test_dependency("unknown", "1.0.0", 5)];
         let diagnostics = create_diagnostics(
@@ -561,7 +561,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -586,8 +586,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_deprecated_diagnostic() {
+    #[tokio::test]
+    async fn test_deprecated_diagnostic() {
         let deps = vec![create_test_dependency("old-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -598,7 +598,7 @@ mod tests {
                 homepage: Some("https://example.com".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -608,7 +608,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let deprecation_diags: Vec<_> = diagnostics
             .iter()
@@ -632,8 +632,8 @@ mod tests {
         assert!(deprecation_diags[0].related_information.is_some());
     }
 
-    #[test]
-    fn test_no_deprecated_diagnostic_for_active() {
+    #[tokio::test]
+    async fn test_no_deprecated_diagnostic_for_active() {
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -643,7 +643,7 @@ mod tests {
                 latest: Some("1.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -653,7 +653,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let deprecation_diags: Vec<_> = diagnostics
             .iter()
@@ -671,8 +671,8 @@ mod tests {
         assert_eq!(deprecation_diags.len(), 0);
     }
 
-    #[test]
-    fn test_deprecated_with_vulnerabilities() {
+    #[tokio::test]
+    async fn test_deprecated_with_vulnerabilities() {
         let deps = vec![create_test_dependency("vuln-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -687,7 +687,7 @@ mod tests {
                 }],
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -697,7 +697,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let deprecation_diags: Vec<_> = diagnostics
             .iter()
@@ -733,8 +733,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_yanked_diagnostic() {
+    #[tokio::test]
+    async fn test_yanked_diagnostic() {
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -744,7 +744,7 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -754,7 +754,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let yanked_diags: Vec<_> = diagnostics
             .iter()
@@ -774,8 +774,8 @@ mod tests {
         assert_eq!(yanked_diags[0].severity, Some(DiagnosticSeverity::WARNING));
     }
 
-    #[test]
-    fn test_no_yanked_diagnostic_for_non_yanked() {
+    #[tokio::test]
+    async fn test_no_yanked_diagnostic_for_non_yanked() {
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -785,7 +785,7 @@ mod tests {
                 latest: Some("1.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -795,7 +795,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let yanked_diags: Vec<_> = diagnostics
             .iter()
@@ -813,8 +813,8 @@ mod tests {
         assert_eq!(yanked_diags.len(), 0);
     }
 
-    #[test]
-    fn test_yanked_priority_over_deprecated_diagnostic() {
+    #[tokio::test]
+    async fn test_yanked_priority_over_deprecated_diagnostic() {
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -825,7 +825,7 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -835,7 +835,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let yanked_diags: Vec<_> = diagnostics
             .iter()
@@ -871,8 +871,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_yanked_priority_over_vulnerabilities_diagnostic() {
+    #[tokio::test]
+    async fn test_yanked_priority_over_vulnerabilities_diagnostic() {
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -888,7 +888,7 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -898,7 +898,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let yanked_diags: Vec<_> = diagnostics
             .iter()
@@ -934,8 +934,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_local_dependency_diagnostic() {
+    #[tokio::test]
+    async fn test_local_dependency_diagnostic() {
         let deps = vec![create_test_dependency("local-crate", "../local", 5)];
         let cache = MemoryCache::new();
 
@@ -947,15 +947,15 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("Local"));
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::HINT));
     }
 
-    #[test]
-    fn test_vulnerability_summary_diagnostic() {
+    #[tokio::test]
+    async fn test_vulnerability_summary_diagnostic() {
         let deps = vec![create_test_dependency("vuln-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -978,7 +978,7 @@ mod tests {
                 ],
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -988,7 +988,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1005,8 +1005,8 @@ mod tests {
         assert!(vuln_diags[0].related_information.is_some());
     }
 
-    #[test]
-    fn test_vulnerability_severity_filtering() {
+    #[tokio::test]
+    async fn test_vulnerability_severity_filtering() {
         let deps = vec![create_test_dependency("vuln-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -1029,7 +1029,7 @@ mod tests {
                 ],
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1039,7 +1039,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1054,8 +1054,8 @@ mod tests {
         assert!(vuln_diags[0].message.contains("1 vuln"));
     }
 
-    #[test]
-    fn test_deprecation_diagnostic_with_repository() {
+    #[tokio::test]
+    async fn test_deprecation_diagnostic_with_repository() {
         let deps = vec![create_test_dependency("old-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -1066,7 +1066,7 @@ mod tests {
                 repository: Some("https://github.com/user/old-dep".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1076,7 +1076,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let deprecation_diags: Vec<_> = diagnostics
             .iter()
@@ -1093,8 +1093,8 @@ mod tests {
         assert!(!related.is_empty());
     }
 
-    #[test]
-    fn test_yanked_diagnostic_with_repository() {
+    #[tokio::test]
+    async fn test_yanked_diagnostic_with_repository() {
         let deps = vec![create_test_dependency("serde", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -1105,7 +1105,7 @@ mod tests {
                 repository: Some("https://github.com/serde-rs/serde".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1115,7 +1115,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let yanked_diags: Vec<_> = diagnostics
             .iter()
@@ -1181,8 +1181,8 @@ mod tests {
         assert_eq!(msg, "");
     }
 
-    #[test]
-    fn test_vulnerability_low_severity_hint() {
+    #[tokio::test]
+    async fn test_vulnerability_low_severity_hint() {
         let deps = vec![create_test_dependency("vuln-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -1197,7 +1197,7 @@ mod tests {
                 }],
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1207,7 +1207,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1222,8 +1222,8 @@ mod tests {
         assert_eq!(vuln_diags[0].severity, Some(DiagnosticSeverity::HINT));
     }
 
-    #[test]
-    fn test_vulnerability_medium_severity_warning() {
+    #[tokio::test]
+    async fn test_vulnerability_medium_severity_warning() {
         let deps = vec![create_test_dependency("vuln-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -1238,7 +1238,7 @@ mod tests {
                 }],
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1248,7 +1248,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1263,8 +1263,8 @@ mod tests {
         assert_eq!(vuln_diags[0].severity, Some(DiagnosticSeverity::WARNING));
     }
 
-    #[test]
-    fn test_vulnerability_critical_severity_error() {
+    #[tokio::test]
+    async fn test_vulnerability_critical_severity_error() {
         let deps = vec![create_test_dependency("vuln-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -1279,7 +1279,7 @@ mod tests {
                 }],
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1289,7 +1289,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1304,8 +1304,8 @@ mod tests {
         assert_eq!(vuln_diags[0].severity, Some(DiagnosticSeverity::ERROR));
     }
 
-    #[test]
-    fn test_yanked_diagnostic_uses_registry_name_npm() {
+    #[tokio::test]
+    async fn test_yanked_diagnostic_uses_registry_name_npm() {
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -1315,7 +1315,7 @@ mod tests {
                 latest: Some("4.17.21".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let diagnostics = create_diagnostics(
             &deps,
@@ -1325,7 +1325,7 @@ mod tests {
             FileType::Npm,
             &hashbrown::HashMap::new(),
             &[],
-        );
+        ).await;
 
         let yanked_diags: Vec<_> = diagnostics
             .iter()
@@ -1349,8 +1349,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_diagnostic_fires_on_transitive_only_vulns() {
+    #[tokio::test]
+    async fn test_diagnostic_fires_on_transitive_only_vulns() {
         use crate::registries::{
             TransitiveVuln, VersionInfo, Vulnerability, VulnerabilitySeverity,
         };
@@ -1363,7 +1363,7 @@ mod tests {
                 latest: Some("1.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         // Transitive vulns are now stored per-document, not in version_cache.
         let mut doc_transitives: hashbrown::HashMap<String, Vec<TransitiveVuln>> =
@@ -1390,7 +1390,7 @@ mod tests {
             FileType::Cargo,
             &doc_transitives,
             &[],
-        );
+        ).await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1419,8 +1419,8 @@ mod tests {
         assert_eq!(vuln_diags[0].severity, Some(DiagnosticSeverity::ERROR));
     }
 
-    #[test]
-    fn test_transitive_vulns_respect_min_severity() {
+    #[tokio::test]
+    async fn test_transitive_vulns_respect_min_severity() {
         let deps = vec![create_test_dependency("my-dep", "1.0.0", 5)];
         let cache = MemoryCache::new();
         cache.insert(
@@ -1429,7 +1429,7 @@ mod tests {
                 latest: Some("1.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
 
         let mut doc_transitives: hashbrown::HashMap<String, Vec<TransitiveVuln>> =
             hashbrown::HashMap::new();
@@ -1467,7 +1467,7 @@ mod tests {
             FileType::Cargo,
             &doc_transitives,
             &[],
-        );
+        ).await;
 
         let vuln_diags: Vec<_> = diagnostics
             .iter()
@@ -1495,8 +1495,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_diagnostic_skipped_for_ignored_package() {
+    #[tokio::test]
+    async fn test_diagnostic_skipped_for_ignored_package() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:lodash".to_string(),
@@ -1504,7 +1504,7 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
         let deps = vec![create_test_dependency("lodash", "1.0.0", 5)];
         let ignored = vec!["lodash".to_string()];
 
@@ -1516,7 +1516,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &ignored,
-        );
+        ).await;
 
         assert!(
             diagnostics.is_empty(),
@@ -1524,8 +1524,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_diagnostic_skipped_for_wildcard_match() {
+    #[tokio::test]
+    async fn test_diagnostic_skipped_for_wildcard_match() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:@internal/utils".to_string(),
@@ -1533,7 +1533,7 @@ mod tests {
                 latest: Some("2.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
         let deps = vec![create_test_dependency("@internal/utils", "1.0.0", 5)];
         let ignored = vec!["@internal/*".to_string()];
 
@@ -1545,7 +1545,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &ignored,
-        );
+        ).await;
 
         assert!(
             diagnostics.is_empty(),
@@ -1553,8 +1553,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_diagnostic_emitted_when_not_ignored() {
+    #[tokio::test]
+    async fn test_diagnostic_emitted_when_not_ignored() {
         let cache = MemoryCache::new();
         cache.insert(
             "test:react".to_string(),
@@ -1562,7 +1562,7 @@ mod tests {
                 latest: Some("18.0.0".to_string()),
                 ..Default::default()
             },
-        );
+        ).await;
         let deps = vec![create_test_dependency("react", "17.0.0", 5)];
         let ignored = vec!["lodash".to_string()];
 
@@ -1574,7 +1574,7 @@ mod tests {
             FileType::Cargo,
             &hashbrown::HashMap::new(),
             &ignored,
-        );
+        ).await;
 
         assert_eq!(
             diagnostics.len(),

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -38,13 +38,18 @@ pub async fn create_diagnostics(
             continue;
         }
 
+        // Single cache lookup per dependency: reuse the result for the outdated,
+        // yanked, deprecated, and vulnerability checks below. Avoids two
+        // back-to-back `spawn_blocking` round-trips against `SqliteCache`.
+        let cache_key = cache_key_fn(&dep.name);
+        let cached = cache.get(&cache_key).await;
+
         // Add outdated version diagnostic
-        if let Some(diag) = create_outdated_diagnostic(dep, cache, &cache_key_fn).await {
+        if let Some(diag) = create_outdated_diagnostic(dep, cached.as_ref()) {
             diagnostics.push(diag);
         }
 
-        let cache_key = cache_key_fn(&dep.name);
-        if let Some(version_info) = cache.get(&cache_key).await {
+        if let Some(version_info) = cached {
             // Add yanked version diagnostic (highest priority)
             if version_info.is_version_yanked(dep.effective_version()) {
                 tracing::debug!(
@@ -111,16 +116,18 @@ fn meets_severity_threshold(severity: &VulnerabilitySeverity, min: &Vulnerabilit
     severity.meets_threshold(min)
 }
 
-/// Create a diagnostic for an outdated dependency
-async fn create_outdated_diagnostic(
+/// Create a diagnostic for an outdated dependency.
+///
+/// Takes the already-fetched `VersionInfo` to avoid an extra cache round-trip
+/// (the caller in `create_diagnostics` looks the value up once and reuses it
+/// for outdated, yanked, deprecated, and vulnerability checks).
+fn create_outdated_diagnostic(
     dep: &Dependency,
-    cache: &impl ReadCache,
-    cache_key_fn: impl Fn(&str) -> String,
+    version_info: Option<&VersionInfo>,
 ) -> Option<Diagnostic> {
-    let cache_key = cache_key_fn(&dep.name);
-    let version_info = cache.get(&cache_key).await?;
+    let version_info = version_info?;
 
-    match compare_versions(dep.effective_version(), &version_info) {
+    match compare_versions(dep.effective_version(), version_info) {
         VersionStatus::UpdateAvailable(new_version) => Some(Diagnostic {
             range: Range {
                 start: Position {

--- a/dependi-lsp/tests/integration_test.rs
+++ b/dependi-lsp/tests/integration_test.rs
@@ -150,7 +150,9 @@ async fn test_cache_integration() {
         transitive_vulnerabilities: vec![],
     };
 
-    cache.insert("crates:serde".to_string(), serde_info.clone()).await;
+    cache
+        .insert("crates:serde".to_string(), serde_info.clone())
+        .await;
 
     // Retrieve and verify
     let retrieved = cache.get("crates:serde").await.unwrap();

--- a/dependi-lsp/tests/integration_test.rs
+++ b/dependi-lsp/tests/integration_test.rs
@@ -129,8 +129,8 @@ fn test_parse_realistic_package_json() {
 }
 
 /// Test cache integration
-#[test]
-fn test_cache_integration() {
+#[tokio::test]
+async fn test_cache_integration() {
     let cache = MemoryCache::new();
 
     // Insert some version info
@@ -150,15 +150,15 @@ fn test_cache_integration() {
         transitive_vulnerabilities: vec![],
     };
 
-    cache.insert("crates:serde".to_string(), serde_info.clone());
+    cache.insert("crates:serde".to_string(), serde_info.clone()).await;
 
     // Retrieve and verify
-    let retrieved = cache.get("crates:serde").unwrap();
+    let retrieved = cache.get("crates:serde").await.unwrap();
     assert_eq!(retrieved.latest, Some("1.0.200".to_string()));
     assert_eq!(retrieved.license, Some("MIT OR Apache-2.0".to_string()));
 
     // Test cache miss
-    assert!(cache.get("crates:nonexistent").is_none());
+    assert!(cache.get("crates:nonexistent").await.is_none());
 }
 
 /// Test inlay hint generation with various scenarios


### PR DESCRIPTION
## Summary

• Made `ReadCache` and `WriteCache` traits async using AFIT (Async Functions In Traits)
• Converted `MemoryCache`, `HybridCache`, and `SqliteCache` to async implementations
• Offloaded blocking SQLite operations to `tokio::task::spawn_blocking` for runtime responsiveness
• Migrated all providers (diagnostics, code_actions, completion) to async API
• Updated backend cache calls and tests to use `#[tokio::test]`
• Added concurrent cache prefetching in `create_update_all_action` and `create_inlay_hints` handlers
• Added 5 new tests for async concurrency, cancellation safety, and runtime responsiveness
• Fixed review findings: error propagation in startup, DashMap guard lifetime, concurrent reads

## Type

perf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the cache async and keep the LSP loop responsive by offloading SQLite work. Also fixes a rare SQLite write race by switching to nanosecond timestamps. Implements the async cache API and concurrency improvements in issue #235.

- **Refactors**
  - Made `ReadCache`/`WriteCache` async (AFIT). Converted `MemoryCache`, `HybridCache`, and `SqliteCache`.
  - Offloaded `rusqlite` calls via `tokio::task::spawn_blocking`; constructors stay sync. Initial cleanup runs synchronously with error propagation; log `cleanup_expired` errors.
  - Capped cache prefetch fan-out at 8; used `join_all` where it fits. Dropped non-Send guards before awaits.
  - `SqliteCache`: compute insert timestamp before offload; use nanosecond `inserted_at` and TTL math (`NANOS_PER_SEC`) to close the UPSERT race; conditional UPSERT prevents stale overwrites; override `contains()` with `SELECT 1 LIMIT 1`.
  - Providers/backend now async; diagnostics reuse a single cache read per dependency. Benches run async via a `tokio` runtime and always hit the cache path.

- **Migration**
  - Add `.await` to cache calls and provider fns (`create_diagnostics`, `create_code_actions`, `get_completions`).
  - Switch tests to `#[tokio::test]`; run benches under a `tokio` runtime.
  - Note: `spawn_blocking` tasks are not cancelable; a dropped future may still finish DB work.

<sup>Written for commit 2a2cd24c3816170d2e193fa8b25f1391c829c48e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Cache APIs and operations converted to async; SQLite cache offloads blocking DB work to background tasks to avoid blocking the LSP event loop.
  * Diagnostics, completions, code actions, and inlay hints now await cached data for more consistent results.
  * Benchmarks and tests updated to run under an async runtime to validate non-blocking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->