### PR TITLE
feat(cache): hybrid memory+SQLite advisory cache for RustSec data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Wire `AdvisoryCacheConfig` through `HybridAdvisoryCache::from_config` so
+  user settings (`enabled`, `ttl_secs`, `negative_ttl_secs`, `db_path`)
+  actually take effect; previously the backend instantiated the cache via
+  `HybridAdvisoryCache::new()` and ignored every config field
+  ([#237](https://github.com/mpiton/zed-dependi/issues/237))
+- Apply `negative_ttl_secs` (default 1 h) to OSV 404 responses; they were
+  previously cached on the same 24 h schedule as positive entries, so a
+  brand-new RUSTSEC ID that OSV had not yet ingested stayed hidden for a
+  full day. 404s now live in a separate memory-only negative cache
+  ([#237](https://github.com/mpiton/zed-dependi/issues/237))
+- Preserve the remaining TTL when backfilling the L1 advisory cache from
+  L2: previously every L2 hit re-stamped the memory entry with
+  `Instant::now()` and the full TTL, doubling the effective lifetime for
+  entries already near SQLite expiry
+  ([#237](https://github.com/mpiton/zed-dependi/issues/237))
+- Validate advisory IDs with an ASCII-alphanumeric/`-` whitelist (≤64 chars)
+  before interpolation into URLs and use as cache keys, blocking malformed
+  values returned in OSV responses
+  ([#237](https://github.com/mpiton/zed-dependi/issues/237))
+- Drop the unusable `idx_advisory_expiry` index from the advisory schema:
+  the cleanup query (`WHERE inserted_at + ttl_secs * ? < ?`) cannot use a
+  composite index because of the arithmetic expression
+  ([#237](https://github.com/mpiton/zed-dependi/issues/237))
 - `dependi-lsp scan` now uses `effective_version()` (the resolved lockfile
   version when available) instead of the declared version specifier when
   querying OSV — previously the CLI queried using the specifier string (e.g.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,11 +75,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   this the old tasks kept ticking forever holding `Arc` clones of the
   replaced memory/SQLite layers
   ([#237](https://github.com/mpiton/zed-dependi/issues/237))
-- Stop panicking when the OSV `reqwest` builder fails at startup. The new
-  `OsvClient::with_default_client_and_caches` infallible fallback uses
-  `reqwest::Client::new()` and keeps the cache wiring intact, so the LSP
-  can keep serving non-vulnerability features instead of crashing during
-  `with_http_client` ([#237](https://github.com/mpiton/zed-dependi/issues/237))
+- Reuse the LSP's shared `reqwest::Client` for the `OsvClient` instead of
+  building a second one. The new `OsvClient::with_shared_client_and_caches`
+  takes the already-verified `Arc<Client>` so there is no second TLS
+  builder failure point at startup, and `build_advisory_runtime` is
+  genuinely infallible (the previous "fallback" via `reqwest::Client::new()`
+  could itself panic, since `Client::new()` is `Client::builder().build().expect(...)`)
+  ([#237](https://github.com/mpiton/zed-dependi/issues/237))
 - Reconfigure the advisory cache trio (`advisory_cache`,
   `negative_advisory_cache`, `osv_client`) inside `LanguageServer::initialize`
   once the LSP receives client settings. Previously the caches were built

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,12 +75,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   this the old tasks kept ticking forever holding `Arc` clones of the
   replaced memory/SQLite layers
   ([#237](https://github.com/mpiton/zed-dependi/issues/237))
+- Fall through to the negative cache and network when the positive
+  advisory cache returns `NotFound`, instead of treating it as
+  authoritative. Pre-split builds wrote 404s to the same SQLite layer with
+  the long positive TTL; without this fall-through, an upgrading user
+  would otherwise be stuck with 24 h-stale `NotFound` rows that never
+  retry. Refreshing 200 responses overwrite the stale row via the
+  existing UPSERT
+  ([#237](https://github.com/mpiton/zed-dependi/issues/237))
+- Make `OsvClient::with_endpoint` fallible (`anyhow::Result<Self>`) and
+  drop its `reqwest::Client::new()` fallback. `Client::new()` is itself
+  `Client::builder().build().expect(...)` and panics under the same
+  conditions as the failing `build()`, so the fallback was an illusion.
+  The scan CLI handler logs and returns a non-zero exit code instead of
+  panicking ([#237](https://github.com/mpiton/zed-dependi/issues/237))
 - Reuse the LSP's shared `reqwest::Client` for the `OsvClient` instead of
   building a second one. The new `OsvClient::with_shared_client_and_caches`
   takes the already-verified `Arc<Client>` so there is no second TLS
   builder failure point at startup, and `build_advisory_runtime` is
-  genuinely infallible (the previous "fallback" via `reqwest::Client::new()`
-  could itself panic, since `Client::new()` is `Client::builder().build().expect(...)`)
+  genuinely infallible
   ([#237](https://github.com/mpiton/zed-dependi/issues/237))
 - Reconfigure the advisory cache trio (`advisory_cache`,
   `negative_advisory_cache`, `osv_client`) inside `LanguageServer::initialize`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reconfigure the advisory cache trio (`advisory_cache`,
+  `negative_advisory_cache`, `osv_client`) inside `LanguageServer::initialize`
+  once the LSP receives client settings. Previously the caches were built
+  from `Config::default()` at struct-construction time and never replaced,
+  so user overrides for `db_path`, `ttl_secs`, `negative_ttl_secs`, or
+  `enabled` had no runtime effect even though the wiring through
+  `HybridAdvisoryCache::from_config` itself was correct
+  ([#237](https://github.com/mpiton/zed-dependi/issues/237))
+- Create parent directories for a user-supplied `AdvisoryCacheConfig.db_path`
+  before opening SQLite. Without this, a nested override silently degraded
+  to the in-memory layer because `SqliteConnectionManager` could not find
+  the directory ([#237](https://github.com/mpiton/zed-dependi/issues/237))
+- Drop writes when the advisory memory cache is configured with a zero TTL
+  (i.e. `enabled = false`). Previously disabled-cache mode still inserted
+  entries that were immediately expired but kept occupying memory until
+  the cleanup task ran ([#237](https://github.com/mpiton/zed-dependi/issues/237))
+- Offload `MemoryAdvisoryCache::cleanup_expired` from the cleanup loop
+  through `tokio::task::spawn_blocking` so a `DashMap::retain` over a very
+  large cache cannot stall the runtime
+  ([#237](https://github.com/mpiton/zed-dependi/issues/237))
+- Replace the flaky unwritable-path advisory cache test with a deterministic
+  blocker file inside a `tempdir`, removing the dependency on
+  `/this/path/should/not/exist/...` succeeding to fail
+  ([#237](https://github.com/mpiton/zed-dependi/issues/237))
+- Isolate the advisory cache wiring smoke test behind a `tempdir`-scoped
+  `db_path` so a previously persisted `RUSTSEC-2020-0036` row in the user's
+  default cache cannot turn the miss assertion into a flake
+  ([#237](https://github.com/mpiton/zed-dependi/issues/237))
 - Wire `AdvisoryCacheConfig` through `HybridAdvisoryCache::from_config` so
   user settings (`enabled`, `ttl_secs`, `negative_ttl_secs`, `db_path`)
   actually take effect; previously the backend instantiated the cache via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Cache RustSec advisory details fetched from OSV.dev with a hybrid
+  memory + SQLite layer. `check_rustsec_unmaintained` now consults the
+  cache before issuing per-advisory `GET /vulns/{id}` requests, with a
+  24-hour TTL for found advisories and a 1-hour TTL for negative entries
+  (404 from OSV). The cache lives in a separate SQLite database
+  (`~/.cache/dependi/advisory_cache.db`) and is configurable via the new
+  `AdvisoryCacheConfig`. Drastically reduces redundant network requests
+  during repeated Rust dependency scans
+  ([#237](https://github.com/mpiton/zed-dependi/issues/237))
 - `Ignore package "<name>"` quick-fix code action on every dependency. Adds
   the package to `lsp.dependi.initialization_options.ignore` in the workspace
   `.zed/settings.json`, creating the file if it does not exist, deduplicating

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Abort the previous advisory cache cleanup tasks when `initialize` rebuilds
+  the runtime, instead of leaking them. `spawn_default_cleanup_task` now
+  returns the `JoinHandle`, the backend tracks the handles in a `Mutex`, and
+  reconfiguration drains-and-aborts before installing the new caches; without
+  this the old tasks kept ticking forever holding `Arc` clones of the
+  replaced memory/SQLite layers
+  ([#237](https://github.com/mpiton/zed-dependi/issues/237))
+- Stop panicking when the OSV `reqwest` builder fails at startup. The new
+  `OsvClient::with_default_client_and_caches` infallible fallback uses
+  `reqwest::Client::new()` and keeps the cache wiring intact, so the LSP
+  can keep serving non-vulnerability features instead of crashing during
+  `with_http_client` ([#237](https://github.com/mpiton/zed-dependi/issues/237))
 - Reconfigure the advisory cache trio (`advisory_cache`,
   `negative_advisory_cache`, `osv_client`) inside `LanguageServer::initialize`
   once the LSP receives client settings. Previously the caches were built

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -511,6 +511,7 @@ name = "dependi-lsp"
 version = "1.7.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "clap",
  "criterion",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -38,6 +38,7 @@ taplo = "0.14"
 hashbrown = { version = "0.17.0", features = ["serde"] }
 quick-xml = "0.38"
 url = "2.5"
+async-trait = "0.1"
 
 [dev-dependencies]
 serial_test = "3"

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -870,6 +870,14 @@ pub struct DependiBackend {
     /// Vulnerability scanning
     osv_client: Arc<OsvClient>,
     vuln_cache: Arc<VulnerabilityCache>,
+    /// RustSec advisory cache (issue #237).
+    ///
+    /// Held on the struct so the background cleanup task spawned by
+    /// `HybridAdvisoryCache::spawn_default_cleanup_task` keeps a strong
+    /// reference to the underlying memory/SQLite layers for the lifetime of
+    /// the backend. Exposed via [`DependiBackend::advisory_cache`] for tests
+    /// and observability.
+    advisory_cache: Arc<crate::cache::HybridAdvisoryCache>,
     /// Per-(ecosystem, name, version) transitive vuln data.
     /// Populated during fresh OSV queries for transitive packages; read on cached re-attribution
     /// so subsequent document opens can still attribute transitives to their direct parents.
@@ -922,6 +930,23 @@ impl DependiBackend {
         // Create token provider manager for centralized auth management
         let token_manager = Arc::new(TokenProviderManager::new());
 
+        // Build the RustSec advisory cache (issue #237) and spawn its
+        // background cleanup task. The Arc is held on the struct so the
+        // spawned task keeps a strong reference to the cache layers.
+        let advisory_cache = Arc::new(crate::cache::HybridAdvisoryCache::new());
+        advisory_cache.spawn_default_cleanup_task();
+        let osv_client = match OsvClient::new_with_cache(
+            Arc::clone(&advisory_cache) as Arc<dyn crate::cache::AdvisoryWriteCache>
+        ) {
+            Ok(client) => Arc::new(client),
+            Err(err) => {
+                tracing::warn!(
+                    "OsvClient init with advisory cache failed ({err}); falling back to default"
+                );
+                Arc::new(OsvClient::default())
+            }
+        };
+
         Self {
             client,
             config: Arc::new(RwLock::new(config)),
@@ -948,13 +973,23 @@ impl DependiBackend {
             maven_central,
             http_client,
             token_manager,
-            osv_client: Arc::new(OsvClient::default()),
+            osv_client,
             vuln_cache: Arc::new(VulnerabilityCache::new()),
+            advisory_cache,
             transitive_vuln_data: Arc::new(DashMap::new()),
             debounce_tasks: Arc::new(DashMap::new()),
             debounce_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             pending_changes: Arc::new(DashMap::new()),
         }
+    }
+
+    /// Read access to the advisory cache (issue #237).
+    ///
+    /// Used by integration tests and observability tooling. Returns the
+    /// hybrid memory+SQLite cache that `OsvClient` consults before issuing
+    /// HTTP requests for individual RustSec advisories.
+    pub fn advisory_cache(&self) -> &Arc<crate::cache::HybridAdvisoryCache> {
+        &self.advisory_cache
     }
 
     fn create_processing_context(&self) -> ProcessingContext {

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -930,10 +930,15 @@ impl DependiBackend {
         // Create token provider manager for centralized auth management
         let token_manager = Arc::new(TokenProviderManager::new());
 
-        // Build the RustSec advisory cache (issue #237) and spawn its
-        // background cleanup task. The Arc is held on the struct so the
-        // spawned task keeps a strong reference to the cache layers.
-        let advisory_cache = Arc::new(crate::cache::HybridAdvisoryCache::new());
+        // Build the RustSec advisory cache (issue #237) from configuration
+        // and spawn its background cleanup task. The Arc is held on the
+        // struct so the spawned task keeps a strong reference to the cache
+        // layers. When `advisory_cache.enabled = false`, `from_config`
+        // returns a zero-TTL hybrid that always misses — so we keep a
+        // single concrete field type and avoid downstream branching.
+        let advisory_cache = Arc::new(crate::cache::HybridAdvisoryCache::from_config(
+            &config.advisory_cache,
+        ));
         advisory_cache.spawn_default_cleanup_task();
         let osv_client = match OsvClient::new_with_cache(
             Arc::clone(&advisory_cache) as Arc<dyn crate::cache::AdvisoryWriteCache>

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -819,6 +819,38 @@ impl ProcessingContext {
     }
 }
 
+/// Build the trio of cache layers and the OSV client that the LSP backend
+/// uses for RustSec advisory lookups, configured from
+/// [`crate::config::AdvisoryCacheConfig`].
+///
+/// Extracted as a free function so [`DependiBackend::with_http_client`] and
+/// [`DependiBackend::initialize`] share one construction path. Keeping the
+/// helper isolated also makes the configuration wiring testable without
+/// instantiating an LSP `Client`.
+fn build_advisory_runtime(
+    config: &crate::config::AdvisoryCacheConfig,
+) -> anyhow::Result<(
+    Arc<crate::cache::HybridAdvisoryCache>,
+    Arc<crate::cache::HybridAdvisoryCache>,
+    Arc<OsvClient>,
+)> {
+    let advisory_cache = Arc::new(crate::cache::HybridAdvisoryCache::from_config(config));
+    advisory_cache.spawn_default_cleanup_task();
+    let negative_advisory_cache = Arc::new(
+        crate::cache::HybridAdvisoryCache::negative_from_config(config),
+    );
+    negative_advisory_cache.spawn_default_cleanup_task();
+    let osv_client = OsvClient::new_with_caches(
+        Arc::clone(&advisory_cache) as Arc<dyn crate::cache::AdvisoryWriteCache>,
+        Arc::clone(&negative_advisory_cache) as Arc<dyn crate::cache::AdvisoryWriteCache>,
+    )?;
+    Ok((
+        advisory_cache,
+        negative_advisory_cache,
+        Arc::new(osv_client),
+    ))
+}
+
 /// Context passed to the background vulnerability fetch task so it can write
 /// per-document transitive attribution after the OSV query completes.
 struct VulnBgContext {
@@ -867,24 +899,28 @@ pub struct DependiBackend {
     http_client: Arc<HttpClient>,
     /// Token provider manager for authentication across all ecosystems
     token_manager: Arc<TokenProviderManager>,
-    /// Vulnerability scanning
-    osv_client: Arc<OsvClient>,
+    /// Vulnerability scanning. Wrapped in `RwLock` so [`Self::initialize`]
+    /// can swap the client to one wired with caches built from the user's
+    /// `AdvisoryCacheConfig` once the LSP receives client settings.
+    osv_client: Arc<tokio::sync::RwLock<Arc<OsvClient>>>,
     vuln_cache: Arc<VulnerabilityCache>,
     /// RustSec advisory cache (issue #237).
     ///
     /// Held on the struct so the background cleanup task spawned by
     /// `HybridAdvisoryCache::spawn_default_cleanup_task` keeps a strong
     /// reference to the underlying memory/SQLite layers for the lifetime of
-    /// the backend. Exposed via [`DependiBackend::advisory_cache`] for tests
-    /// and observability.
-    advisory_cache: Arc<crate::cache::HybridAdvisoryCache>,
+    /// the backend. Wrapped in `RwLock` so [`Self::initialize`] can swap in
+    /// a cache built from the user's `AdvisoryCacheConfig`. Exposed via
+    /// [`DependiBackend::advisory_cache`] for tests and observability.
+    advisory_cache: Arc<tokio::sync::RwLock<Arc<crate::cache::HybridAdvisoryCache>>>,
     /// Negative RustSec advisory cache (issue #237).
     ///
     /// Same shape as [`Self::advisory_cache`] but with `negative_ttl_secs`
     /// and no SQLite layer — 404 entries should not be persisted across
     /// LSP sessions. Held on the struct so the spawned cleanup task can
-    /// keep strong references.
-    negative_advisory_cache: Arc<crate::cache::HybridAdvisoryCache>,
+    /// keep strong references. Wrapped in `RwLock` for the same
+    /// reconfiguration reason as `advisory_cache`.
+    negative_advisory_cache: Arc<tokio::sync::RwLock<Arc<crate::cache::HybridAdvisoryCache>>>,
     /// Per-(ecosystem, name, version) transitive vuln data.
     /// Populated during fresh OSV queries for transitive packages; read on cached re-attribution
     /// so subsequent document opens can still attribute transitives to their direct parents.
@@ -937,34 +973,15 @@ impl DependiBackend {
         // Create token provider manager for centralized auth management
         let token_manager = Arc::new(TokenProviderManager::new());
 
-        // Build the RustSec advisory caches (issue #237) from configuration
-        // and spawn their background cleanup tasks. Two separate caches:
-        // - `advisory_cache` holds positive `Found` entries with `ttl_secs`.
-        // - `negative_advisory_cache` holds 404 entries with the shorter
-        //   `negative_ttl_secs`, memory-only because short-TTL entries do
-        //   not need cross-session persistence.
-        // Each Arc is kept on the struct so the spawned cleanup tasks have
-        // strong references for the lifetime of the backend.
-        let advisory_cache = Arc::new(crate::cache::HybridAdvisoryCache::from_config(
-            &config.advisory_cache,
-        ));
-        advisory_cache.spawn_default_cleanup_task();
-        let negative_advisory_cache = Arc::new(
-            crate::cache::HybridAdvisoryCache::negative_from_config(&config.advisory_cache),
-        );
-        negative_advisory_cache.spawn_default_cleanup_task();
-        let osv_client = match OsvClient::new_with_caches(
-            Arc::clone(&advisory_cache) as Arc<dyn crate::cache::AdvisoryWriteCache>,
-            Arc::clone(&negative_advisory_cache) as Arc<dyn crate::cache::AdvisoryWriteCache>,
-        ) {
-            Ok(client) => Arc::new(client),
-            Err(err) => {
-                tracing::warn!(
-                    "OsvClient init with advisory cache failed ({err}); falling back to default"
-                );
-                Arc::new(OsvClient::default())
-            }
-        };
+        // Build the RustSec advisory caches (issue #237) from defaults so the
+        // backend has a working OsvClient even before `initialize` arrives.
+        // The trio is wrapped in RwLock and replaced in `initialize` once the
+        // user's `AdvisoryCacheConfig` is parsed; otherwise client overrides
+        // (custom `db_path`, custom TTLs, `enabled = false`) would never take
+        // effect because the LSP cannot see them at struct-construction time.
+        let (advisory_cache, negative_advisory_cache, osv_client) =
+            build_advisory_runtime(&config.advisory_cache)
+                .expect("Failed to build advisory cache runtime at startup");
 
         Self {
             client,
@@ -992,10 +1009,10 @@ impl DependiBackend {
             maven_central,
             http_client,
             token_manager,
-            osv_client,
+            osv_client: Arc::new(tokio::sync::RwLock::new(osv_client)),
             vuln_cache: Arc::new(VulnerabilityCache::new()),
-            advisory_cache,
-            negative_advisory_cache,
+            advisory_cache: Arc::new(tokio::sync::RwLock::new(advisory_cache)),
+            negative_advisory_cache: Arc::new(tokio::sync::RwLock::new(negative_advisory_cache)),
             transitive_vuln_data: Arc::new(DashMap::new()),
             debounce_tasks: Arc::new(DashMap::new()),
             debounce_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -1007,19 +1024,21 @@ impl DependiBackend {
     ///
     /// Used by integration tests and observability tooling. Returns the
     /// hybrid memory+SQLite cache that `OsvClient` consults before issuing
-    /// HTTP requests for individual RustSec advisories.
-    pub fn advisory_cache(&self) -> &Arc<crate::cache::HybridAdvisoryCache> {
-        &self.advisory_cache
+    /// HTTP requests for individual RustSec advisories. Async because the
+    /// underlying handle is now wrapped in a `RwLock` to support runtime
+    /// reconfiguration in `initialize`.
+    pub async fn advisory_cache(&self) -> Arc<crate::cache::HybridAdvisoryCache> {
+        Arc::clone(&*self.advisory_cache.read().await)
     }
 
     /// Read access to the negative advisory cache (issue #237).
     ///
     /// Used by integration tests to inspect 404 caching state.
-    pub fn negative_advisory_cache(&self) -> &Arc<crate::cache::HybridAdvisoryCache> {
-        &self.negative_advisory_cache
+    pub async fn negative_advisory_cache(&self) -> Arc<crate::cache::HybridAdvisoryCache> {
+        Arc::clone(&*self.negative_advisory_cache.read().await)
     }
 
-    fn create_processing_context(&self) -> ProcessingContext {
+    async fn create_processing_context(&self) -> ProcessingContext {
         ProcessingContext {
             client: self.client.clone(),
             config: Arc::clone(&self.config),
@@ -1044,7 +1063,7 @@ impl DependiBackend {
             nuget: Arc::clone(&self.nuget),
             rubygems: Arc::clone(&self.rubygems),
             maven_central: Arc::clone(&self.maven_central),
-            osv_client: Arc::clone(&self.osv_client),
+            osv_client: Arc::clone(&*self.osv_client.read().await),
             vuln_cache: Arc::clone(&self.vuln_cache),
             transitive_vuln_data: Arc::clone(&self.transitive_vuln_data),
         }
@@ -1458,6 +1477,7 @@ impl DependiBackend {
 
     async fn process_document(&self, uri: &Url, content: &str) {
         self.create_processing_context()
+            .await
             .process_document(uri, content)
             .await;
     }
@@ -1789,6 +1809,30 @@ impl LanguageServer for DependiBackend {
             );
         }
 
+        // Reconfigure the RustSec advisory cache trio (issue #237). The
+        // backend was constructed with `Config::default()` because the LSP
+        // protocol delivers client settings only at `initialize` time, so
+        // user overrides for `db_path`, TTLs, or `enabled` would otherwise
+        // never take effect.
+        match build_advisory_runtime(&config.advisory_cache) {
+            Ok((new_cache, new_neg, new_osv)) => {
+                *self.advisory_cache.write().await = new_cache;
+                *self.negative_advisory_cache.write().await = new_neg;
+                *self.osv_client.write().await = new_osv;
+                tracing::info!(
+                    "Advisory cache reconfigured from client settings (enabled={}, ttl_secs={}, negative_ttl_secs={})",
+                    config.advisory_cache.enabled,
+                    config.advisory_cache.ttl_secs,
+                    config.advisory_cache.negative_ttl_secs
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "Advisory cache reconfiguration failed ({err}); keeping startup defaults"
+                );
+            }
+        }
+
         // Store the configuration
         if let Ok(mut cfg) = self.config.write() {
             *cfg = config;
@@ -1886,7 +1930,7 @@ impl LanguageServer for DependiBackend {
                 .unwrap_or(200);
 
             // Create processing context for the spawned task
-            let ctx = self.create_processing_context();
+            let ctx = self.create_processing_context().await;
             let uri_clone = uri.clone();
             let content = change.text;
             let pending_changes = Arc::clone(&self.pending_changes);
@@ -2379,6 +2423,43 @@ mod tests {
         assert!(
             found.is_none(),
             "expected None when no ancestor has .zed/, got {found:?}"
+        );
+    }
+
+    /// Regression for issue #237 reviewer finding: `AdvisoryCacheConfig` must
+    /// flow through to the SQLite layer instead of being locked to defaults.
+    /// We point the helper at a custom `db_path` and verify the file appears
+    /// after a write — proof that the user's config was honoured end-to-end.
+    #[tokio::test]
+    async fn build_advisory_runtime_honors_custom_db_path() {
+        use crate::cache::{AdvisoryKind, AdvisoryWriteCache, CachedAdvisory};
+        use crate::config::AdvisoryCacheConfig;
+        use std::time::SystemTime;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp.path().join("nested").join("custom.db");
+        let config = AdvisoryCacheConfig {
+            enabled: true,
+            ttl_secs: 60,
+            negative_ttl_secs: 30,
+            db_path: Some(db_path.clone()),
+        };
+
+        let (cache, _neg, _osv) = super::build_advisory_runtime(&config).expect("runtime builds");
+        cache
+            .insert(CachedAdvisory {
+                id: "RUSTSEC-2020-0036".into(),
+                kind: AdvisoryKind::Found {
+                    summary: None,
+                    unmaintained: false,
+                },
+                fetched_at: SystemTime::now(),
+            })
+            .await;
+
+        assert!(
+            db_path.exists(),
+            "custom db_path {db_path:?} was not honoured by the helper"
         );
     }
 }

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -819,36 +819,61 @@ impl ProcessingContext {
     }
 }
 
-/// Build the trio of cache layers and the OSV client that the LSP backend
-/// uses for RustSec advisory lookups, configured from
-/// [`crate::config::AdvisoryCacheConfig`].
+/// The cache trio + OsvClient + cleanup-task handles produced by
+/// [`build_advisory_runtime`]. Returned together so callers can swap the
+/// runtime atomically and abort the previous cleanup tasks instead of
+/// leaking them.
+struct AdvisoryRuntime {
+    positive: Arc<crate::cache::HybridAdvisoryCache>,
+    negative: Arc<crate::cache::HybridAdvisoryCache>,
+    osv_client: Arc<OsvClient>,
+    cleanup_handles: Vec<tokio::task::JoinHandle<()>>,
+}
+
+/// Build the cache trio + OsvClient configured from
+/// [`crate::config::AdvisoryCacheConfig`] and spawn the cleanup tasks.
 ///
 /// Extracted as a free function so [`DependiBackend::with_http_client`] and
 /// [`DependiBackend::initialize`] share one construction path. Keeping the
 /// helper isolated also makes the configuration wiring testable without
 /// instantiating an LSP `Client`.
-fn build_advisory_runtime(
-    config: &crate::config::AdvisoryCacheConfig,
-) -> anyhow::Result<(
-    Arc<crate::cache::HybridAdvisoryCache>,
-    Arc<crate::cache::HybridAdvisoryCache>,
-    Arc<OsvClient>,
-)> {
-    let advisory_cache = Arc::new(crate::cache::HybridAdvisoryCache::from_config(config));
-    advisory_cache.spawn_default_cleanup_task();
-    let negative_advisory_cache = Arc::new(
-        crate::cache::HybridAdvisoryCache::negative_from_config(config),
-    );
-    negative_advisory_cache.spawn_default_cleanup_task();
-    let osv_client = OsvClient::new_with_caches(
-        Arc::clone(&advisory_cache) as Arc<dyn crate::cache::AdvisoryWriteCache>,
-        Arc::clone(&negative_advisory_cache) as Arc<dyn crate::cache::AdvisoryWriteCache>,
-    )?;
-    Ok((
-        advisory_cache,
-        negative_advisory_cache,
-        Arc::new(osv_client),
-    ))
+///
+/// Infallible: when the OSV `reqwest` builder fails (rare; happens if the
+/// platform cannot load native TLS roots), this falls back to
+/// `reqwest::Client::new()` instead of panicking. The caches are still wired
+/// to the same OSV client, so backend cache handles do not become orphaned.
+fn build_advisory_runtime(config: &crate::config::AdvisoryCacheConfig) -> AdvisoryRuntime {
+    let positive = Arc::new(crate::cache::HybridAdvisoryCache::from_config(config));
+    let h1 = positive.spawn_default_cleanup_task();
+    let negative = Arc::new(crate::cache::HybridAdvisoryCache::negative_from_config(
+        config,
+    ));
+    let h2 = negative.spawn_default_cleanup_task();
+
+    let positive_dyn = Arc::clone(&positive) as Arc<dyn crate::cache::AdvisoryWriteCache>;
+    let negative_dyn = Arc::clone(&negative) as Arc<dyn crate::cache::AdvisoryWriteCache>;
+    let osv_client = match OsvClient::new_with_caches(
+        Arc::clone(&positive_dyn),
+        Arc::clone(&negative_dyn),
+    ) {
+        Ok(client) => Arc::new(client),
+        Err(err) => {
+            tracing::warn!(
+                "OsvClient HTTP builder failed ({err}); falling back to default reqwest::Client. Vulnerability checks continue using the same caches."
+            );
+            Arc::new(OsvClient::with_default_client_and_caches(
+                positive_dyn,
+                negative_dyn,
+            ))
+        }
+    };
+
+    AdvisoryRuntime {
+        positive,
+        negative,
+        osv_client,
+        cleanup_handles: vec![h1, h2],
+    }
 }
 
 /// Context passed to the background vulnerability fetch task so it can write
@@ -921,6 +946,13 @@ pub struct DependiBackend {
     /// keep strong references. Wrapped in `RwLock` for the same
     /// reconfiguration reason as `advisory_cache`.
     negative_advisory_cache: Arc<tokio::sync::RwLock<Arc<crate::cache::HybridAdvisoryCache>>>,
+    /// `JoinHandle`s for the advisory cache cleanup tasks (issue #237).
+    ///
+    /// `initialize` rebuilds the advisory runtime and must abort the previous
+    /// cleanup tasks before installing the new caches; otherwise the old
+    /// tasks keep ticking forever holding `Arc` clones of the previous
+    /// memory/SQLite layers (a slow leak that grows on every reconfigure).
+    advisory_cleanup_handles: Arc<tokio::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>>,
     /// Per-(ecosystem, name, version) transitive vuln data.
     /// Populated during fresh OSV queries for transitive packages; read on cached re-attribution
     /// so subsequent document opens can still attribute transitives to their direct parents.
@@ -979,9 +1011,11 @@ impl DependiBackend {
         // user's `AdvisoryCacheConfig` is parsed; otherwise client overrides
         // (custom `db_path`, custom TTLs, `enabled = false`) would never take
         // effect because the LSP cannot see them at struct-construction time.
-        let (advisory_cache, negative_advisory_cache, osv_client) =
-            build_advisory_runtime(&config.advisory_cache)
-                .expect("Failed to build advisory cache runtime at startup");
+        let runtime = build_advisory_runtime(&config.advisory_cache);
+        let advisory_cache = runtime.positive;
+        let negative_advisory_cache = runtime.negative;
+        let osv_client = runtime.osv_client;
+        let advisory_cleanup_handles = runtime.cleanup_handles;
 
         Self {
             client,
@@ -1013,6 +1047,7 @@ impl DependiBackend {
             vuln_cache: Arc::new(VulnerabilityCache::new()),
             advisory_cache: Arc::new(tokio::sync::RwLock::new(advisory_cache)),
             negative_advisory_cache: Arc::new(tokio::sync::RwLock::new(negative_advisory_cache)),
+            advisory_cleanup_handles: Arc::new(tokio::sync::Mutex::new(advisory_cleanup_handles)),
             transitive_vuln_data: Arc::new(DashMap::new()),
             debounce_tasks: Arc::new(DashMap::new()),
             debounce_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -1813,25 +1848,26 @@ impl LanguageServer for DependiBackend {
         // backend was constructed with `Config::default()` because the LSP
         // protocol delivers client settings only at `initialize` time, so
         // user overrides for `db_path`, TTLs, or `enabled` would otherwise
-        // never take effect.
-        match build_advisory_runtime(&config.advisory_cache) {
-            Ok((new_cache, new_neg, new_osv)) => {
-                *self.advisory_cache.write().await = new_cache;
-                *self.negative_advisory_cache.write().await = new_neg;
-                *self.osv_client.write().await = new_osv;
-                tracing::info!(
-                    "Advisory cache reconfigured from client settings (enabled={}, ttl_secs={}, negative_ttl_secs={})",
-                    config.advisory_cache.enabled,
-                    config.advisory_cache.ttl_secs,
-                    config.advisory_cache.negative_ttl_secs
-                );
+        // never take effect. Abort the previous cleanup tasks before
+        // installing the new runtime; otherwise they keep ticking with
+        // strong references to the now-replaced caches (slow leak).
+        let new_runtime = build_advisory_runtime(&config.advisory_cache);
+        {
+            let mut handles = self.advisory_cleanup_handles.lock().await;
+            for handle in handles.drain(..) {
+                handle.abort();
             }
-            Err(err) => {
-                tracing::warn!(
-                    "Advisory cache reconfiguration failed ({err}); keeping startup defaults"
-                );
-            }
+            *handles = new_runtime.cleanup_handles;
         }
+        *self.advisory_cache.write().await = new_runtime.positive;
+        *self.negative_advisory_cache.write().await = new_runtime.negative;
+        *self.osv_client.write().await = new_runtime.osv_client;
+        tracing::info!(
+            "Advisory cache reconfigured from client settings (enabled={}, ttl_secs={}, negative_ttl_secs={})",
+            config.advisory_cache.enabled,
+            config.advisory_cache.ttl_secs,
+            config.advisory_cache.negative_ttl_secs
+        );
 
         // Store the configuration
         if let Ok(mut cfg) = self.config.write() {
@@ -2445,8 +2481,9 @@ mod tests {
             db_path: Some(db_path.clone()),
         };
 
-        let (cache, _neg, _osv) = super::build_advisory_runtime(&config).expect("runtime builds");
-        cache
+        let runtime = super::build_advisory_runtime(&config);
+        runtime
+            .positive
             .insert(CachedAdvisory {
                 id: "RUSTSEC-2020-0036".into(),
                 kind: AdvisoryKind::Found {
@@ -2461,5 +2498,11 @@ mod tests {
             db_path.exists(),
             "custom db_path {db_path:?} was not honoured by the helper"
         );
+
+        // Abort the cleanup tasks so dropping the tempdir does not leave them
+        // ticking on a stale advisory_cache.db path.
+        for handle in runtime.cleanup_handles {
+            handle.abort();
+        }
     }
 }

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -838,11 +838,15 @@ struct AdvisoryRuntime {
 /// helper isolated also makes the configuration wiring testable without
 /// instantiating an LSP `Client`.
 ///
-/// Infallible: when the OSV `reqwest` builder fails (rare; happens if the
-/// platform cannot load native TLS roots), this falls back to
-/// `reqwest::Client::new()` instead of panicking. The caches are still wired
-/// to the same OSV client, so backend cache handles do not become orphaned.
-fn build_advisory_runtime(config: &crate::config::AdvisoryCacheConfig) -> AdvisoryRuntime {
+/// Infallible: reuses the caller-supplied `reqwest::Client` (the LSP's
+/// shared HTTP client) instead of building a second one. The caller has
+/// already proven `reqwest` works on this platform, so this avoids a
+/// second TLS/builder failure point that previously forced the helper to
+/// either panic or fall back to the panicky `Client::new()`.
+fn build_advisory_runtime(
+    config: &crate::config::AdvisoryCacheConfig,
+    http_client: Arc<HttpClient>,
+) -> AdvisoryRuntime {
     let positive = Arc::new(crate::cache::HybridAdvisoryCache::from_config(config));
     let h1 = positive.spawn_default_cleanup_task();
     let negative = Arc::new(crate::cache::HybridAdvisoryCache::negative_from_config(
@@ -852,21 +856,11 @@ fn build_advisory_runtime(config: &crate::config::AdvisoryCacheConfig) -> Adviso
 
     let positive_dyn = Arc::clone(&positive) as Arc<dyn crate::cache::AdvisoryWriteCache>;
     let negative_dyn = Arc::clone(&negative) as Arc<dyn crate::cache::AdvisoryWriteCache>;
-    let osv_client = match OsvClient::new_with_caches(
-        Arc::clone(&positive_dyn),
-        Arc::clone(&negative_dyn),
-    ) {
-        Ok(client) => Arc::new(client),
-        Err(err) => {
-            tracing::warn!(
-                "OsvClient HTTP builder failed ({err}); falling back to default reqwest::Client. Vulnerability checks continue using the same caches."
-            );
-            Arc::new(OsvClient::with_default_client_and_caches(
-                positive_dyn,
-                negative_dyn,
-            ))
-        }
-    };
+    let osv_client = Arc::new(OsvClient::with_shared_client_and_caches(
+        http_client,
+        positive_dyn,
+        negative_dyn,
+    ));
 
     AdvisoryRuntime {
         positive,
@@ -1011,7 +1005,7 @@ impl DependiBackend {
         // user's `AdvisoryCacheConfig` is parsed; otherwise client overrides
         // (custom `db_path`, custom TTLs, `enabled = false`) would never take
         // effect because the LSP cannot see them at struct-construction time.
-        let runtime = build_advisory_runtime(&config.advisory_cache);
+        let runtime = build_advisory_runtime(&config.advisory_cache, Arc::clone(&http_client));
         let advisory_cache = runtime.positive;
         let negative_advisory_cache = runtime.negative;
         let osv_client = runtime.osv_client;
@@ -1851,7 +1845,8 @@ impl LanguageServer for DependiBackend {
         // never take effect. Abort the previous cleanup tasks before
         // installing the new runtime; otherwise they keep ticking with
         // strong references to the now-replaced caches (slow leak).
-        let new_runtime = build_advisory_runtime(&config.advisory_cache);
+        let new_runtime =
+            build_advisory_runtime(&config.advisory_cache, Arc::clone(&self.http_client));
         {
             let mut handles = self.advisory_cleanup_handles.lock().await;
             for handle in handles.drain(..) {
@@ -2481,7 +2476,9 @@ mod tests {
             db_path: Some(db_path.clone()),
         };
 
-        let runtime = super::build_advisory_runtime(&config);
+        let http_client = crate::registries::http_client::create_shared_client()
+            .expect("shared client builds in test");
+        let runtime = super::build_advisory_runtime(&config, http_client);
         runtime
             .positive
             .insert(CachedAdvisory {

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -878,6 +878,13 @@ pub struct DependiBackend {
     /// the backend. Exposed via [`DependiBackend::advisory_cache`] for tests
     /// and observability.
     advisory_cache: Arc<crate::cache::HybridAdvisoryCache>,
+    /// Negative RustSec advisory cache (issue #237).
+    ///
+    /// Same shape as [`Self::advisory_cache`] but with `negative_ttl_secs`
+    /// and no SQLite layer — 404 entries should not be persisted across
+    /// LSP sessions. Held on the struct so the spawned cleanup task can
+    /// keep strong references.
+    negative_advisory_cache: Arc<crate::cache::HybridAdvisoryCache>,
     /// Per-(ecosystem, name, version) transitive vuln data.
     /// Populated during fresh OSV queries for transitive packages; read on cached re-attribution
     /// so subsequent document opens can still attribute transitives to their direct parents.
@@ -930,18 +937,25 @@ impl DependiBackend {
         // Create token provider manager for centralized auth management
         let token_manager = Arc::new(TokenProviderManager::new());
 
-        // Build the RustSec advisory cache (issue #237) from configuration
-        // and spawn its background cleanup task. The Arc is held on the
-        // struct so the spawned task keeps a strong reference to the cache
-        // layers. When `advisory_cache.enabled = false`, `from_config`
-        // returns a zero-TTL hybrid that always misses — so we keep a
-        // single concrete field type and avoid downstream branching.
+        // Build the RustSec advisory caches (issue #237) from configuration
+        // and spawn their background cleanup tasks. Two separate caches:
+        // - `advisory_cache` holds positive `Found` entries with `ttl_secs`.
+        // - `negative_advisory_cache` holds 404 entries with the shorter
+        //   `negative_ttl_secs`, memory-only because short-TTL entries do
+        //   not need cross-session persistence.
+        // Each Arc is kept on the struct so the spawned cleanup tasks have
+        // strong references for the lifetime of the backend.
         let advisory_cache = Arc::new(crate::cache::HybridAdvisoryCache::from_config(
             &config.advisory_cache,
         ));
         advisory_cache.spawn_default_cleanup_task();
-        let osv_client = match OsvClient::new_with_cache(
-            Arc::clone(&advisory_cache) as Arc<dyn crate::cache::AdvisoryWriteCache>
+        let negative_advisory_cache = Arc::new(
+            crate::cache::HybridAdvisoryCache::negative_from_config(&config.advisory_cache),
+        );
+        negative_advisory_cache.spawn_default_cleanup_task();
+        let osv_client = match OsvClient::new_with_caches(
+            Arc::clone(&advisory_cache) as Arc<dyn crate::cache::AdvisoryWriteCache>,
+            Arc::clone(&negative_advisory_cache) as Arc<dyn crate::cache::AdvisoryWriteCache>,
         ) {
             Ok(client) => Arc::new(client),
             Err(err) => {
@@ -981,6 +995,7 @@ impl DependiBackend {
             osv_client,
             vuln_cache: Arc::new(VulnerabilityCache::new()),
             advisory_cache,
+            negative_advisory_cache,
             transitive_vuln_data: Arc::new(DashMap::new()),
             debounce_tasks: Arc::new(DashMap::new()),
             debounce_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -995,6 +1010,13 @@ impl DependiBackend {
     /// HTTP requests for individual RustSec advisories.
     pub fn advisory_cache(&self) -> &Arc<crate::cache::HybridAdvisoryCache> {
         &self.advisory_cache
+    }
+
+    /// Read access to the negative advisory cache (issue #237).
+    ///
+    /// Used by integration tests to inspect 404 caching state.
+    pub fn negative_advisory_cache(&self) -> &Arc<crate::cache::HybridAdvisoryCache> {
+        &self.negative_advisory_cache
     }
 
     fn create_processing_context(&self) -> ProcessingContext {

--- a/dependi-lsp/src/cache/advisory/memory.rs
+++ b/dependi-lsp/src/cache/advisory/memory.rs
@@ -53,6 +53,27 @@ impl MemoryAdvisoryCache {
             ttl,
         }
     }
+
+    /// The configured TTL applied to fresh inserts.
+    pub fn ttl(&self) -> Duration {
+        self.ttl
+    }
+
+    /// Insert with an explicit TTL instead of the cache-wide default.
+    ///
+    /// Used by [`super::HybridAdvisoryCache`] when backfilling the L1 layer
+    /// from an L2 hit so that an entry near SQLite expiry does not gain a
+    /// fresh full-length TTL by being read.
+    pub async fn insert_with_remaining_ttl(&self, advisory: CachedAdvisory, remaining: Duration) {
+        self.entries.insert(
+            advisory.id.clone(),
+            MemoryAdvisoryEntry {
+                advisory,
+                inserted_at: Instant::now(),
+                ttl: remaining,
+            },
+        );
+    }
 }
 
 #[async_trait]
@@ -230,6 +251,27 @@ mod tests {
         assert_eq!(removed, 1);
         assert!(cache.get("RUSTSEC-2020-0036").await.is_none());
         assert!(cache.get("RUSTSEC-9999-0001").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn ttl_getter_returns_configured_ttl() {
+        let cache = MemoryAdvisoryCache::with_ttl(Duration::from_secs(1234));
+        assert_eq!(cache.ttl(), Duration::from_secs(1234));
+        let default_cache = MemoryAdvisoryCache::new();
+        assert_eq!(default_cache.ttl(), DEFAULT_ADVISORY_TTL);
+    }
+
+    #[tokio::test]
+    async fn insert_with_remaining_ttl_uses_explicit_value_not_default() {
+        let cache = MemoryAdvisoryCache::with_ttl(Duration::from_secs(60));
+        cache
+            .insert_with_remaining_ttl(sample_found(), Duration::from_millis(20))
+            .await;
+        // The entry must respect the *short* explicit TTL, not the 60-second
+        // default, otherwise backfill would silently extend SQLite TTLs.
+        assert!(cache.get("RUSTSEC-2020-0036").await.is_some());
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        assert!(cache.get("RUSTSEC-2020-0036").await.is_none());
     }
 
     #[tokio::test]

--- a/dependi-lsp/src/cache/advisory/memory.rs
+++ b/dependi-lsp/src/cache/advisory/memory.rs
@@ -114,4 +114,46 @@ mod tests {
         let cache = MemoryAdvisoryCache::new();
         assert!(cache.get("RUSTSEC-9999-9999").await.is_none());
     }
+
+    fn sample_not_found(id: &str) -> CachedAdvisory {
+        CachedAdvisory {
+            id: id.to_string(),
+            kind: AdvisoryKind::NotFound,
+            fetched_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    #[tokio::test]
+    async fn second_insert_overwrites_first() {
+        let cache = MemoryAdvisoryCache::new();
+        cache.insert(sample_found()).await;
+        let replacement = CachedAdvisory {
+            id: "RUSTSEC-2020-0036".to_string(),
+            kind: AdvisoryKind::Found {
+                summary: None,
+                unmaintained: false,
+            },
+            fetched_at: SystemTime::UNIX_EPOCH,
+        };
+        cache.insert(replacement.clone()).await;
+        assert_eq!(cache.get(&replacement.id).await, Some(replacement));
+    }
+
+    #[tokio::test]
+    async fn remove_deletes_entry() {
+        let cache = MemoryAdvisoryCache::new();
+        cache.insert(sample_found()).await;
+        cache.remove("RUSTSEC-2020-0036").await;
+        assert!(cache.get("RUSTSEC-2020-0036").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn clear_empties_cache() {
+        let cache = MemoryAdvisoryCache::new();
+        cache.insert(sample_found()).await;
+        cache.insert(sample_not_found("RUSTSEC-9999-0001")).await;
+        cache.clear().await;
+        assert!(cache.get("RUSTSEC-2020-0036").await.is_none());
+        assert!(cache.get("RUSTSEC-9999-0001").await.is_none());
+    }
 }

--- a/dependi-lsp/src/cache/advisory/memory.rs
+++ b/dependi-lsp/src/cache/advisory/memory.rs
@@ -65,6 +65,9 @@ impl MemoryAdvisoryCache {
     /// from an L2 hit so that an entry near SQLite expiry does not gain a
     /// fresh full-length TTL by being read.
     pub async fn insert_with_remaining_ttl(&self, advisory: CachedAdvisory, remaining: Duration) {
+        if remaining.is_zero() {
+            return;
+        }
         self.entries.insert(
             advisory.id.clone(),
             MemoryAdvisoryEntry {
@@ -88,6 +91,12 @@ impl AdvisoryReadCache for MemoryAdvisoryCache {
 #[async_trait]
 impl AdvisoryWriteCache for MemoryAdvisoryCache {
     async fn insert(&self, advisory: CachedAdvisory) {
+        // A zero TTL marks the cache as disabled — drop writes so disabled
+        // mode does not accumulate entries that are immediately expired but
+        // still occupy memory until cleanup runs.
+        if self.ttl.is_zero() {
+            return;
+        }
         self.entries.insert(
             advisory.id.clone(),
             MemoryAdvisoryEntry {

--- a/dependi-lsp/src/cache/advisory/memory.rs
+++ b/dependi-lsp/src/cache/advisory/memory.rs
@@ -83,6 +83,46 @@ impl AdvisoryWriteCache for MemoryAdvisoryCache {
     }
 }
 
+impl MemoryAdvisoryCache {
+    /// Remove every expired entry. Returns the number of entries removed.
+    pub fn cleanup_expired(&self) -> usize {
+        let before = self.entries.len();
+        self.entries.retain(|_, entry| !entry.is_expired());
+        before.saturating_sub(self.entries.len())
+    }
+
+    /// Snapshot statistics about the cache.
+    pub fn stats(&self) -> AdvisoryCacheStats {
+        let total = self.entries.len();
+        let expired = self.entries.iter().filter(|e| e.is_expired()).count();
+        AdvisoryCacheStats {
+            total,
+            expired,
+            valid: total.saturating_sub(expired),
+        }
+    }
+
+    /// Test-only length accessor.
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Test-only emptiness check.
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Snapshot statistics for an advisory cache.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AdvisoryCacheStats {
+    pub total: usize,
+    pub expired: usize,
+    pub valid: usize,
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::SystemTime;
@@ -174,5 +214,33 @@ mod tests {
             summary: Some("unmaintained".to_string()),
             unmaintained: true,
         }));
+    }
+
+    #[tokio::test]
+    async fn cleanup_expired_removes_only_expired_entries() {
+        let cache = MemoryAdvisoryCache::with_ttl(Duration::from_millis(20));
+        cache.insert(sample_found()).await;
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        cache.insert(sample_not_found("RUSTSEC-9999-0001")).await;
+
+        let removed = cache.cleanup_expired();
+        assert_eq!(removed, 1);
+        assert!(cache.get("RUSTSEC-2020-0036").await.is_none());
+        assert!(cache.get("RUSTSEC-9999-0001").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn stats_report_total_expired_and_valid() {
+        let cache = MemoryAdvisoryCache::with_ttl(Duration::from_millis(20));
+        cache.insert(sample_found()).await;
+        let before = cache.stats();
+        assert_eq!(before.total, 1);
+        assert_eq!(before.expired, 0);
+        assert_eq!(before.valid, 1);
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        let after = cache.stats();
+        assert_eq!(after.total, 1);
+        assert_eq!(after.expired, 1);
+        assert_eq!(after.valid, 0);
     }
 }

--- a/dependi-lsp/src/cache/advisory/memory.rs
+++ b/dependi-lsp/src/cache/advisory/memory.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
 use dashmap::DashMap;
 
 use super::{AdvisoryReadCache, AdvisoryWriteCache, CachedAdvisory};
@@ -54,6 +55,7 @@ impl MemoryAdvisoryCache {
     }
 }
 
+#[async_trait]
 impl AdvisoryReadCache for MemoryAdvisoryCache {
     async fn get(&self, advisory_id: &str) -> Option<CachedAdvisory> {
         self.entries
@@ -62,6 +64,7 @@ impl AdvisoryReadCache for MemoryAdvisoryCache {
     }
 }
 
+#[async_trait]
 impl AdvisoryWriteCache for MemoryAdvisoryCache {
     async fn insert(&self, advisory: CachedAdvisory) {
         self.entries.insert(

--- a/dependi-lsp/src/cache/advisory/memory.rs
+++ b/dependi-lsp/src/cache/advisory/memory.rs
@@ -1,0 +1,1 @@
+//! In-memory advisory cache (L1 layer).

--- a/dependi-lsp/src/cache/advisory/memory.rs
+++ b/dependi-lsp/src/cache/advisory/memory.rs
@@ -156,4 +156,23 @@ mod tests {
         assert!(cache.get("RUSTSEC-2020-0036").await.is_none());
         assert!(cache.get("RUSTSEC-9999-0001").await.is_none());
     }
+
+    #[tokio::test]
+    async fn expired_entry_is_treated_as_missing() {
+        let cache = MemoryAdvisoryCache::with_ttl(Duration::from_millis(5));
+        cache.insert(sample_found()).await;
+        tokio::time::sleep(Duration::from_millis(15)).await;
+        assert!(cache.get("RUSTSEC-2020-0036").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn fresh_entry_is_returned_before_expiry() {
+        let cache = MemoryAdvisoryCache::with_ttl(Duration::from_millis(200));
+        cache.insert(sample_found()).await;
+        let value = cache.get("RUSTSEC-2020-0036").await;
+        assert!(matches!(value, Some(c) if c.kind == AdvisoryKind::Found {
+            summary: Some("unmaintained".to_string()),
+            unmaintained: true,
+        }));
+    }
 }

--- a/dependi-lsp/src/cache/advisory/memory.rs
+++ b/dependi-lsp/src/cache/advisory/memory.rs
@@ -1,1 +1,117 @@
-//! In-memory advisory cache (L1 layer).
+//! In-memory advisory cache (L1 layer) backed by [`DashMap`].
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+
+use super::{AdvisoryReadCache, AdvisoryWriteCache, CachedAdvisory};
+
+/// Default TTL for cached advisory entries (24 hours).
+pub const DEFAULT_ADVISORY_TTL: Duration = Duration::from_secs(86_400);
+
+#[derive(Clone, Debug)]
+struct MemoryAdvisoryEntry {
+    advisory: CachedAdvisory,
+    inserted_at: Instant,
+    ttl: Duration,
+}
+
+impl MemoryAdvisoryEntry {
+    fn is_expired(&self) -> bool {
+        self.inserted_at.elapsed() > self.ttl
+    }
+}
+
+/// Thread-safe, in-memory advisory cache built on a [`DashMap`].
+#[derive(Clone)]
+pub struct MemoryAdvisoryCache {
+    entries: Arc<DashMap<String, MemoryAdvisoryEntry>>,
+    ttl: Duration,
+}
+
+impl Default for MemoryAdvisoryCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MemoryAdvisoryCache {
+    /// Build a cache with the default 24-hour TTL.
+    pub fn new() -> Self {
+        Self {
+            entries: Arc::new(DashMap::new()),
+            ttl: DEFAULT_ADVISORY_TTL,
+        }
+    }
+
+    /// Build a cache with a custom TTL (used by tests and for negative caching).
+    pub fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            entries: Arc::new(DashMap::new()),
+            ttl,
+        }
+    }
+}
+
+impl AdvisoryReadCache for MemoryAdvisoryCache {
+    async fn get(&self, advisory_id: &str) -> Option<CachedAdvisory> {
+        self.entries
+            .get(advisory_id)
+            .and_then(|entry| (!entry.is_expired()).then(|| entry.advisory.clone()))
+    }
+}
+
+impl AdvisoryWriteCache for MemoryAdvisoryCache {
+    async fn insert(&self, advisory: CachedAdvisory) {
+        self.entries.insert(
+            advisory.id.clone(),
+            MemoryAdvisoryEntry {
+                advisory,
+                inserted_at: Instant::now(),
+                ttl: self.ttl,
+            },
+        );
+    }
+
+    async fn remove(&self, advisory_id: &str) {
+        self.entries.remove(advisory_id);
+    }
+
+    async fn clear(&self) {
+        self.entries.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::SystemTime;
+
+    use super::super::AdvisoryKind;
+    use super::*;
+
+    fn sample_found() -> CachedAdvisory {
+        CachedAdvisory {
+            id: "RUSTSEC-2020-0036".to_string(),
+            kind: AdvisoryKind::Found {
+                summary: Some("unmaintained".to_string()),
+                unmaintained: true,
+            },
+            fetched_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_and_get_round_trip() {
+        let cache = MemoryAdvisoryCache::new();
+        let advisory = sample_found();
+        cache.insert(advisory.clone()).await;
+        assert_eq!(cache.get(&advisory.id).await, Some(advisory));
+    }
+
+    #[tokio::test]
+    async fn missing_id_returns_none() {
+        let cache = MemoryAdvisoryCache::new();
+        assert!(cache.get("RUSTSEC-9999-9999").await.is_none());
+    }
+}

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -285,6 +285,16 @@ mod tests {
         assert!(sqlite.get("RUSTSEC-2021-0001").await.is_none());
     }
 
+    #[tokio::test]
+    async fn hybrid_with_no_sqlite_falls_back_to_memory_only() {
+        let memory = MemoryAdvisoryCache::new();
+        let hybrid = HybridAdvisoryCache::from_parts(memory.clone(), None);
+        let advisory = sample_found("RUSTSEC-2020-0036");
+
+        hybrid.insert(advisory.clone()).await;
+        assert_eq!(hybrid.get(&advisory.id).await, Some(advisory));
+    }
+
     #[test]
     fn cached_advisory_round_trips_through_json() {
         let advisory = CachedAdvisory {

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -82,6 +82,24 @@ impl<T: AdvisoryWriteCache> AdvisoryWriteCache for Arc<T> {
     }
 }
 
+/// No-op cache used when caching is disabled via configuration.
+///
+/// All reads return `None`, all writes are silently dropped.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NullAdvisoryCache;
+
+impl AdvisoryReadCache for NullAdvisoryCache {
+    async fn get(&self, _advisory_id: &str) -> Option<CachedAdvisory> {
+        None
+    }
+}
+
+impl AdvisoryWriteCache for NullAdvisoryCache {
+    async fn insert(&self, _advisory: CachedAdvisory) {}
+    async fn remove(&self, _advisory_id: &str) {}
+    async fn clear(&self) {}
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -135,5 +153,27 @@ mod tests {
         });
         assert_eq!(cache.get("anything").await, Some(advisory.clone()));
         assert!(cache.contains("anything").await);
+    }
+
+    #[tokio::test]
+    async fn null_cache_get_returns_none() {
+        let cache = NullAdvisoryCache;
+        assert_eq!(cache.get("RUSTSEC-2020-0036").await, None);
+        assert!(!cache.contains("RUSTSEC-2020-0036").await);
+    }
+
+    #[tokio::test]
+    async fn null_cache_writes_are_noop() {
+        let cache = NullAdvisoryCache;
+        cache
+            .insert(CachedAdvisory {
+                id: "RUSTSEC-2020-0036".to_string(),
+                kind: AdvisoryKind::NotFound,
+                fetched_at: SystemTime::UNIX_EPOCH,
+            })
+            .await;
+        cache.remove("RUSTSEC-2020-0036").await;
+        cache.clear().await;
+        assert_eq!(cache.get("RUSTSEC-2020-0036").await, None);
     }
 }

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -1,0 +1,63 @@
+//! RustSec advisory cache (issue #237)
+//!
+//! Caches the result of `OSV GET /vulns/{id}` to avoid redundant network
+//! requests for the same RUSTSEC advisory across LSP sessions.
+
+pub mod memory;
+pub mod sqlite;
+
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+
+/// Cached classification of a single OSV advisory.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum AdvisoryKind {
+    /// Advisory exists at OSV; we recorded the parts we need.
+    Found {
+        summary: Option<String>,
+        unmaintained: bool,
+    },
+    /// Advisory ID returned 404 from OSV.
+    NotFound,
+}
+
+/// One cache entry: an advisory ID plus its classification and fetch time.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CachedAdvisory {
+    pub id: String,
+    pub kind: AdvisoryKind,
+    pub fetched_at: SystemTime,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cached_advisory_round_trips_through_json() {
+        let advisory = CachedAdvisory {
+            id: "RUSTSEC-2020-0036".to_string(),
+            kind: AdvisoryKind::Found {
+                summary: Some("failure crate is unmaintained".to_string()),
+                unmaintained: true,
+            },
+            fetched_at: SystemTime::UNIX_EPOCH,
+        };
+        let json = serde_json::to_string(&advisory).expect("serialize");
+        let back: CachedAdvisory = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(advisory, back);
+    }
+
+    #[test]
+    fn not_found_kind_round_trips() {
+        let advisory = CachedAdvisory {
+            id: "RUSTSEC-9999-0001".to_string(),
+            kind: AdvisoryKind::NotFound,
+            fetched_at: SystemTime::UNIX_EPOCH,
+        };
+        let json = serde_json::to_string(&advisory).expect("serialize");
+        let back: CachedAdvisory = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(advisory, back);
+    }
+}

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -172,6 +172,29 @@ impl AdvisoryReadCache for HybridAdvisoryCache {
     }
 }
 
+impl AdvisoryWriteCache for HybridAdvisoryCache {
+    async fn insert(&self, advisory: CachedAdvisory) {
+        self.memory.insert(advisory.clone()).await;
+        if let Some(ref sqlite) = self.sqlite {
+            sqlite.insert(advisory).await;
+        }
+    }
+
+    async fn remove(&self, advisory_id: &str) {
+        self.memory.remove(advisory_id).await;
+        if let Some(ref sqlite) = self.sqlite {
+            sqlite.remove(advisory_id).await;
+        }
+    }
+
+    async fn clear(&self) {
+        self.memory.clear().await;
+        if let Some(ref sqlite) = self.sqlite {
+            sqlite.clear().await;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::memory::MemoryAdvisoryCache;
@@ -219,6 +242,47 @@ mod tests {
         let sqlite = Arc::new(SqliteAdvisoryCache::in_memory().expect("in-memory sqlite"));
         let hybrid = HybridAdvisoryCache::from_parts(memory, Some(sqlite));
         assert!(hybrid.get("RUSTSEC-1990-0001").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn hybrid_insert_writes_both_layers() {
+        let memory = MemoryAdvisoryCache::new();
+        let sqlite = Arc::new(SqliteAdvisoryCache::in_memory().expect("in-memory sqlite"));
+        let advisory = sample_found("RUSTSEC-2020-0036");
+        let hybrid = HybridAdvisoryCache::from_parts(memory.clone(), Some(Arc::clone(&sqlite)));
+
+        hybrid.insert(advisory.clone()).await;
+
+        assert_eq!(memory.get(&advisory.id).await, Some(advisory.clone()));
+        assert_eq!(sqlite.get(&advisory.id).await, Some(advisory));
+    }
+
+    #[tokio::test]
+    async fn hybrid_remove_clears_both_layers() {
+        let memory = MemoryAdvisoryCache::new();
+        let sqlite = Arc::new(SqliteAdvisoryCache::in_memory().expect("in-memory sqlite"));
+        let advisory = sample_found("RUSTSEC-2020-0036");
+        let hybrid = HybridAdvisoryCache::from_parts(memory.clone(), Some(Arc::clone(&sqlite)));
+
+        hybrid.insert(advisory.clone()).await;
+        hybrid.remove(&advisory.id).await;
+
+        assert!(memory.get(&advisory.id).await.is_none());
+        assert!(sqlite.get(&advisory.id).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn hybrid_clear_clears_both_layers() {
+        let memory = MemoryAdvisoryCache::new();
+        let sqlite = Arc::new(SqliteAdvisoryCache::in_memory().expect("in-memory sqlite"));
+        let hybrid = HybridAdvisoryCache::from_parts(memory.clone(), Some(Arc::clone(&sqlite)));
+
+        hybrid.insert(sample_found("RUSTSEC-2020-0036")).await;
+        hybrid.insert(sample_found("RUSTSEC-2021-0001")).await;
+        hybrid.clear().await;
+
+        assert!(memory.get("RUSTSEC-2020-0036").await.is_none());
+        assert!(sqlite.get("RUSTSEC-2021-0001").await.is_none());
     }
 
     #[test]

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -6,6 +6,7 @@
 pub mod memory;
 pub mod sqlite;
 
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
@@ -28,6 +29,57 @@ pub struct CachedAdvisory {
     pub id: String,
     pub kind: AdvisoryKind,
     pub fetched_at: SystemTime,
+}
+
+/// Read-only access to the advisory cache.
+///
+/// Mirrors [`crate::cache::ReadCache`] but specialised for advisory entries.
+#[allow(async_fn_in_trait)]
+pub trait AdvisoryReadCache: Send + Sync {
+    /// Fetch a cached advisory. Returns `None` on miss or expiry.
+    async fn get(&self, advisory_id: &str) -> Option<CachedAdvisory>;
+
+    /// Convenience wrapper around `get` for existence checks.
+    async fn contains(&self, advisory_id: &str) -> bool {
+        self.get(advisory_id).await.is_some()
+    }
+}
+
+/// Write access to the advisory cache.
+#[allow(async_fn_in_trait)]
+pub trait AdvisoryWriteCache: AdvisoryReadCache {
+    /// Insert (or replace) an advisory entry.
+    async fn insert(&self, advisory: CachedAdvisory);
+
+    /// Remove a single advisory entry.
+    async fn remove(&self, advisory_id: &str);
+
+    /// Remove every entry from the cache.
+    async fn clear(&self);
+}
+
+impl<T: AdvisoryReadCache> AdvisoryReadCache for Arc<T> {
+    async fn get(&self, advisory_id: &str) -> Option<CachedAdvisory> {
+        (**self).get(advisory_id).await
+    }
+
+    async fn contains(&self, advisory_id: &str) -> bool {
+        (**self).contains(advisory_id).await
+    }
+}
+
+impl<T: AdvisoryWriteCache> AdvisoryWriteCache for Arc<T> {
+    async fn insert(&self, advisory: CachedAdvisory) {
+        (**self).insert(advisory).await
+    }
+
+    async fn remove(&self, advisory_id: &str) {
+        (**self).remove(advisory_id).await
+    }
+
+    async fn clear(&self) {
+        (**self).clear().await
+    }
 }
 
 #[cfg(test)]
@@ -59,5 +111,29 @@ mod tests {
         let json = serde_json::to_string(&advisory).expect("serialize");
         let back: CachedAdvisory = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(advisory, back);
+    }
+
+    #[tokio::test]
+    async fn arc_blanket_impl_forwards_reads() {
+        struct DummyCache {
+            value: Option<CachedAdvisory>,
+        }
+
+        impl AdvisoryReadCache for DummyCache {
+            async fn get(&self, _id: &str) -> Option<CachedAdvisory> {
+                self.value.clone()
+            }
+        }
+
+        let advisory = CachedAdvisory {
+            id: "RUSTSEC-2020-0036".to_string(),
+            kind: AdvisoryKind::NotFound,
+            fetched_at: SystemTime::UNIX_EPOCH,
+        };
+        let cache: Arc<DummyCache> = Arc::new(DummyCache {
+            value: Some(advisory.clone()),
+        });
+        assert_eq!(cache.get("anything").await, Some(advisory.clone()));
+        assert!(cache.contains("anything").await);
     }
 }

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -11,7 +11,7 @@ use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 
-pub use memory::{DEFAULT_ADVISORY_TTL, MemoryAdvisoryCache};
+pub use memory::{AdvisoryCacheStats, DEFAULT_ADVISORY_TTL, MemoryAdvisoryCache};
 
 /// Cached classification of a single OSV advisory.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -7,7 +7,7 @@ pub mod memory;
 pub mod sqlite;
 
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use serde::{Deserialize, Serialize};
 
@@ -110,9 +110,95 @@ impl AdvisoryWriteCache for NullAdvisoryCache {
     async fn clear(&self) {}
 }
 
+/// Cleanup interval for the hybrid cache background task (30 minutes).
+pub const ADVISORY_CLEANUP_INTERVAL: Duration = Duration::from_secs(30 * 60);
+
+/// Two-tier advisory cache: in-memory L1 backed by SQLite L2.
+pub struct HybridAdvisoryCache {
+    memory: memory::MemoryAdvisoryCache,
+    sqlite: Option<Arc<sqlite::SqliteAdvisoryCache>>,
+}
+
+impl HybridAdvisoryCache {
+    /// Construct a hybrid cache, attempting to open the default SQLite path.
+    pub fn new() -> Self {
+        let sqlite = match sqlite::SqliteAdvisoryCache::new() {
+            Ok(cache) => {
+                tracing::info!("Advisory SQLite cache initialised");
+                Some(Arc::new(cache))
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "Advisory SQLite cache unavailable, using memory only: {}",
+                    err
+                );
+                None
+            }
+        };
+        let memory = memory::MemoryAdvisoryCache::new();
+        Self { memory, sqlite }
+    }
+
+    /// Build directly from prepared layers (used by tests and by callers
+    /// that have constructed a custom SQLite cache).
+    pub fn from_parts(
+        memory: memory::MemoryAdvisoryCache,
+        sqlite: Option<Arc<sqlite::SqliteAdvisoryCache>>,
+    ) -> Self {
+        Self { memory, sqlite }
+    }
+}
+
+impl Default for HybridAdvisoryCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AdvisoryReadCache for HybridAdvisoryCache {
+    async fn get(&self, advisory_id: &str) -> Option<CachedAdvisory> {
+        if let Some(value) = self.memory.get(advisory_id).await {
+            return Some(value);
+        }
+
+        if let Some(ref sqlite) = self.sqlite
+            && let Some(value) = sqlite.get(advisory_id).await
+        {
+            self.memory.insert(value.clone()).await;
+            return Some(value);
+        }
+
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::memory::MemoryAdvisoryCache;
+    use super::sqlite::SqliteAdvisoryCache;
     use super::*;
+
+    fn sample_found(id: &str) -> CachedAdvisory {
+        CachedAdvisory {
+            id: id.to_string(),
+            kind: AdvisoryKind::Found {
+                summary: Some("unmaintained".to_string()),
+                unmaintained: true,
+            },
+            fetched_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    #[tokio::test]
+    async fn hybrid_l1_hit_returns_without_consulting_l2() {
+        let memory = MemoryAdvisoryCache::new();
+        let sqlite = Arc::new(SqliteAdvisoryCache::in_memory().expect("in-memory sqlite"));
+        let advisory = sample_found("RUSTSEC-2020-0036");
+        memory.insert(advisory.clone()).await;
+        // Note: deliberately NOT inserting into SQLite.
+        let hybrid = HybridAdvisoryCache::from_parts(memory, Some(sqlite));
+        assert_eq!(hybrid.get("RUSTSEC-2020-0036").await, Some(advisory));
+    }
 
     #[test]
     fn cached_advisory_round_trips_through_json() {

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -189,6 +189,29 @@ impl HybridAdvisoryCache {
         Self::from_parts(memory, sqlite)
     }
 
+    /// Build a *negative* advisory cache from an [`AdvisoryCacheConfig`].
+    ///
+    /// 404 OSV responses live on a different freshness schedule than real
+    /// `Found` entries: a missing advisory might just mean OSV has not yet
+    /// ingested a brand-new RUSTSEC ID, so we want to retry sooner. This
+    /// constructor uses `config.negative_ttl_secs` for the memory TTL and
+    /// deliberately omits the SQLite layer — short-TTL entries do not need
+    /// cross-session persistence and would otherwise share storage with the
+    /// positive cache.
+    ///
+    /// When `enabled = false`, the cache is zero-TTL (always misses).
+    pub fn negative_from_config(config: &crate::config::AdvisoryCacheConfig) -> Self {
+        if !config.enabled {
+            return Self::from_parts(
+                memory::MemoryAdvisoryCache::with_ttl(Duration::from_secs(0)),
+                None,
+            );
+        }
+        let memory =
+            memory::MemoryAdvisoryCache::with_ttl(Duration::from_secs(config.negative_ttl_secs));
+        Self::from_parts(memory, None)
+    }
+
     /// Spawn a background task that periodically prunes expired entries from
     /// both layers. The default interval is [`ADVISORY_CLEANUP_INTERVAL`].
     pub fn spawn_default_cleanup_task(self: &Arc<Self>) {

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -9,6 +9,7 @@ pub mod sqlite;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 pub use memory::{AdvisoryCacheStats, DEFAULT_ADVISORY_TTL, MemoryAdvisoryCache};
@@ -37,7 +38,8 @@ pub struct CachedAdvisory {
 /// Read-only access to the advisory cache.
 ///
 /// Mirrors [`crate::cache::ReadCache`] but specialised for advisory entries.
-#[allow(async_fn_in_trait)]
+/// Uses `#[async_trait]` so the trait remains dyn-compatible (`Arc<dyn …>`).
+#[async_trait]
 pub trait AdvisoryReadCache: Send + Sync {
     /// Fetch a cached advisory. Returns `None` on miss or expiry.
     async fn get(&self, advisory_id: &str) -> Option<CachedAdvisory>;
@@ -53,7 +55,7 @@ pub trait AdvisoryReadCache: Send + Sync {
 /// Mirrors [`crate::cache::WriteCache`] but specialised for advisory entries.
 /// Unlike `WriteCache`, the key is not passed separately — `CachedAdvisory`
 /// carries its own `id`.
-#[allow(async_fn_in_trait)]
+#[async_trait]
 pub trait AdvisoryWriteCache: AdvisoryReadCache {
     /// Insert (or replace) an advisory entry.
     ///
@@ -68,7 +70,8 @@ pub trait AdvisoryWriteCache: AdvisoryReadCache {
     async fn clear(&self);
 }
 
-impl<T: AdvisoryReadCache> AdvisoryReadCache for Arc<T> {
+#[async_trait]
+impl<T: AdvisoryReadCache + ?Sized> AdvisoryReadCache for Arc<T> {
     async fn get(&self, advisory_id: &str) -> Option<CachedAdvisory> {
         (**self).get(advisory_id).await
     }
@@ -78,7 +81,8 @@ impl<T: AdvisoryReadCache> AdvisoryReadCache for Arc<T> {
     }
 }
 
-impl<T: AdvisoryWriteCache> AdvisoryWriteCache for Arc<T> {
+#[async_trait]
+impl<T: AdvisoryWriteCache + ?Sized> AdvisoryWriteCache for Arc<T> {
     async fn insert(&self, advisory: CachedAdvisory) {
         (**self).insert(advisory).await
     }
@@ -98,12 +102,14 @@ impl<T: AdvisoryWriteCache> AdvisoryWriteCache for Arc<T> {
 #[derive(Clone, Copy, Debug, Default)]
 pub struct NullAdvisoryCache;
 
+#[async_trait]
 impl AdvisoryReadCache for NullAdvisoryCache {
     async fn get(&self, _advisory_id: &str) -> Option<CachedAdvisory> {
         None
     }
 }
 
+#[async_trait]
 impl AdvisoryWriteCache for NullAdvisoryCache {
     async fn insert(&self, _advisory: CachedAdvisory) {}
     async fn remove(&self, _advisory_id: &str) {}
@@ -189,6 +195,7 @@ impl Default for HybridAdvisoryCache {
     }
 }
 
+#[async_trait]
 impl AdvisoryReadCache for HybridAdvisoryCache {
     async fn get(&self, advisory_id: &str) -> Option<CachedAdvisory> {
         if let Some(value) = self.memory.get(advisory_id).await {
@@ -206,6 +213,7 @@ impl AdvisoryReadCache for HybridAdvisoryCache {
     }
 }
 
+#[async_trait]
 impl AdvisoryWriteCache for HybridAdvisoryCache {
     async fn insert(&self, advisory: CachedAdvisory) {
         self.memory.insert(advisory.clone()).await;
@@ -377,6 +385,7 @@ mod tests {
             value: Option<CachedAdvisory>,
         }
 
+        #[async_trait]
         impl AdvisoryReadCache for DummyCache {
             async fn get(&self, _id: &str) -> Option<CachedAdvisory> {
                 self.value.clone()

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -227,7 +227,14 @@ impl HybridAdvisoryCache {
             ticker.tick().await; // skip immediate fire
             loop {
                 ticker.tick().await;
-                let removed = memory.cleanup_expired();
+                // DashMap::retain holds a write lock during the scan. For
+                // very large caches this can briefly block the executor —
+                // offload to the blocking pool to keep the runtime healthy.
+                let memory_for_cleanup = memory.clone();
+                let removed =
+                    tokio::task::spawn_blocking(move || memory_for_cleanup.cleanup_expired())
+                        .await
+                        .unwrap_or(0);
                 if removed > 0 {
                     tracing::debug!("Advisory cache: pruned {} expired memory entries", removed);
                 }
@@ -590,15 +597,21 @@ mod tests {
 
     #[tokio::test]
     async fn from_config_enabled_with_unwritable_path_falls_back_to_memory_only() {
-        // A path inside a non-existent directory hierarchy SQLite cannot
-        // create — we must NOT panic; the hybrid should fall back to memory.
+        // Build a deterministic "cannot create directory" condition: place a
+        // regular file where a parent directory would need to live, then ask
+        // SQLite to open a path beneath it. `create_dir_all` rejects this on
+        // every platform regardless of permissions (file is not a directory),
+        // so the test does not depend on whether the runner has root or
+        // peculiar /this/path locations.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blocker = tmp.path().join("blocker_file");
+        std::fs::write(&blocker, b"not a directory").expect("write blocker");
+        let db_path = blocker.join("nested").join("advisory_cache.db");
         let config = crate::config::AdvisoryCacheConfig {
             enabled: true,
             ttl_secs: 60,
             negative_ttl_secs: 30,
-            db_path: Some(std::path::PathBuf::from(
-                "/this/path/should/not/exist/dependi/advisory_cache.db",
-            )),
+            db_path: Some(db_path),
         };
         let hybrid = HybridAdvisoryCache::from_config(&config);
         hybrid

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -205,7 +205,19 @@ impl AdvisoryReadCache for HybridAdvisoryCache {
         if let Some(ref sqlite) = self.sqlite
             && let Some(value) = sqlite.get(advisory_id).await
         {
-            self.memory.insert(value.clone()).await;
+            // Backfill L1 with the *remaining* TTL relative to the original
+            // fetch time, not a fresh full memory-TTL window. Otherwise an
+            // entry that is about to expire in SQLite would gain a brand-new
+            // memory-TTL on every L2 read, doubling the effective TTL.
+            let remaining = match value.fetched_at.elapsed() {
+                Ok(elapsed) => self.memory.ttl().saturating_sub(elapsed),
+                Err(_) => Duration::from_secs(0),
+            };
+            if !remaining.is_zero() {
+                self.memory
+                    .insert_with_remaining_ttl(value.clone(), remaining)
+                    .await;
+            }
             return Some(value);
         }
 
@@ -269,13 +281,76 @@ mod tests {
     async fn hybrid_l2_hit_backfills_l1() {
         let memory = MemoryAdvisoryCache::new();
         let sqlite = Arc::new(SqliteAdvisoryCache::in_memory().expect("in-memory sqlite"));
-        let advisory = sample_found("RUSTSEC-2020-0036");
+        let advisory = CachedAdvisory {
+            id: "RUSTSEC-2020-0036".to_string(),
+            kind: AdvisoryKind::Found {
+                summary: Some("unmaintained".to_string()),
+                unmaintained: true,
+            },
+            // `SystemTime::now()` so `elapsed()` succeeds and `remaining` is
+            // close to the configured memory TTL.
+            fetched_at: SystemTime::now(),
+        };
         sqlite.insert(advisory.clone()).await;
         let hybrid = HybridAdvisoryCache::from_parts(memory.clone(), Some(sqlite));
 
         assert_eq!(hybrid.get(&advisory.id).await, Some(advisory.clone()));
         // After the first read, the memory layer should hold it directly.
         assert_eq!(memory.get(&advisory.id).await, Some(advisory));
+    }
+
+    /// Regression: an L2 hit must NOT extend the effective TTL past the
+    /// original SQLite fetch time + memory TTL by re-stamping the L1 entry
+    /// with `Instant::now()`. The L1 backfill should respect the remaining
+    /// TTL relative to `fetched_at`.
+    #[tokio::test]
+    async fn hybrid_l2_backfill_preserves_remaining_ttl() {
+        // Memory TTL of 50 ms.
+        let memory = MemoryAdvisoryCache::with_ttl(Duration::from_millis(50));
+        let sqlite = Arc::new(SqliteAdvisoryCache::in_memory().expect("in-memory sqlite"));
+        // Advisory fetched 40 ms ago — only ~10 ms of memory TTL should remain.
+        let advisory = CachedAdvisory {
+            id: "RUSTSEC-2020-0036".to_string(),
+            kind: AdvisoryKind::Found {
+                summary: None,
+                unmaintained: false,
+            },
+            fetched_at: SystemTime::now() - Duration::from_millis(40),
+        };
+        sqlite.insert(advisory.clone()).await;
+        let hybrid = HybridAdvisoryCache::from_parts(memory.clone(), Some(sqlite));
+
+        // First read: backfills L1.
+        assert_eq!(hybrid.get(&advisory.id).await, Some(advisory.clone()));
+        assert!(memory.get(&advisory.id).await.is_some());
+
+        // Wait long enough that the *remaining* TTL has elapsed but a fresh
+        // 50 ms window would still be alive. If backfill used the full TTL,
+        // the entry would still be present.
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(
+            memory.get(&advisory.id).await.is_none(),
+            "L1 backfill must not extend effective TTL past fetched_at + memory_ttl"
+        );
+    }
+
+    /// If `fetched_at` is somehow already past `memory_ttl`, the backfill
+    /// should be skipped entirely (zero remaining ⇒ never write a 0-TTL row).
+    #[tokio::test]
+    async fn hybrid_l2_backfill_skips_when_remaining_ttl_is_zero() {
+        let memory = MemoryAdvisoryCache::with_ttl(Duration::from_millis(10));
+        let sqlite = Arc::new(SqliteAdvisoryCache::in_memory().expect("in-memory sqlite"));
+        let advisory = CachedAdvisory {
+            id: "RUSTSEC-2020-0036".to_string(),
+            kind: AdvisoryKind::NotFound,
+            fetched_at: SystemTime::now() - Duration::from_secs(60),
+        };
+        sqlite.insert(advisory.clone()).await;
+        let hybrid = HybridAdvisoryCache::from_parts(memory.clone(), Some(sqlite));
+
+        // The hybrid still returns the L2 value, but does not backfill L1.
+        assert_eq!(hybrid.get(&advisory.id).await, Some(advisory.clone()));
+        assert!(memory.get(&advisory.id).await.is_none());
     }
 
     #[tokio::test]

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -147,6 +147,40 @@ impl HybridAdvisoryCache {
     ) -> Self {
         Self { memory, sqlite }
     }
+
+    /// Spawn a background task that periodically prunes expired entries from
+    /// both layers. The default interval is [`ADVISORY_CLEANUP_INTERVAL`].
+    pub fn spawn_default_cleanup_task(self: &Arc<Self>) {
+        self.spawn_cleanup_task(ADVISORY_CLEANUP_INTERVAL);
+    }
+
+    /// Spawn the cleanup task with a custom interval (used by tests).
+    pub fn spawn_cleanup_task(self: &Arc<Self>, interval: Duration) {
+        let memory = self.memory.clone();
+        let sqlite = self.sqlite.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.tick().await; // skip immediate fire
+            loop {
+                ticker.tick().await;
+                let removed = memory.cleanup_expired();
+                if removed > 0 {
+                    tracing::debug!("Advisory cache: pruned {} expired memory entries", removed);
+                }
+                if let Some(ref sqlite) = sqlite {
+                    match sqlite.cleanup_expired().await {
+                        Ok(rows) if rows > 0 => {
+                            tracing::debug!("Advisory cache: pruned {} expired SQLite rows", rows);
+                        }
+                        Ok(_) => {}
+                        Err(err) => {
+                            tracing::warn!("Advisory cache cleanup failed for SQLite: {}", err);
+                        }
+                    }
+                }
+            }
+        });
+    }
 }
 
 impl Default for HybridAdvisoryCache {
@@ -293,6 +327,21 @@ mod tests {
 
         hybrid.insert(advisory.clone()).await;
         assert_eq!(hybrid.get(&advisory.id).await, Some(advisory));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn background_cleanup_removes_expired_memory_entries() {
+        let memory = MemoryAdvisoryCache::with_ttl(Duration::from_millis(20));
+        memory.insert(sample_found("RUSTSEC-2020-0036")).await;
+        let sqlite = Arc::new(SqliteAdvisoryCache::in_memory().expect("in-memory sqlite"));
+        let hybrid = Arc::new(HybridAdvisoryCache::from_parts(
+            memory.clone(),
+            Some(sqlite),
+        ));
+        hybrid.spawn_cleanup_task(Duration::from_millis(40));
+
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert!(memory.get("RUSTSEC-2020-0036").await.is_none());
     }
 
     #[test]

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -12,6 +12,7 @@ use std::time::SystemTime;
 use serde::{Deserialize, Serialize};
 
 pub use memory::{AdvisoryCacheStats, DEFAULT_ADVISORY_TTL, MemoryAdvisoryCache};
+pub use sqlite::{DEFAULT_ADVISORY_TTL_SECS, SqliteAdvisoryCache};
 
 /// Cached classification of a single OSV advisory.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -46,9 +46,16 @@ pub trait AdvisoryReadCache: Send + Sync {
 }
 
 /// Write access to the advisory cache.
+///
+/// Mirrors [`crate::cache::WriteCache`] but specialised for advisory entries.
+/// Unlike `WriteCache`, the key is not passed separately — `CachedAdvisory`
+/// carries its own `id`.
 #[allow(async_fn_in_trait)]
 pub trait AdvisoryWriteCache: AdvisoryReadCache {
     /// Insert (or replace) an advisory entry.
+    ///
+    /// The `advisory.id` field acts as the cache key; unlike
+    /// [`crate::cache::WriteCache::insert`] the key is not passed separately.
     async fn insert(&self, advisory: CachedAdvisory);
 
     /// Remove a single advisory entry.

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -214,12 +214,19 @@ impl HybridAdvisoryCache {
 
     /// Spawn a background task that periodically prunes expired entries from
     /// both layers. The default interval is [`ADVISORY_CLEANUP_INTERVAL`].
-    pub fn spawn_default_cleanup_task(self: &Arc<Self>) {
-        self.spawn_cleanup_task(ADVISORY_CLEANUP_INTERVAL);
+    ///
+    /// Returns the `JoinHandle` so callers (notably the LSP backend, which
+    /// rebuilds the cache trio inside `initialize`) can `abort()` the task
+    /// when the cache is replaced. Without this, the old cleanup task keeps
+    /// holding `Arc` clones of the previous memory/SQLite layers forever.
+    #[must_use = "abort the handle when the cache is replaced to avoid leaking the cleanup task"]
+    pub fn spawn_default_cleanup_task(self: &Arc<Self>) -> tokio::task::JoinHandle<()> {
+        self.spawn_cleanup_task(ADVISORY_CLEANUP_INTERVAL)
     }
 
     /// Spawn the cleanup task with a custom interval (used by tests).
-    pub fn spawn_cleanup_task(self: &Arc<Self>, interval: Duration) {
+    #[must_use = "abort the handle when the cache is replaced to avoid leaking the cleanup task"]
+    pub fn spawn_cleanup_task(self: &Arc<Self>, interval: Duration) -> tokio::task::JoinHandle<()> {
         let memory = self.memory.clone();
         let sqlite = self.sqlite.clone();
         tokio::spawn(async move {
@@ -250,7 +257,7 @@ impl HybridAdvisoryCache {
                     }
                 }
             }
-        });
+        })
     }
 }
 
@@ -486,7 +493,7 @@ mod tests {
             memory.clone(),
             Some(sqlite),
         ));
-        hybrid.spawn_cleanup_task(Duration::from_millis(40));
+        let _cleanup = hybrid.spawn_cleanup_task(Duration::from_millis(40));
 
         tokio::time::sleep(Duration::from_millis(120)).await;
         assert!(memory.get("RUSTSEC-2020-0036").await.is_none());

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -154,6 +154,41 @@ impl HybridAdvisoryCache {
         Self { memory, sqlite }
     }
 
+    /// Build a hybrid cache from an [`AdvisoryCacheConfig`] (issue #237).
+    ///
+    /// When `config.enabled` is `false`, returns a hybrid whose memory layer
+    /// has a zero-second TTL and no SQLite backing. Every read therefore
+    /// misses, which matches the "caching disabled" semantics without
+    /// requiring callers to branch on a different concrete type.
+    ///
+    /// When `enabled` is `true`, the memory TTL is taken from
+    /// `config.ttl_secs` and the SQLite layer is opened at `config.db_path`
+    /// (or the default location). A SQLite open failure is logged and falls
+    /// back to a memory-only hybrid — matching pre-existing `new()` behaviour.
+    pub fn from_config(config: &crate::config::AdvisoryCacheConfig) -> Self {
+        if !config.enabled {
+            return Self::from_parts(
+                memory::MemoryAdvisoryCache::with_ttl(Duration::from_secs(0)),
+                None,
+            );
+        }
+        let memory = memory::MemoryAdvisoryCache::with_ttl(Duration::from_secs(config.ttl_secs));
+        let sqlite = match sqlite::SqliteAdvisoryCache::from_config(config) {
+            Ok(cache) => {
+                tracing::info!("Advisory SQLite cache initialised from config");
+                Some(Arc::new(cache))
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "Advisory SQLite cache unavailable, using memory only: {}",
+                    err
+                );
+                None
+            }
+        };
+        Self::from_parts(memory, sqlite)
+    }
+
     /// Spawn a background task that periodically prunes expired entries from
     /// both layers. The default interval is [`ADVISORY_CLEANUP_INTERVAL`].
     pub fn spawn_default_cleanup_task(self: &Arc<Self>) {
@@ -484,6 +519,73 @@ mod tests {
         let cache = NullAdvisoryCache;
         assert_eq!(cache.get("RUSTSEC-2020-0036").await, None);
         assert!(!cache.contains("RUSTSEC-2020-0036").await);
+    }
+
+    #[tokio::test]
+    async fn from_config_disabled_returns_hybrid_that_always_misses() {
+        let config = crate::config::AdvisoryCacheConfig {
+            enabled: false,
+            ttl_secs: 86_400,
+            negative_ttl_secs: 3_600,
+            db_path: None,
+        };
+        let hybrid = HybridAdvisoryCache::from_config(&config);
+        // Insert an advisory, then read it back: a zero-TTL hybrid must miss
+        // even immediately after insertion.
+        hybrid
+            .insert(CachedAdvisory {
+                id: "RUSTSEC-2020-0036".to_string(),
+                kind: AdvisoryKind::NotFound,
+                fetched_at: SystemTime::now(),
+            })
+            .await;
+        // Wait one tick to ensure the zero TTL has definitely elapsed.
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        assert!(hybrid.get("RUSTSEC-2020-0036").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn from_config_enabled_uses_configured_ttl_for_memory_layer() {
+        let tmp = tempfile::tempdir().expect("tmp dir");
+        let config = crate::config::AdvisoryCacheConfig {
+            enabled: true,
+            ttl_secs: 3_600,
+            negative_ttl_secs: 60,
+            db_path: Some(tmp.path().join("advisory_cache.db")),
+        };
+        let hybrid = HybridAdvisoryCache::from_config(&config);
+        hybrid
+            .insert(CachedAdvisory {
+                id: "RUSTSEC-2020-0036".to_string(),
+                kind: AdvisoryKind::NotFound,
+                fetched_at: SystemTime::now(),
+            })
+            .await;
+        // With ttl_secs = 3600 the entry must be present immediately.
+        assert!(hybrid.get("RUSTSEC-2020-0036").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn from_config_enabled_with_unwritable_path_falls_back_to_memory_only() {
+        // A path inside a non-existent directory hierarchy SQLite cannot
+        // create — we must NOT panic; the hybrid should fall back to memory.
+        let config = crate::config::AdvisoryCacheConfig {
+            enabled: true,
+            ttl_secs: 60,
+            negative_ttl_secs: 30,
+            db_path: Some(std::path::PathBuf::from(
+                "/this/path/should/not/exist/dependi/advisory_cache.db",
+            )),
+        };
+        let hybrid = HybridAdvisoryCache::from_config(&config);
+        hybrid
+            .insert(CachedAdvisory {
+                id: "RUSTSEC-2020-0036".to_string(),
+                kind: AdvisoryKind::NotFound,
+                fetched_at: SystemTime::now(),
+            })
+            .await;
+        assert!(hybrid.get("RUSTSEC-2020-0036").await.is_some());
     }
 
     #[tokio::test]

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -200,6 +200,27 @@ mod tests {
         assert_eq!(hybrid.get("RUSTSEC-2020-0036").await, Some(advisory));
     }
 
+    #[tokio::test]
+    async fn hybrid_l2_hit_backfills_l1() {
+        let memory = MemoryAdvisoryCache::new();
+        let sqlite = Arc::new(SqliteAdvisoryCache::in_memory().expect("in-memory sqlite"));
+        let advisory = sample_found("RUSTSEC-2020-0036");
+        sqlite.insert(advisory.clone()).await;
+        let hybrid = HybridAdvisoryCache::from_parts(memory.clone(), Some(sqlite));
+
+        assert_eq!(hybrid.get(&advisory.id).await, Some(advisory.clone()));
+        // After the first read, the memory layer should hold it directly.
+        assert_eq!(memory.get(&advisory.id).await, Some(advisory));
+    }
+
+    #[tokio::test]
+    async fn hybrid_double_miss_returns_none() {
+        let memory = MemoryAdvisoryCache::new();
+        let sqlite = Arc::new(SqliteAdvisoryCache::in_memory().expect("in-memory sqlite"));
+        let hybrid = HybridAdvisoryCache::from_parts(memory, Some(sqlite));
+        assert!(hybrid.get("RUSTSEC-1990-0001").await.is_none());
+    }
+
     #[test]
     fn cached_advisory_round_trips_through_json() {
         let advisory = CachedAdvisory {

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -11,6 +11,8 @@ use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 
+pub use memory::{DEFAULT_ADVISORY_TTL, MemoryAdvisoryCache};
+
 /// Cached classification of a single OSV advisory.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum AdvisoryKind {

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -1,0 +1,1 @@
+//! SQLite-backed advisory cache (L2 layer).

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -108,11 +108,12 @@ impl SqliteAdvisoryCache {
             )",
             [],
         )?;
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_advisory_expiry \
-             ON advisories(inserted_at, ttl_secs)",
-            [],
-        )?;
+        // Intentionally no expiry index. The cleanup query
+        // (`WHERE inserted_at + ttl_secs * ? < ?`) wraps `inserted_at` in an
+        // arithmetic expression, so SQLite cannot use a `(inserted_at,
+        // ttl_secs)` index for it. Advisory rows are bounded by the small
+        // number of distinct RUSTSEC IDs encountered, so a periodic full
+        // scan is cheap.
         Ok(())
     }
 
@@ -128,11 +129,8 @@ impl SqliteAdvisoryCache {
             )",
             [],
         )?;
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_advisory_expiry \
-             ON advisories(inserted_at, ttl_secs)",
-            [],
-        )?;
+        // See `init_schema` — the expiry index is intentionally omitted
+        // because it cannot be used by the cleanup query.
         Ok(())
     }
 }
@@ -245,7 +243,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn in_memory_constructor_creates_table_and_index() {
+    async fn in_memory_constructor_creates_table() {
         let cache = SqliteAdvisoryCache::in_memory().expect("open in-memory cache");
         let conn = cache.pool.get().expect("get conn");
         let count: i64 = conn
@@ -256,7 +254,17 @@ mod tests {
             )
             .expect("query table");
         assert_eq!(count, 1);
+    }
 
+    /// Regression: the expiry index was removed because the cleanup query
+    /// `WHERE inserted_at + ttl_secs * ? < ?` cannot use a
+    /// `(inserted_at, ttl_secs)` index — the arithmetic forces a full scan
+    /// regardless. Re-introducing the index without revising the query
+    /// would just bloat the schema without benefit.
+    #[tokio::test]
+    async fn schema_does_not_create_unused_expiry_index() {
+        let cache = SqliteAdvisoryCache::in_memory().expect("open in-memory cache");
+        let conn = cache.pool.get().expect("get conn");
         let idx: i64 = conn
             .query_row(
                 "SELECT count(*) FROM sqlite_master \
@@ -265,7 +273,7 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("query index");
-        assert_eq!(idx, 1);
+        assert_eq!(idx, 0, "idx_advisory_expiry must not be created");
     }
 
     #[tokio::test]

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -42,7 +42,17 @@ impl SqliteAdvisoryCache {
     /// connection pool cannot be built.
     pub fn from_config(config: &crate::config::AdvisoryCacheConfig) -> anyhow::Result<Self> {
         let path = match &config.db_path {
-            Some(p) => p.clone(),
+            Some(p) => {
+                // Create parent directories for user-supplied custom paths.
+                // Without this, opening a nested override silently degrades
+                // to memory-only when SQLite cannot find the directory.
+                if let Some(parent) = p.parent()
+                    && !parent.as_os_str().is_empty()
+                {
+                    std::fs::create_dir_all(parent)?;
+                }
+                p.clone()
+            }
             None => {
                 let cache_dir = Self::cache_dir()?;
                 std::fs::create_dir_all(&cache_dir)?;
@@ -302,8 +312,8 @@ mod tests {
         assert!(b >= a);
     }
 
-    #[test]
-    fn with_ttl_secs_overrides_default() {
+    #[tokio::test]
+    async fn with_ttl_secs_overrides_default() {
         let cache = SqliteAdvisoryCache::in_memory()
             .expect("open in-memory cache")
             .with_ttl_secs(42);

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -297,4 +297,26 @@ mod tests {
         let cache = SqliteAdvisoryCache::in_memory().unwrap();
         assert!(cache.get("RUSTSEC-2099-9999").await.is_none());
     }
+
+    #[tokio::test]
+    async fn expired_entries_are_dropped_on_read() {
+        let cache = SqliteAdvisoryCache::in_memory()
+            .expect("open in-memory cache")
+            .with_ttl_secs(0);
+        cache.insert(sample_found()).await;
+        // ttl_secs = 0 means any positive elapsed time expires the row.
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        assert!(cache.get("RUSTSEC-2020-0036").await.is_none());
+
+        // Row should be deleted as a side effect of the previous get.
+        let conn = cache.pool.get().expect("conn");
+        let count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM advisories WHERE id = ?",
+                ["RUSTSEC-2020-0036"],
+                |row| row.get(0),
+            )
+            .expect("query");
+        assert_eq!(count, 0);
+    }
 }

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use async_trait::async_trait;
 use r2d2::Pool;
 use rusqlite::params;
 
@@ -139,6 +140,7 @@ impl SqliteAdvisoryCache {
     }
 }
 
+#[async_trait]
 impl AdvisoryReadCache for SqliteAdvisoryCache {
     async fn get(&self, advisory_id: &str) -> Option<CachedAdvisory> {
         let pool = Arc::clone(&self.pool);
@@ -177,6 +179,7 @@ impl AdvisoryReadCache for SqliteAdvisoryCache {
     }
 }
 
+#[async_trait]
 impl AdvisoryWriteCache for SqliteAdvisoryCache {
     async fn insert(&self, advisory: CachedAdvisory) {
         let pool = Arc::clone(&self.pool);

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -4,16 +4,20 @@ use std::path::PathBuf;
 use std::sync::Arc;
 #[cfg(test)]
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
-#[cfg(test)]
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use r2d2::Pool;
+use rusqlite::params;
 
 use crate::cache::sqlite_manager::SqliteConnectionManager;
 
+use super::{AdvisoryReadCache, AdvisoryWriteCache, CachedAdvisory};
+
 /// Default TTL for stored advisories (24 hours).
 pub const DEFAULT_ADVISORY_TTL_SECS: i64 = 86_400;
+
+/// Nanoseconds per second — matches `cache::sqlite::NANOS_PER_SEC`.
+const NANOS_PER_SEC: i64 = 1_000_000_000;
 
 #[cfg(test)]
 static TEST_DB_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -95,10 +99,6 @@ impl SqliteAdvisoryCache {
              ON advisories(inserted_at, ttl_secs)",
             [],
         )?;
-        tracing::debug!(
-            ttl_secs = self.ttl_secs,
-            "SqliteAdvisoryCache schema initialised"
-        );
         Ok(())
     }
 
@@ -123,7 +123,99 @@ impl SqliteAdvisoryCache {
     }
 }
 
-#[cfg(test)]
+impl AdvisoryReadCache for SqliteAdvisoryCache {
+    async fn get(&self, advisory_id: &str) -> Option<CachedAdvisory> {
+        let pool = Arc::clone(&self.pool);
+        let id = advisory_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get().ok()?;
+            let now = current_timestamp();
+            let row: Result<(String, i64, i64), _> = conn.query_row(
+                "SELECT data, inserted_at, ttl_secs FROM advisories WHERE id = ?",
+                [id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            );
+            match row {
+                Ok((data, inserted_at, ttl_secs)) => {
+                    if now > inserted_at + ttl_secs * NANOS_PER_SEC {
+                        let _ = conn.execute("DELETE FROM advisories WHERE id = ?", [id.as_str()]);
+                        None
+                    } else {
+                        match serde_json::from_str::<CachedAdvisory>(&data) {
+                            Ok(advisory) => Some(advisory),
+                            Err(err) => {
+                                tracing::warn!("Corrupted advisory cache row for {}: {}", id, err);
+                                let _ = conn
+                                    .execute("DELETE FROM advisories WHERE id = ?", [id.as_str()]);
+                                None
+                            }
+                        }
+                    }
+                }
+                Err(_) => None,
+            }
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+}
+
+impl AdvisoryWriteCache for SqliteAdvisoryCache {
+    async fn insert(&self, advisory: CachedAdvisory) {
+        let pool = Arc::clone(&self.pool);
+        let ttl_secs = self.ttl_secs;
+        let now = current_timestamp();
+        let id = advisory.id.clone();
+        let data = match serde_json::to_string(&advisory) {
+            Ok(s) => s,
+            Err(err) => {
+                tracing::warn!("Failed to serialise advisory {}: {}", id, err);
+                return;
+            }
+        };
+        let _ = tokio::task::spawn_blocking(move || {
+            let Some(conn) = pool.get().ok() else {
+                return;
+            };
+            let _ = conn.execute(
+                "INSERT INTO advisories (id, data, inserted_at, ttl_secs) \
+                 VALUES (?, ?, ?, ?) \
+                 ON CONFLICT(id) DO UPDATE SET \
+                   data = excluded.data, \
+                   inserted_at = excluded.inserted_at, \
+                   ttl_secs = excluded.ttl_secs \
+                 WHERE excluded.inserted_at >= advisories.inserted_at",
+                params![id, data, now, ttl_secs],
+            );
+        })
+        .await;
+    }
+
+    async fn remove(&self, advisory_id: &str) {
+        let pool = Arc::clone(&self.pool);
+        let id = advisory_id.to_string();
+        let _ = tokio::task::spawn_blocking(move || {
+            let Some(conn) = pool.get().ok() else {
+                return;
+            };
+            let _ = conn.execute("DELETE FROM advisories WHERE id = ?", [id.as_str()]);
+        })
+        .await;
+    }
+
+    async fn clear(&self) {
+        let pool = Arc::clone(&self.pool);
+        let _ = tokio::task::spawn_blocking(move || {
+            let Some(conn) = pool.get().ok() else {
+                return;
+            };
+            let _ = conn.execute("DELETE FROM advisories", []);
+        })
+        .await;
+    }
+}
+
 fn current_timestamp() -> i64 {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -175,5 +267,34 @@ mod tests {
             .expect("open in-memory cache")
             .with_ttl_secs(42);
         assert_eq!(cache.ttl_secs, 42);
+    }
+
+    use std::time::SystemTime;
+
+    use super::super::{AdvisoryKind, CachedAdvisory};
+
+    fn sample_found() -> CachedAdvisory {
+        CachedAdvisory {
+            id: "RUSTSEC-2020-0036".to_string(),
+            kind: AdvisoryKind::Found {
+                summary: Some("unmaintained".to_string()),
+                unmaintained: true,
+            },
+            fetched_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_then_get_returns_advisory() {
+        let cache = SqliteAdvisoryCache::in_memory().unwrap();
+        let advisory = sample_found();
+        cache.insert(advisory.clone()).await;
+        assert_eq!(cache.get(&advisory.id).await, Some(advisory));
+    }
+
+    #[tokio::test]
+    async fn get_unknown_id_returns_none() {
+        let cache = SqliteAdvisoryCache::in_memory().unwrap();
+        assert!(cache.get("RUSTSEC-2099-9999").await.is_none());
     }
 }

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -395,4 +395,34 @@ mod tests {
         // Newer entry must still be present.
         assert_eq!(cache.get("RUSTSEC-2020-0036").await, Some(newer));
     }
+
+    #[tokio::test]
+    async fn corrupted_row_is_deleted_and_treated_as_miss() {
+        let cache = SqliteAdvisoryCache::in_memory().unwrap();
+        let now = current_timestamp();
+        {
+            let conn = cache.pool.get().unwrap();
+            conn.execute(
+                "INSERT INTO advisories (id, data, inserted_at, ttl_secs) VALUES (?, ?, ?, ?)",
+                params![
+                    "RUSTSEC-2020-0036",
+                    "{not valid json",
+                    now,
+                    DEFAULT_ADVISORY_TTL_SECS
+                ],
+            )
+            .unwrap();
+        }
+        assert!(cache.get("RUSTSEC-2020-0036").await.is_none());
+
+        let conn = cache.pool.get().unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM advisories WHERE id = ?",
+                ["RUSTSEC-2020-0036"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+    }
 }

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -1,1 +1,179 @@
 //! SQLite-backed advisory cache (L2 layer).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+#[cfg(test)]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use r2d2::Pool;
+
+use crate::cache::sqlite_manager::SqliteConnectionManager;
+
+/// Default TTL for stored advisories (24 hours).
+pub const DEFAULT_ADVISORY_TTL_SECS: i64 = 86_400;
+
+#[cfg(test)]
+static TEST_DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// SQLite-backed cache for OSV advisory results.
+pub struct SqliteAdvisoryCache {
+    pool: Arc<Pool<SqliteConnectionManager>>,
+    ttl_secs: i64,
+}
+
+impl SqliteAdvisoryCache {
+    /// Build a cache at the default location (`~/.cache/dependi/advisory_cache.db`).
+    pub fn new() -> anyhow::Result<Self> {
+        let cache_dir = Self::cache_dir()?;
+        std::fs::create_dir_all(&cache_dir)?;
+        let path = cache_dir.join("advisory_cache.db");
+        Self::with_path(path, DEFAULT_ADVISORY_TTL_SECS)
+    }
+
+    /// Build a cache at a custom path, with a custom TTL.
+    pub fn with_path(path: PathBuf, ttl_secs: i64) -> anyhow::Result<Self> {
+        let manager = SqliteConnectionManager::file_with_config(&path, 5_000, 64_000);
+        let pool = Pool::builder()
+            .max_size(4)
+            .min_idle(Some(1))
+            .connection_timeout(Duration::from_secs(5))
+            .idle_timeout(Some(Duration::from_secs(600)))
+            .max_lifetime(Some(Duration::from_secs(1800)))
+            .build(manager)?;
+
+        let cache = Self {
+            pool: Arc::new(pool),
+            ttl_secs,
+        };
+        cache.init_schema()?;
+        Ok(cache)
+    }
+
+    /// In-memory cache for tests.
+    #[cfg(test)]
+    pub fn in_memory() -> anyhow::Result<Self> {
+        let id = TEST_DB_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let uri = format!("file:advisorymemdb{id}?mode=memory&cache=shared");
+        let manager = SqliteConnectionManager::in_memory(&uri);
+        let pool = Pool::builder().max_size(4).build(manager)?;
+        let cache = Self {
+            pool: Arc::new(pool),
+            ttl_secs: DEFAULT_ADVISORY_TTL_SECS,
+        };
+        cache.init_schema_memory()?;
+        Ok(cache)
+    }
+
+    /// Construct a cache with a custom TTL (used by negative-cache wiring).
+    pub fn with_ttl_secs(self, ttl_secs: i64) -> Self {
+        Self { ttl_secs, ..self }
+    }
+
+    fn cache_dir() -> anyhow::Result<PathBuf> {
+        let cache_dir = dirs::cache_dir()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine cache directory"))?;
+        Ok(cache_dir.join("dependi"))
+    }
+
+    fn init_schema(&self) -> anyhow::Result<()> {
+        let conn = self.pool.get()?;
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS advisories (
+                id TEXT PRIMARY KEY,
+                data TEXT NOT NULL,
+                inserted_at INTEGER NOT NULL,
+                ttl_secs INTEGER NOT NULL
+            )",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_advisory_expiry \
+             ON advisories(inserted_at, ttl_secs)",
+            [],
+        )?;
+        tracing::debug!(
+            ttl_secs = self.ttl_secs,
+            "SqliteAdvisoryCache schema initialised"
+        );
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn init_schema_memory(&self) -> anyhow::Result<()> {
+        let conn = self.pool.get()?;
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS advisories (
+                id TEXT PRIMARY KEY,
+                data TEXT NOT NULL,
+                inserted_at INTEGER NOT NULL,
+                ttl_secs INTEGER NOT NULL
+            )",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_advisory_expiry \
+             ON advisories(inserted_at, ttl_secs)",
+            [],
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+fn current_timestamp() -> i64 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    nanos.min(i64::MAX as u128) as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn in_memory_constructor_creates_table_and_index() {
+        let cache = SqliteAdvisoryCache::in_memory().expect("open in-memory cache");
+        let conn = cache.pool.get().expect("get conn");
+        let count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE name = 'advisories' AND type = 'table'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("query table");
+        assert_eq!(count, 1);
+
+        let idx: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master \
+                 WHERE name = 'idx_advisory_expiry' AND type = 'index'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("query index");
+        assert_eq!(idx, 1);
+    }
+
+    #[tokio::test]
+    async fn current_timestamp_is_positive_and_monotonic() {
+        let a = current_timestamp();
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        let b = current_timestamp();
+        assert!(a > 0);
+        assert!(b >= a);
+    }
+
+    #[test]
+    fn with_ttl_secs_overrides_default() {
+        let cache = SqliteAdvisoryCache::in_memory()
+            .expect("open in-memory cache")
+            .with_ttl_secs(42);
+        assert_eq!(cache.ttl_secs, 42);
+    }
+}

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -319,4 +319,53 @@ mod tests {
             .expect("query");
         assert_eq!(count, 0);
     }
+
+    #[tokio::test]
+    async fn older_insert_does_not_clobber_newer_one() {
+        let cache = SqliteAdvisoryCache::in_memory().unwrap();
+
+        let newer = CachedAdvisory {
+            id: "RUSTSEC-2020-0036".to_string(),
+            kind: AdvisoryKind::Found {
+                summary: Some("newer".to_string()),
+                unmaintained: true,
+            },
+            fetched_at: SystemTime::UNIX_EPOCH,
+        };
+
+        // Manually craft an older row directly via SQL with a past timestamp.
+        let older_data = serde_json::to_string(&CachedAdvisory {
+            id: "RUSTSEC-2020-0036".to_string(),
+            kind: AdvisoryKind::Found {
+                summary: Some("older".to_string()),
+                unmaintained: false,
+            },
+            fetched_at: SystemTime::UNIX_EPOCH,
+        })
+        .unwrap();
+        cache.insert(newer.clone()).await;
+
+        let conn = cache.pool.get().unwrap();
+        let now = current_timestamp();
+        // Try to upsert using `now - 1s` as inserted_at.
+        let attempt = conn.execute(
+            "INSERT INTO advisories (id, data, inserted_at, ttl_secs) \
+             VALUES (?, ?, ?, ?) \
+             ON CONFLICT(id) DO UPDATE SET \
+               data = excluded.data, \
+               inserted_at = excluded.inserted_at, \
+               ttl_secs = excluded.ttl_secs \
+             WHERE excluded.inserted_at >= advisories.inserted_at",
+            params![
+                "RUSTSEC-2020-0036",
+                older_data,
+                now - NANOS_PER_SEC,
+                DEFAULT_ADVISORY_TTL_SECS,
+            ],
+        );
+        assert!(attempt.is_ok());
+
+        // Newer entry must still be present.
+        assert_eq!(cache.get("RUSTSEC-2020-0036").await, Some(newer));
+    }
 }

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -35,6 +35,23 @@ impl SqliteAdvisoryCache {
         Self::with_path(path, DEFAULT_ADVISORY_TTL_SECS)
     }
 
+    /// Build a cache from an [`AdvisoryCacheConfig`] (issue #237).
+    ///
+    /// Uses `config.db_path` if set, otherwise the default cache location.
+    /// Returns an error if the database directory cannot be created or the
+    /// connection pool cannot be built.
+    pub fn from_config(config: &crate::config::AdvisoryCacheConfig) -> anyhow::Result<Self> {
+        let path = match &config.db_path {
+            Some(p) => p.clone(),
+            None => {
+                let cache_dir = Self::cache_dir()?;
+                std::fs::create_dir_all(&cache_dir)?;
+                cache_dir.join("advisory_cache.db")
+            }
+        };
+        Self::with_path(path, config.ttl_secs as i64)
+    }
+
     /// Build a cache at a custom path, with a custom TTL.
     pub fn with_path(path: PathBuf, ttl_secs: i64) -> anyhow::Result<Self> {
         let manager = SqliteConnectionManager::file_with_config(&path, 5_000, 64_000);

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -10,15 +10,12 @@ use async_trait::async_trait;
 use r2d2::Pool;
 use rusqlite::params;
 
-use crate::cache::sqlite_manager::SqliteConnectionManager;
+use crate::cache::sqlite_manager::{NANOS_PER_SEC, SqliteConnectionManager};
 
 use super::{AdvisoryReadCache, AdvisoryWriteCache, CachedAdvisory};
 
 /// Default TTL for stored advisories (24 hours).
 pub const DEFAULT_ADVISORY_TTL_SECS: i64 = 86_400;
-
-/// Nanoseconds per second — matches `cache::sqlite::NANOS_PER_SEC`.
-const NANOS_PER_SEC: i64 = 1_000_000_000;
 
 #[cfg(test)]
 static TEST_DB_COUNTER: AtomicU64 = AtomicU64::new(0);

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -76,6 +76,22 @@ impl SqliteAdvisoryCache {
         Self { ttl_secs, ..self }
     }
 
+    /// Delete every expired entry. Returns the number of rows removed.
+    pub async fn cleanup_expired(&self) -> anyhow::Result<usize> {
+        let pool = Arc::clone(&self.pool);
+        tokio::task::spawn_blocking(move || -> anyhow::Result<usize> {
+            let conn = pool.get()?;
+            let now = current_timestamp();
+            let rows = conn.execute(
+                "DELETE FROM advisories WHERE inserted_at + ttl_secs * ? < ?",
+                params![NANOS_PER_SEC, now],
+            )?;
+            Ok(rows)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e}"))?
+    }
+
     fn cache_dir() -> anyhow::Result<PathBuf> {
         let cache_dir = dirs::cache_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not determine cache directory"))?;
@@ -318,6 +334,17 @@ mod tests {
             )
             .expect("query");
         assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_expired_deletes_only_expired_rows() {
+        let cache = SqliteAdvisoryCache::in_memory().unwrap().with_ttl_secs(0);
+        cache.insert(sample_found()).await;
+        tokio::time::sleep(Duration::from_millis(2)).await;
+
+        let removed = cache.cleanup_expired().await.expect("cleanup");
+        assert_eq!(removed, 1);
+        assert!(cache.get("RUSTSEC-2020-0036").await.is_none());
     }
 
     #[tokio::test]

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -396,6 +396,31 @@ mod tests {
         assert_eq!(cache.get("RUSTSEC-2020-0036").await, Some(newer));
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dropped_get_future_does_not_corrupt_cache() {
+        let cache = Arc::new(SqliteAdvisoryCache::in_memory().unwrap());
+        cache.insert(sample_found()).await;
+
+        // Spawn many gets, abort half of them mid-flight.
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let cache = Arc::clone(&cache);
+            handles.push(tokio::spawn(
+                async move { cache.get("RUSTSEC-2020-0036").await },
+            ));
+        }
+        for (i, h) in handles.into_iter().enumerate() {
+            if i % 2 == 0 {
+                h.abort();
+            } else {
+                let _ = h.await;
+            }
+        }
+
+        // Survivor reads still work.
+        assert!(cache.get("RUSTSEC-2020-0036").await.is_some());
+    }
+
     #[tokio::test]
     async fn corrupted_row_is_deleted_and_treated_as_miss() {
         let cache = SqliteAdvisoryCache::in_memory().unwrap();

--- a/dependi-lsp/src/cache/mod.rs
+++ b/dependi-lsp/src/cache/mod.rs
@@ -19,6 +19,7 @@ use dashmap::DashMap;
 
 use crate::registries::VersionInfo;
 
+pub mod advisory;
 pub mod sqlite;
 pub(crate) mod sqlite_manager;
 

--- a/dependi-lsp/src/cache/mod.rs
+++ b/dependi-lsp/src/cache/mod.rs
@@ -23,7 +23,7 @@ pub mod advisory;
 pub mod sqlite;
 pub(crate) mod sqlite_manager;
 
-pub use advisory::{AdvisoryKind, CachedAdvisory};
+pub use advisory::{AdvisoryKind, AdvisoryReadCache, AdvisoryWriteCache, CachedAdvisory};
 pub use sqlite::SqliteCache;
 
 /// Trait for read-only cache operations

--- a/dependi-lsp/src/cache/mod.rs
+++ b/dependi-lsp/src/cache/mod.rs
@@ -23,7 +23,9 @@ pub mod advisory;
 pub mod sqlite;
 pub(crate) mod sqlite_manager;
 
-pub use advisory::{AdvisoryKind, AdvisoryReadCache, AdvisoryWriteCache, CachedAdvisory};
+pub use advisory::{
+    AdvisoryKind, AdvisoryReadCache, AdvisoryWriteCache, CachedAdvisory, NullAdvisoryCache,
+};
 pub use sqlite::SqliteCache;
 
 /// Trait for read-only cache operations

--- a/dependi-lsp/src/cache/mod.rs
+++ b/dependi-lsp/src/cache/mod.rs
@@ -23,6 +23,7 @@ pub mod advisory;
 pub mod sqlite;
 pub(crate) mod sqlite_manager;
 
+pub use advisory::{AdvisoryKind, CachedAdvisory};
 pub use sqlite::SqliteCache;
 
 /// Trait for read-only cache operations

--- a/dependi-lsp/src/cache/mod.rs
+++ b/dependi-lsp/src/cache/mod.rs
@@ -24,7 +24,8 @@ pub mod sqlite;
 pub(crate) mod sqlite_manager;
 
 pub use advisory::{
-    AdvisoryKind, AdvisoryReadCache, AdvisoryWriteCache, CachedAdvisory, NullAdvisoryCache,
+    AdvisoryCacheStats, AdvisoryKind, AdvisoryReadCache, AdvisoryWriteCache, CachedAdvisory,
+    DEFAULT_ADVISORY_TTL, MemoryAdvisoryCache, NullAdvisoryCache,
 };
 pub use sqlite::SqliteCache;
 

--- a/dependi-lsp/src/cache/mod.rs
+++ b/dependi-lsp/src/cache/mod.rs
@@ -24,8 +24,9 @@ pub mod sqlite;
 pub(crate) mod sqlite_manager;
 
 pub use advisory::{
-    AdvisoryCacheStats, AdvisoryKind, AdvisoryReadCache, AdvisoryWriteCache, CachedAdvisory,
-    DEFAULT_ADVISORY_TTL, MemoryAdvisoryCache, NullAdvisoryCache,
+    ADVISORY_CLEANUP_INTERVAL, AdvisoryCacheStats, AdvisoryKind, AdvisoryReadCache,
+    AdvisoryWriteCache, CachedAdvisory, DEFAULT_ADVISORY_TTL, HybridAdvisoryCache,
+    MemoryAdvisoryCache, NullAdvisoryCache,
 };
 pub use sqlite::SqliteCache;
 

--- a/dependi-lsp/src/cache/sqlite.rs
+++ b/dependi-lsp/src/cache/sqlite.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use super::sqlite_manager::SqliteConnectionManager;
+use super::sqlite_manager::{NANOS_PER_SEC, SqliteConnectionManager};
 use r2d2::Pool;
 use rusqlite::params;
 
@@ -403,10 +403,6 @@ pub struct PoolState {
     /// Number of idle connections available
     pub idle_connections: u32,
 }
-
-/// Nanoseconds in one second — used to convert `ttl_secs` to the same unit as
-/// `inserted_at` when computing expiration in SQL queries.
-const NANOS_PER_SEC: i64 = 1_000_000_000;
 
 /// Current Unix time in nanoseconds.
 ///

--- a/dependi-lsp/src/cache/sqlite_manager.rs
+++ b/dependi-lsp/src/cache/sqlite_manager.rs
@@ -7,6 +7,13 @@ use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
 
+/// Nanoseconds in one second — used to convert `ttl_secs` to the same unit as
+/// `inserted_at` when computing expiration in SQL queries.
+///
+/// Centralised here so both the version cache (`cache::sqlite`) and the
+/// advisory cache (`cache::advisory::sqlite`) share the same definition.
+pub(crate) const NANOS_PER_SEC: i64 = 1_000_000_000;
+
 /// Connection manager for SQLite databases used with r2d2 connection pooling.
 pub struct SqliteConnectionManager {
     path: PathBuf,
@@ -128,5 +135,10 @@ mod tests {
             .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
             .unwrap();
         assert_eq!(busy_timeout, 3000);
+    }
+
+    #[test]
+    fn nanos_per_sec_is_one_billion() {
+        assert_eq!(super::NANOS_PER_SEC, 1_000_000_000);
     }
 }

--- a/dependi-lsp/src/config.rs
+++ b/dependi-lsp/src/config.rs
@@ -19,6 +19,8 @@ pub struct Config {
     pub diagnostics: DiagnosticsConfig,
     /// Cache configuration
     pub cache: CacheConfig,
+    /// RustSec advisory cache configuration (issue #237)
+    pub advisory_cache: AdvisoryCacheConfig,
     /// Security/vulnerability configuration
     pub security: SecurityConfig,
     /// Packages to ignore (glob patterns)
@@ -80,6 +82,31 @@ impl Default for CacheConfig {
         Self {
             ttl_secs: DEFAULT_CACHE_TTL_SECS,
             debounce_ms: DEFAULT_DEBOUNCE_MS,
+        }
+    }
+}
+
+/// Configuration for the RustSec advisory cache (issue #237).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct AdvisoryCacheConfig {
+    /// Enable the cache. Disabled => NullAdvisoryCache (every call hits HTTP).
+    pub enabled: bool,
+    /// Positive cache TTL in seconds.
+    pub ttl_secs: u64,
+    /// Negative cache TTL in seconds (used for OSV 404 responses).
+    pub negative_ttl_secs: u64,
+    /// Optional override for the SQLite database path.
+    pub db_path: Option<std::path::PathBuf>,
+}
+
+impl Default for AdvisoryCacheConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            ttl_secs: 86_400,
+            negative_ttl_secs: 3_600,
+            db_path: None,
         }
     }
 }
@@ -726,5 +753,28 @@ mod tests {
         let patterns = vec!["".to_string()];
         assert!(super::is_package_ignored("", &patterns));
         assert!(!super::is_package_ignored("anything", &patterns));
+    }
+}
+
+#[cfg(test)]
+mod advisory_config_tests {
+    use super::AdvisoryCacheConfig;
+
+    #[test]
+    fn defaults_match_design_spec() {
+        let cfg = AdvisoryCacheConfig::default();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.ttl_secs, 86_400);
+        assert_eq!(cfg.negative_ttl_secs, 3_600);
+        assert!(cfg.db_path.is_none());
+    }
+
+    #[test]
+    fn deserialise_partial_json_uses_defaults_for_missing_fields() {
+        let cfg: AdvisoryCacheConfig =
+            serde_json::from_str(r#"{"enabled":false}"#).expect("partial deserialise");
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.ttl_secs, 86_400);
+        assert_eq!(cfg.negative_ttl_secs, 3_600);
     }
 }

--- a/dependi-lsp/src/main.rs
+++ b/dependi-lsp/src/main.rs
@@ -436,7 +436,13 @@ async fn run_scan(
 
     // Allow tests to inject a custom OSV endpoint
     let osv_client = match std::env::var("OSV_ENDPOINT") {
-        Ok(url) => OsvClient::with_endpoint(url),
+        Ok(url) => match OsvClient::with_endpoint(url) {
+            Ok(client) => client,
+            Err(e) => {
+                eprintln!("Error building OSV client for OSV_ENDPOINT: {e}");
+                return ExitCode::FAILURE;
+            }
+        },
         Err(_) => OsvClient::default(),
     };
     let results = match osv_client.query_batch(&queries).await {

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -27,10 +27,21 @@ pub struct QueryResult {
 pub struct OsvClient {
     client: Arc<Client>,
     base_url: String,
+    // Wired into `check_rustsec_unmaintained` in Task 22; until then the field
+    // is only consumed via the test-only `advisory_cache()` accessor, so the
+    // lib-only build legitimately sees no read.
+    #[allow(dead_code)]
+    advisory_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
 }
 
 impl OsvClient {
     pub fn new() -> anyhow::Result<Self> {
+        Self::new_with_cache(Arc::new(crate::cache::advisory::NullAdvisoryCache))
+    }
+
+    pub fn new_with_cache(
+        advisory_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
+    ) -> anyhow::Result<Self> {
         let client = Client::builder()
             .user_agent("dependi-lsp (https://github.com/mathieu/zed-dependi)")
             .timeout(Duration::from_secs(30))
@@ -39,11 +50,23 @@ impl OsvClient {
         Ok(Self {
             client: Arc::new(client),
             base_url: OSV_API_BASE.to_string(),
+            advisory_cache,
         })
     }
 
-    /// Constructor used in tests to point the client at a mock server.
+    /// Constructor used in tests to point the client at a mock server (no cache).
     pub fn with_endpoint(endpoint: String) -> Self {
+        Self::with_endpoint_and_cache(
+            endpoint,
+            Arc::new(crate::cache::advisory::NullAdvisoryCache),
+        )
+    }
+
+    /// Test/runtime constructor: explicit endpoint and cache.
+    pub fn with_endpoint_and_cache(
+        endpoint: String,
+        advisory_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
+    ) -> Self {
         Self {
             base_url: endpoint,
             client: Arc::new(
@@ -52,7 +75,14 @@ impl OsvClient {
                     .build()
                     .expect("reqwest client should build"),
             ),
+            advisory_cache,
         }
+    }
+
+    /// Accessor used by integration tests to verify cache state.
+    #[cfg(test)]
+    pub fn advisory_cache(&self) -> &Arc<dyn crate::cache::advisory::AdvisoryWriteCache> {
+        &self.advisory_cache
     }
 
     fn convert_vulnerability(osv: &OsvVulnerability) -> Vulnerability {
@@ -496,6 +526,23 @@ mod tests {
         assert!(
             result.is_err(),
             "query to unreachable endpoint should error, got {result:?}"
+        );
+    }
+
+    use crate::cache::advisory::{AdvisoryReadCache, AdvisoryWriteCache, NullAdvisoryCache};
+
+    #[tokio::test]
+    async fn with_endpoint_accepts_advisory_cache() {
+        let cache: Arc<dyn AdvisoryWriteCache> = Arc::new(NullAdvisoryCache);
+        let client =
+            OsvClient::with_endpoint_and_cache("http://example.invalid".to_string(), cache);
+        // Smoke-test: cache is reachable through the public accessor.
+        assert!(
+            client
+                .advisory_cache()
+                .get("RUSTSEC-2020-0036")
+                .await
+                .is_none()
         );
     }
 

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -88,6 +88,23 @@ impl OsvClient {
         })
     }
 
+    /// Infallible constructor used by the LSP backend as a startup fallback
+    /// when [`OsvClient::new_with_caches`] fails (rare reqwest builder
+    /// errors). Uses `reqwest::Client::new()` directly — which never
+    /// panics — so the LSP can keep serving non-vulnerability features
+    /// instead of crashing during `initialize`.
+    pub fn with_default_client_and_caches(
+        positive_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
+        negative_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
+    ) -> Self {
+        Self {
+            client: Arc::new(Client::new()),
+            base_url: OSV_API_BASE.to_string(),
+            advisory_cache: positive_cache,
+            negative_cache,
+        }
+    }
+
     /// Build a client pointing at a custom OSV endpoint (no advisory cache).
     ///
     /// Used at runtime by the standalone scanner (`OSV_ENDPOINT` env var) and

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -39,19 +39,41 @@ pub struct QueryResult {
 }
 
 /// OSV.dev API client
+///
+/// Holds two caches because positive and negative OSV results have different
+/// freshness needs: a real RUSTSEC entry is stable for a long time (hours),
+/// but a 404 might just mean OSV has not yet ingested a brand-new advisory,
+/// so we cache it for a much shorter window controlled by
+/// `AdvisoryCacheConfig::negative_ttl_secs`.
 pub struct OsvClient {
     client: Arc<Client>,
     base_url: String,
+    /// Cache used for `Found` advisory entries (long TTL).
     advisory_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
+    /// Cache used for `NotFound` advisory entries (short TTL).
+    negative_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
 }
 
 impl OsvClient {
     pub fn new() -> anyhow::Result<Self> {
-        Self::new_with_cache(Arc::new(crate::cache::advisory::NullAdvisoryCache))
+        let null: Arc<dyn crate::cache::advisory::AdvisoryWriteCache> =
+            Arc::new(crate::cache::advisory::NullAdvisoryCache);
+        Self::new_with_caches(Arc::clone(&null), null)
     }
 
+    /// Backwards-compatible constructor: uses the same cache for positive
+    /// and negative entries. Prefer [`OsvClient::new_with_caches`] when the
+    /// caller has separate positive/negative caches with different TTLs.
     pub fn new_with_cache(
         advisory_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
+    ) -> anyhow::Result<Self> {
+        Self::new_with_caches(Arc::clone(&advisory_cache), advisory_cache)
+    }
+
+    /// Build a client with explicit positive and negative caches.
+    pub fn new_with_caches(
+        positive_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
+        negative_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
     ) -> anyhow::Result<Self> {
         let client = Client::builder()
             .user_agent("dependi-lsp (https://github.com/mathieu/zed-dependi)")
@@ -61,7 +83,8 @@ impl OsvClient {
         Ok(Self {
             client: Arc::new(client),
             base_url: OSV_API_BASE.to_string(),
-            advisory_cache,
+            advisory_cache: positive_cache,
+            negative_cache,
         })
     }
 
@@ -76,10 +99,13 @@ impl OsvClient {
             .timeout(Duration::from_secs(30))
             .build()
             .unwrap_or_else(|_| Client::new());
+        let null: Arc<dyn crate::cache::advisory::AdvisoryWriteCache> =
+            Arc::new(crate::cache::advisory::NullAdvisoryCache);
         Self {
             base_url: endpoint,
             client: Arc::new(client),
-            advisory_cache: Arc::new(crate::cache::advisory::NullAdvisoryCache),
+            advisory_cache: Arc::clone(&null),
+            negative_cache: null,
         }
     }
 
@@ -88,10 +114,26 @@ impl OsvClient {
     /// Gated to `#[cfg(test)]` so production code paths cannot accidentally
     /// inject a `NullAdvisoryCache` here. Runtime callers that need cache
     /// injection should use [`OsvClient::new_with_cache`] instead.
+    ///
+    /// Reuses `advisory_cache` for both the positive and negative layers;
+    /// tests that need to assert separate behaviour should use
+    /// [`OsvClient::with_endpoint_and_caches`] instead.
     #[cfg(test)]
     pub fn with_endpoint_and_cache(
         endpoint: String,
         advisory_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
+    ) -> Self {
+        Self::with_endpoint_and_caches(endpoint, Arc::clone(&advisory_cache), advisory_cache)
+    }
+
+    /// Test-only constructor: explicit endpoint, positive cache, and
+    /// negative cache. Mirrors [`OsvClient::new_with_caches`] but lets the
+    /// caller pin the URL to a wiremock server.
+    #[cfg(test)]
+    pub fn with_endpoint_and_caches(
+        endpoint: String,
+        positive_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
+        negative_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
     ) -> Self {
         let client = Client::builder()
             .timeout(Duration::from_secs(30))
@@ -100,14 +142,21 @@ impl OsvClient {
         Self {
             base_url: endpoint,
             client: Arc::new(client),
-            advisory_cache,
+            advisory_cache: positive_cache,
+            negative_cache,
         }
     }
 
-    /// Accessor used by integration tests to verify cache state.
+    /// Accessor used by integration tests to verify positive cache state.
     #[cfg(test)]
     pub fn advisory_cache(&self) -> &Arc<dyn crate::cache::advisory::AdvisoryWriteCache> {
         &self.advisory_cache
+    }
+
+    /// Accessor used by integration tests to verify negative cache state.
+    #[cfg(test)]
+    pub fn negative_cache(&self) -> &Arc<dyn crate::cache::advisory::AdvisoryWriteCache> {
+        &self.negative_cache
     }
 
     fn convert_vulnerability(osv: &OsvVulnerability) -> Vulnerability {
@@ -241,12 +290,14 @@ impl OsvClient {
             ids.len()
         );
 
-        let cache = Arc::clone(&self.advisory_cache);
+        let positive_cache = Arc::clone(&self.advisory_cache);
+        let negative_cache = Arc::clone(&self.negative_cache);
         let results: Vec<bool> = stream::iter(ids.iter().cloned())
             .map(|id| {
                 let url = format!("{}/vulns/{id}", self.base_url);
                 let client = Arc::clone(&self.client);
-                let cache = Arc::clone(&cache);
+                let positive_cache = Arc::clone(&positive_cache);
+                let negative_cache = Arc::clone(&negative_cache);
 
                 async move {
                     if !is_valid_advisory_id(&id) {
@@ -254,13 +305,21 @@ impl OsvClient {
                         return false;
                     }
 
-                    if let Some(cached) = cache.get(&id).await {
+                    // Positive cache wins over negative: if a real `Found`
+                    // entry exists, it cannot also be `NotFound`. Check it
+                    // first to avoid the (cheap) negative-cache lookup.
+                    if let Some(cached) = positive_cache.get(&id).await {
                         return match cached.kind {
                             crate::cache::advisory::AdvisoryKind::Found {
                                 unmaintained, ..
                             } => unmaintained,
                             crate::cache::advisory::AdvisoryKind::NotFound => false,
                         };
+                    }
+                    if let Some(cached) = negative_cache.get(&id).await
+                        && matches!(cached.kind, crate::cache::advisory::AdvisoryKind::NotFound)
+                    {
+                        return false;
                     }
 
                     let response = match client.get(&url).send().await {
@@ -272,7 +331,9 @@ impl OsvClient {
                     };
 
                     if response.status().as_u16() == 404 {
-                        cache
+                        // 404s land in the negative cache so they expire on
+                        // the shorter `negative_ttl_secs` schedule.
+                        negative_cache
                             .insert(crate::cache::advisory::CachedAdvisory {
                                 id: id.clone(),
                                 kind: crate::cache::advisory::AdvisoryKind::NotFound,
@@ -318,7 +379,7 @@ impl OsvClient {
                         summary_match || informational_match
                     });
 
-                    cache
+                    positive_cache
                         .insert(crate::cache::advisory::CachedAdvisory {
                             id: id.clone(),
                             kind: crate::cache::advisory::AdvisoryKind::Found {
@@ -782,6 +843,95 @@ mod tests {
             .await
             .expect("negative cached");
         assert_eq!(cached.kind, AdvisoryKind::NotFound);
+    }
+
+    #[tokio::test]
+    async fn http_404_lands_on_negative_cache_only() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/vulns/RUSTSEC-9999-0001"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let positive: Arc<dyn AdvisoryWriteCache> = Arc::new(MemoryAdvisoryCache::new());
+        let negative: Arc<dyn AdvisoryWriteCache> = Arc::new(MemoryAdvisoryCache::new());
+        let client = OsvClient::with_endpoint_and_caches(
+            server.uri(),
+            Arc::clone(&positive),
+            Arc::clone(&negative),
+        );
+
+        let _ = client
+            .check_rustsec_unmaintained(&["RUSTSEC-9999-0001".to_string()])
+            .await;
+
+        assert!(
+            positive.get("RUSTSEC-9999-0001").await.is_none(),
+            "404 must NOT land on the positive cache"
+        );
+        let cached = negative
+            .get("RUSTSEC-9999-0001")
+            .await
+            .expect("404 should land on negative cache");
+        assert_eq!(cached.kind, AdvisoryKind::NotFound);
+    }
+
+    #[tokio::test]
+    async fn http_200_lands_on_positive_cache_only() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/vulns/RUSTSEC-2020-0036"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(sample_response_body()))
+            .mount(&server)
+            .await;
+
+        let positive: Arc<dyn AdvisoryWriteCache> = Arc::new(MemoryAdvisoryCache::new());
+        let negative: Arc<dyn AdvisoryWriteCache> = Arc::new(MemoryAdvisoryCache::new());
+        let client = OsvClient::with_endpoint_and_caches(
+            server.uri(),
+            Arc::clone(&positive),
+            Arc::clone(&negative),
+        );
+
+        let _ = client
+            .check_rustsec_unmaintained(&["RUSTSEC-2020-0036".to_string()])
+            .await;
+
+        let cached = positive
+            .get("RUSTSEC-2020-0036")
+            .await
+            .expect("200 should land on positive cache");
+        assert!(matches!(cached.kind, AdvisoryKind::Found { .. }));
+        assert!(
+            negative.get("RUSTSEC-2020-0036").await.is_none(),
+            "200 must NOT land on the negative cache"
+        );
+    }
+
+    /// Confirm `negative_from_config` produces a memory-only hybrid that
+    /// honours `negative_ttl_secs` instead of `ttl_secs`.
+    #[tokio::test]
+    async fn negative_from_config_uses_negative_ttl() {
+        // ttl_secs would keep the entry alive a long time; negative_ttl_secs
+        // is short. After the short TTL expires, the entry must be gone.
+        let config = crate::config::AdvisoryCacheConfig {
+            enabled: true,
+            ttl_secs: 86_400,
+            negative_ttl_secs: 0,
+            db_path: None,
+        };
+        let hybrid = crate::cache::HybridAdvisoryCache::negative_from_config(&config);
+        hybrid
+            .insert(CachedAdvisory {
+                id: "RUSTSEC-9999-0001".to_string(),
+                kind: AdvisoryKind::NotFound,
+                fetched_at: SystemTime::now(),
+            })
+            .await;
+        // ttl=0 expires immediately on read.
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        assert!(hybrid.get("RUSTSEC-9999-0001").await.is_none());
     }
 
     #[tokio::test]

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -680,6 +680,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn http_404_is_negatively_cached() {
+        let server = MockServer::start().await;
+        let counter = Arc::new(AtomicUsize::new(0));
+        {
+            let counter = Arc::clone(&counter);
+            Mock::given(method("GET"))
+                .and(path("/vulns/RUSTSEC-9999-0001"))
+                .respond_with(move |_req: &wiremock::Request| {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    ResponseTemplate::new(404)
+                })
+                .mount(&server)
+                .await;
+        }
+
+        let cache: Arc<dyn AdvisoryWriteCache> = Arc::new(MemoryAdvisoryCache::new());
+        let client = OsvClient::with_endpoint_and_cache(server.uri(), Arc::clone(&cache));
+
+        let first = client
+            .check_rustsec_unmaintained(&["RUSTSEC-9999-0001".to_string()])
+            .await;
+        let second = client
+            .check_rustsec_unmaintained(&["RUSTSEC-9999-0001".to_string()])
+            .await;
+
+        assert!(!first);
+        assert!(!second);
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        let cached = cache
+            .get("RUSTSEC-9999-0001")
+            .await
+            .expect("negative cached");
+        assert_eq!(cached.kind, AdvisoryKind::NotFound);
+    }
+
+    #[tokio::test]
     async fn test_rustsec_advisory_lookup_limits_concurrency() {
         const EXPECTED_LIMIT: usize = RUSTSEC_ADVISORY_LOOKUP_CONCURRENCY;
 

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -27,10 +27,6 @@ pub struct QueryResult {
 pub struct OsvClient {
     client: Arc<Client>,
     base_url: String,
-    // Wired into `check_rustsec_unmaintained` in Task 22; until then the field
-    // is only consumed via the test-only `advisory_cache()` accessor, so the
-    // lib-only build legitimately sees no read.
-    #[allow(dead_code)]
     advisory_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
 }
 
@@ -206,7 +202,7 @@ impl OsvClient {
         Ok(results)
     }
 
-    async fn check_rustsec_unmaintained(&self, ids: &[String]) -> bool {
+    pub(crate) async fn check_rustsec_unmaintained(&self, ids: &[String]) -> bool {
         if ids.is_empty() {
             return false;
         }
@@ -216,12 +212,23 @@ impl OsvClient {
             ids.len()
         );
 
+        let cache = Arc::clone(&self.advisory_cache);
         let results: Vec<bool> = stream::iter(ids.iter().cloned())
             .map(|id| {
                 let url = format!("{}/vulns/{id}", self.base_url);
                 let client = Arc::clone(&self.client);
+                let cache = Arc::clone(&cache);
 
                 async move {
+                    if let Some(cached) = cache.get(&id).await {
+                        return match cached.kind {
+                            crate::cache::advisory::AdvisoryKind::Found {
+                                unmaintained, ..
+                            } => unmaintained,
+                            crate::cache::advisory::AdvisoryKind::NotFound => false,
+                        };
+                    }
+
                     let response = match client.get(&url).send().await {
                         Ok(r) => r,
                         Err(e) => {
@@ -229,6 +236,26 @@ impl OsvClient {
                             return false;
                         }
                     };
+
+                    if response.status().as_u16() == 404 {
+                        cache
+                            .insert(crate::cache::advisory::CachedAdvisory {
+                                id: id.clone(),
+                                kind: crate::cache::advisory::AdvisoryKind::NotFound,
+                                fetched_at: std::time::SystemTime::now(),
+                            })
+                            .await;
+                        return false;
+                    }
+
+                    if !response.status().is_success() {
+                        tracing::warn!(
+                            "OSV /vulns/{} returned {}, not caching",
+                            id,
+                            response.status()
+                        );
+                        return false;
+                    }
 
                     let details: Option<OsvVulnerabilityDetails> = match response.json().await {
                         Ok(d) => d,
@@ -238,14 +265,13 @@ impl OsvClient {
                         }
                     };
 
+                    let summary = details.as_ref().and_then(|v| v.summary.clone());
+
                     let is_unmaintained = details.as_ref().is_some_and(|v| {
-                        // Check summary for "maintained" or "deprecated" keywords
                         let summary_match = v.summary.as_ref().is_some_and(|s| {
                             let lower = s.to_lowercase();
                             lower.contains("maintained") || lower.contains("deprecated")
                         });
-
-                        // Check database_specific.informational for "unmaintained"
                         let informational_match = v.affected.as_ref().is_some_and(|affected| {
                             affected.iter().any(|a| {
                                 a.database_specific.as_ref().is_some_and(|db| {
@@ -255,19 +281,22 @@ impl OsvClient {
                                 })
                             })
                         });
-
                         summary_match || informational_match
                     });
 
+                    cache
+                        .insert(crate::cache::advisory::CachedAdvisory {
+                            id: id.clone(),
+                            kind: crate::cache::advisory::AdvisoryKind::Found {
+                                summary,
+                                unmaintained: is_unmaintained,
+                            },
+                            fetched_at: std::time::SystemTime::now(),
+                        })
+                        .await;
+
                     if is_unmaintained {
-                        tracing::info!(
-                            "Advisory {} indicates unmaintained package: {}",
-                            id,
-                            details
-                                .as_ref()
-                                .and_then(|v| v.summary.as_ref())
-                                .unwrap_or(&String::new())
-                        );
+                        tracing::info!("Advisory {} indicates unmaintained package", id,);
                     }
 
                     is_unmaintained
@@ -544,6 +573,67 @@ mod tests {
                 .await
                 .is_none()
         );
+    }
+
+    use std::time::SystemTime;
+
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    use crate::cache::advisory::{AdvisoryKind, CachedAdvisory, MemoryAdvisoryCache};
+
+    fn sample_response_body() -> serde_json::Value {
+        serde_json::json!({
+            "summary": "test crate is unmaintained",
+            "affected": [{
+                "database_specific": {
+                    "informational": "unmaintained"
+                }
+            }]
+        })
+    }
+
+    #[tokio::test]
+    async fn cache_hit_skips_http_for_known_advisory() {
+        let server = MockServer::start().await;
+        let counter = Arc::new(AtomicUsize::new(0));
+        {
+            let counter = Arc::clone(&counter);
+            Mock::given(method("GET"))
+                .and(path("/vulns/RUSTSEC-2020-0036"))
+                .respond_with(move |_req: &wiremock::Request| {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    ResponseTemplate::new(200).set_body_json(sample_response_body())
+                })
+                .mount(&server)
+                .await;
+        }
+
+        let cache: Arc<dyn AdvisoryWriteCache> = Arc::new(MemoryAdvisoryCache::new());
+        // Pre-populate the cache so the first call hits the L1 layer.
+        cache
+            .insert(CachedAdvisory {
+                id: "RUSTSEC-2020-0036".to_string(),
+                kind: AdvisoryKind::Found {
+                    summary: Some("cached".to_string()),
+                    unmaintained: true,
+                },
+                fetched_at: SystemTime::now(),
+            })
+            .await;
+
+        let client = OsvClient::with_endpoint_and_cache(server.uri(), Arc::clone(&cache));
+        let result = client
+            .check_rustsec_unmaintained(&["RUSTSEC-2020-0036".to_string()])
+            .await;
+
+        assert!(
+            result,
+            "cached advisory marked unmaintained must short-circuit"
+        );
+        assert_eq!(counter.load(Ordering::SeqCst), 0, "no HTTP call expected");
     }
 
     #[tokio::test]

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -65,27 +65,41 @@ impl OsvClient {
         })
     }
 
-    /// Constructor used in tests to point the client at a mock server (no cache).
+    /// Build a client pointing at a custom OSV endpoint (no advisory cache).
+    ///
+    /// Used at runtime by the standalone scanner (`OSV_ENDPOINT` env var) and
+    /// by tests to point the client at a mock HTTP server. Falls back to a
+    /// minimally-configured `reqwest::Client` if the builder rejects the
+    /// timeout we request — `reqwest::Client::new()` itself never panics.
     pub fn with_endpoint(endpoint: String) -> Self {
-        Self::with_endpoint_and_cache(
-            endpoint,
-            Arc::new(crate::cache::advisory::NullAdvisoryCache),
-        )
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| Client::new());
+        Self {
+            base_url: endpoint,
+            client: Arc::new(client),
+            advisory_cache: Arc::new(crate::cache::advisory::NullAdvisoryCache),
+        }
     }
 
-    /// Test/runtime constructor: explicit endpoint and cache.
+    /// Test-only constructor: explicit endpoint **and** advisory cache.
+    ///
+    /// Gated to `#[cfg(test)]` so production code paths cannot accidentally
+    /// inject a `NullAdvisoryCache` here. Runtime callers that need cache
+    /// injection should use [`OsvClient::new_with_cache`] instead.
+    #[cfg(test)]
     pub fn with_endpoint_and_cache(
         endpoint: String,
         advisory_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
     ) -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| Client::new());
         Self {
             base_url: endpoint,
-            client: Arc::new(
-                Client::builder()
-                    .timeout(Duration::from_secs(30))
-                    .build()
-                    .expect("reqwest client should build"),
-            ),
+            client: Arc::new(client),
             advisory_cache,
         }
     }

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -16,6 +16,21 @@ use crate::registries::{Vulnerability, VulnerabilitySeverity};
 const OSV_API_BASE: &str = "https://api.osv.dev/v1";
 const RUSTSEC_ADVISORY_LOOKUP_CONCURRENCY: usize = 5;
 
+/// Maximum length for an OSV advisory ID. Real RUSTSEC IDs are 16 characters
+/// (`RUSTSEC-YYYY-NNNN`); 64 is generous head-room for related schemes.
+const MAX_ADVISORY_ID_LEN: usize = 64;
+
+/// Whitelist sanity check for advisory IDs returned by OSV.
+///
+/// `check_rustsec_unmaintained` interpolates the ID directly into a URL and
+/// uses it as a cache key, so we constrain the alphabet up-front.
+/// Accepts only ASCII alphanumerics and the `-` separator.
+fn is_valid_advisory_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= MAX_ADVISORY_ID_LEN
+        && id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+}
+
 /// Result of a vulnerability query
 #[derive(Debug, Clone, Default)]
 pub struct QueryResult {
@@ -220,6 +235,11 @@ impl OsvClient {
                 let cache = Arc::clone(&cache);
 
                 async move {
+                    if !is_valid_advisory_id(&id) {
+                        tracing::warn!("Skipping advisory with unexpected ID format: {:?}", id);
+                        return false;
+                    }
+
                     if let Some(cached) = cache.get(&id).await {
                         return match cached.kind {
                             crate::cache::advisory::AdvisoryKind::Found {
@@ -431,6 +451,41 @@ mod tests {
         });
 
         format!("http://{addr}")
+    }
+
+    #[test]
+    fn is_valid_advisory_id_accepts_canonical_rustsec_format() {
+        assert!(is_valid_advisory_id("RUSTSEC-2020-0036"));
+        assert!(is_valid_advisory_id("RUSTSEC-2099-9999"));
+        // Non-RUSTSEC alphanumerics + `-` are also fine; OSV exposes
+        // GHSA / CVE / OSV IDs through the same endpoint.
+        assert!(is_valid_advisory_id("GHSA-xxxx-yyyy-zzzz"));
+        assert!(is_valid_advisory_id("CVE-2024-0001"));
+    }
+
+    #[test]
+    fn is_valid_advisory_id_rejects_dangerous_characters() {
+        // Empty string is rejected.
+        assert!(!is_valid_advisory_id(""));
+        // Path traversal attempts.
+        assert!(!is_valid_advisory_id("../etc/passwd"));
+        assert!(!is_valid_advisory_id("RUSTSEC/2020/0036"));
+        // URL-injection attempts.
+        assert!(!is_valid_advisory_id("RUSTSEC-2020-0036?evil=1"));
+        assert!(!is_valid_advisory_id("RUSTSEC-2020-0036#frag"));
+        // Whitespace and control chars.
+        assert!(!is_valid_advisory_id("RUSTSEC-2020 0036"));
+        assert!(!is_valid_advisory_id("RUSTSEC-2020-0036\n"));
+        // Unicode is rejected — OSV IDs are ASCII.
+        assert!(!is_valid_advisory_id("RUSTSEC-é"));
+    }
+
+    #[test]
+    fn is_valid_advisory_id_rejects_oversized_ids() {
+        let long = "A".repeat(65);
+        assert!(!is_valid_advisory_id(&long));
+        let just_at_limit = "A".repeat(64);
+        assert!(is_valid_advisory_id(&just_at_limit));
     }
 
     #[test]

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -113,22 +113,21 @@ impl OsvClient {
     /// Build a client pointing at a custom OSV endpoint (no advisory cache).
     ///
     /// Used at runtime by the standalone scanner (`OSV_ENDPOINT` env var) and
-    /// by tests to point the client at a mock HTTP server. Falls back to a
-    /// minimally-configured `reqwest::Client` if the builder rejects the
-    /// timeout we request — `reqwest::Client::new()` itself never panics.
-    pub fn with_endpoint(endpoint: String) -> Self {
-        let client = Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .unwrap_or_else(|_| Client::new());
+    /// by tests to point the client at a mock HTTP server. Returns
+    /// `Err` if `reqwest` cannot build a `Client` (rare TLS/cert issue) —
+    /// previously this fell back to `reqwest::Client::new()`, but that is
+    /// itself `Client::builder().build().expect(...)` and panics under the
+    /// same conditions, so the fallback was an illusion.
+    pub fn with_endpoint(endpoint: String) -> anyhow::Result<Self> {
+        let client = Client::builder().timeout(Duration::from_secs(30)).build()?;
         let null: Arc<dyn crate::cache::advisory::AdvisoryWriteCache> =
             Arc::new(crate::cache::advisory::NullAdvisoryCache);
-        Self {
+        Ok(Self {
             base_url: endpoint,
             client: Arc::new(client),
             advisory_cache: Arc::clone(&null),
             negative_cache: null,
-        }
+        })
     }
 
     /// Test-only constructor: explicit endpoint **and** advisory cache.
@@ -327,16 +326,21 @@ impl OsvClient {
                         return false;
                     }
 
-                    // Positive cache wins over negative: if a real `Found`
-                    // entry exists, it cannot also be `NotFound`. Check it
-                    // first to avoid the (cheap) negative-cache lookup.
-                    if let Some(cached) = positive_cache.get(&id).await {
-                        return match cached.kind {
-                            crate::cache::advisory::AdvisoryKind::Found {
-                                unmaintained, ..
-                            } => unmaintained,
-                            crate::cache::advisory::AdvisoryKind::NotFound => false,
-                        };
+                    // Positive cache wins over negative for `Found` entries.
+                    // We deliberately do NOT short-circuit on `NotFound` from
+                    // the positive cache: pre-split builds wrote 404s into
+                    // the same SQLite layer with the long positive TTL, so a
+                    // user upgrading would otherwise be stuck with 24-h-stale
+                    // 404 rows that never get a chance to retry. Falling
+                    // through lets the short-TTL negative cache handle the
+                    // 404 path; if the network now returns 200, the
+                    // subsequent `positive_cache.insert` (UPSERT) overwrites
+                    // the stale row.
+                    if let Some(cached) = positive_cache.get(&id).await
+                        && let crate::cache::advisory::AdvisoryKind::Found { unmaintained, .. } =
+                            cached.kind
+                    {
+                        return unmaintained;
                     }
                     if let Some(cached) = negative_cache.get(&id).await
                         && matches!(cached.kind, crate::cache::advisory::AdvisoryKind::NotFound)
@@ -694,7 +698,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_osv_client_with_endpoint_uses_custom_url() {
-        let client = OsvClient::with_endpoint("http://127.0.0.1:1".to_string());
+        let client = OsvClient::with_endpoint("http://127.0.0.1:1".to_string())
+            .expect("with_endpoint builds in test");
         // Port 1 is not listening; a real query must error, proving the client
         // actually attempted to reach the custom URL (and not fallen back to
         // api.osv.dev).
@@ -956,6 +961,64 @@ mod tests {
         assert!(hybrid.get("RUSTSEC-9999-0001").await.is_none());
     }
 
+    /// Regression: pre-split builds wrote 404s to the positive cache. After
+    /// the split, those rows linger for the full positive TTL (24 h). A
+    /// `NotFound` returned from the *positive* cache must therefore NOT be
+    /// treated as authoritative; the lookup must fall through so the
+    /// short-TTL negative cache or the network can refresh the answer.
+    #[tokio::test]
+    async fn positive_cache_not_found_falls_through_to_network() {
+        let server = MockServer::start().await;
+        let hits = Arc::new(AtomicUsize::new(0));
+        {
+            let hits = Arc::clone(&hits);
+            Mock::given(method("GET"))
+                .and(path("/vulns/RUSTSEC-2020-0036"))
+                .respond_with(move |_req: &wiremock::Request| {
+                    hits.fetch_add(1, Ordering::SeqCst);
+                    ResponseTemplate::new(200).set_body_json(sample_response_body())
+                })
+                .mount(&server)
+                .await;
+        }
+
+        let positive: Arc<dyn AdvisoryWriteCache> = Arc::new(MemoryAdvisoryCache::new());
+        let negative: Arc<dyn AdvisoryWriteCache> = Arc::new(MemoryAdvisoryCache::new());
+
+        // Pre-seed the positive cache with a stale `NotFound` (as a pre-split
+        // build would have done for a 404). The new lookup logic must not
+        // short-circuit on it.
+        positive
+            .insert(CachedAdvisory {
+                id: "RUSTSEC-2020-0036".to_string(),
+                kind: AdvisoryKind::NotFound,
+                fetched_at: SystemTime::now(),
+            })
+            .await;
+
+        let client = OsvClient::with_endpoint_and_caches(
+            server.uri(),
+            Arc::clone(&positive),
+            Arc::clone(&negative),
+        );
+
+        let _ = client
+            .check_rustsec_unmaintained(&["RUSTSEC-2020-0036".to_string()])
+            .await;
+
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1,
+            "stale NotFound on positive cache must not short-circuit the network call"
+        );
+        // The fresh 200 must overwrite the stale row via UPSERT semantics.
+        let cached = positive
+            .get("RUSTSEC-2020-0036")
+            .await
+            .expect("positive cache must hold the refreshed Found entry");
+        assert!(matches!(cached.kind, AdvisoryKind::Found { .. }));
+    }
+
     #[tokio::test]
     async fn http_500_is_not_cached_and_retries() {
         let server = MockServer::start().await;
@@ -994,7 +1057,7 @@ mod tests {
         let max_seen = Arc::new(AtomicUsize::new(0));
         let endpoint =
             spawn_counting_osv_server(Arc::clone(&active_requests), Arc::clone(&max_seen)).await;
-        let client = OsvClient::with_endpoint(endpoint);
+        let client = OsvClient::with_endpoint(endpoint).expect("with_endpoint builds in test");
         let ids: Vec<String> = (0..(EXPECTED_LIMIT * 2 + 3))
             .map(|index| format!("RUSTSEC-2099-{index:04}"))
             .collect();

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -637,6 +637,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn first_call_populates_cache_and_second_call_skips_http() {
+        let server = MockServer::start().await;
+        let counter = Arc::new(AtomicUsize::new(0));
+        {
+            let counter = Arc::clone(&counter);
+            Mock::given(method("GET"))
+                .and(path("/vulns/RUSTSEC-2020-0036"))
+                .respond_with(move |_req: &wiremock::Request| {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    ResponseTemplate::new(200).set_body_json(sample_response_body())
+                })
+                .mount(&server)
+                .await;
+        }
+
+        let cache: Arc<dyn AdvisoryWriteCache> = Arc::new(MemoryAdvisoryCache::new());
+        let client = OsvClient::with_endpoint_and_cache(server.uri(), Arc::clone(&cache));
+
+        let first = client
+            .check_rustsec_unmaintained(&["RUSTSEC-2020-0036".to_string()])
+            .await;
+        let second = client
+            .check_rustsec_unmaintained(&["RUSTSEC-2020-0036".to_string()])
+            .await;
+
+        assert!(first);
+        assert!(second);
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "second call should be cached"
+        );
+        let cached = cache.get("RUSTSEC-2020-0036").await.expect("entry stored");
+        assert!(matches!(
+            cached.kind,
+            AdvisoryKind::Found {
+                unmaintained: true,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
     async fn test_rustsec_advisory_lookup_limits_concurrency() {
         const EXPECTED_LIMIT: usize = RUSTSEC_ADVISORY_LOOKUP_CONCURRENCY;
 

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -88,17 +88,22 @@ impl OsvClient {
         })
     }
 
-    /// Infallible constructor used by the LSP backend as a startup fallback
-    /// when [`OsvClient::new_with_caches`] fails (rare reqwest builder
-    /// errors). Uses `reqwest::Client::new()` directly — which never
-    /// panics — so the LSP can keep serving non-vulnerability features
-    /// instead of crashing during `initialize`.
-    pub fn with_default_client_and_caches(
+    /// Infallible constructor that reuses an already-built `reqwest::Client`
+    /// (typically the LSP's shared HTTP client created via
+    /// `create_shared_client`). Avoids a second TLS/builder-init step that
+    /// could fail or panic at runtime — the caller has proven `reqwest`
+    /// works on this platform by virtue of holding a `Client` already.
+    ///
+    /// Note: drops the OSV-specific 30 s timeout customisation; the shared
+    /// client's default timeout applies. OSV requests are short-lived in
+    /// practice, so this is acceptable.
+    pub fn with_shared_client_and_caches(
+        client: Arc<Client>,
         positive_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
         negative_cache: Arc<dyn crate::cache::advisory::AdvisoryWriteCache>,
     ) -> Self {
         Self {
-            client: Arc::new(Client::new()),
+            client,
             base_url: OSV_API_BASE.to_string(),
             advisory_cache: positive_cache,
             negative_cache,

--- a/dependi-lsp/src/vulnerabilities/osv.rs
+++ b/dependi-lsp/src/vulnerabilities/osv.rs
@@ -716,6 +716,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn http_500_is_not_cached_and_retries() {
+        let server = MockServer::start().await;
+        let counter = Arc::new(AtomicUsize::new(0));
+        {
+            let counter = Arc::clone(&counter);
+            Mock::given(method("GET"))
+                .and(path("/vulns/RUSTSEC-2020-0036"))
+                .respond_with(move |_req: &wiremock::Request| {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    ResponseTemplate::new(500)
+                })
+                .mount(&server)
+                .await;
+        }
+
+        let cache: Arc<dyn AdvisoryWriteCache> = Arc::new(MemoryAdvisoryCache::new());
+        let client = OsvClient::with_endpoint_and_cache(server.uri(), Arc::clone(&cache));
+
+        let _ = client
+            .check_rustsec_unmaintained(&["RUSTSEC-2020-0036".to_string()])
+            .await;
+        let _ = client
+            .check_rustsec_unmaintained(&["RUSTSEC-2020-0036".to_string()])
+            .await;
+
+        assert_eq!(counter.load(Ordering::SeqCst), 2, "no caching on 5xx");
+        assert!(cache.get("RUSTSEC-2020-0036").await.is_none());
+    }
+
+    #[tokio::test]
     async fn test_rustsec_advisory_lookup_limits_concurrency() {
         const EXPECTED_LIMIT: usize = RUSTSEC_ADVISORY_LOOKUP_CONCURRENCY;
 

--- a/dependi-lsp/tests/advisory_cache_wiring_test.rs
+++ b/dependi-lsp/tests/advisory_cache_wiring_test.rs
@@ -1,0 +1,14 @@
+//! Smoke test: HybridAdvisoryCache constructs without panic and survives a
+//! cache-miss lookup. Guards Task 26 of the RustSec advisory cache plan
+//! (issue #237): the LSP backend must be able to instantiate the cache at
+//! startup without exploding even when the SQLite layer is unavailable.
+
+use std::sync::Arc;
+
+use dependi_lsp::cache::{AdvisoryReadCache, HybridAdvisoryCache};
+
+#[tokio::test]
+async fn hybrid_advisory_cache_constructs_without_panic() {
+    let cache = Arc::new(HybridAdvisoryCache::new());
+    assert!(cache.get("RUSTSEC-2020-0036").await.is_none());
+}

--- a/dependi-lsp/tests/advisory_cache_wiring_test.rs
+++ b/dependi-lsp/tests/advisory_cache_wiring_test.rs
@@ -6,9 +6,20 @@
 use std::sync::Arc;
 
 use dependi_lsp::cache::{AdvisoryReadCache, HybridAdvisoryCache};
+use dependi_lsp::config::AdvisoryCacheConfig;
 
 #[tokio::test]
 async fn hybrid_advisory_cache_constructs_without_panic() {
-    let cache = Arc::new(HybridAdvisoryCache::new());
+    // Use an isolated db_path so a previous run that persisted a hit for
+    // RUSTSEC-2020-0036 in the user's default cache cannot turn this miss
+    // assertion into a flake.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = AdvisoryCacheConfig {
+        enabled: true,
+        ttl_secs: 60,
+        negative_ttl_secs: 30,
+        db_path: Some(tmp.path().join("advisory_cache.db")),
+    };
+    let cache = Arc::new(HybridAdvisoryCache::from_config(&config));
     assert!(cache.get("RUSTSEC-2020-0036").await.is_none());
 }


### PR DESCRIPTION
## Summary

• Implement hybrid cache (L1 memory + L2 SQLite) for RustSec advisory details from OSV.dev
• Eliminate redundant network requests during repeated dependency scans  
• Configurable TTL: 24h for found advisories, 1h for 404 negatives (AdvisoryCacheConfig)
• 8 review fixes post-implementation: config wiring, negative TTL, L1 backfill, API validation, dead code cleanup

## Architecture

- **L1 (Memory)**: DashMap-based with instant-based TTL, spawn_blocking cleanup task every 30min
- **L2 (SQLite)**: r2d2 connection pool, UPSERT with nanosecond timestamp guard, separate negative cache
- **Integration**: OsvClient wired to both caches at startup via backend; cache reads before HTTP

## Test Coverage

- 724+ passing lib tests (unchanged from main)
- New tests: memory cache (concurrent access, expiry), SQLite cache (schema, UPSERT ordering, cleanup), hybrid wiring
- Full TDD cycle: test-first, minimal implementation per task, frequent commits (38 total)

## Related

Closes #237

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hybrid advisory cache for RustSec lookups (L1 memory + L2 SQLite) to cut repeated OSV requests and speed repeated scans. Caching is configurable (24h positives, 1h negatives) via `AdvisoryCacheConfig` and is reconfigured at LSP initialize based on client settings. Closes #237.

- New Features
  - Two-tier cache: L1 `DashMap` with TTL, L2 SQLite at `~/.cache/dependi/advisory_cache.db`, plus a 30‑min cleanup task.
  - `OsvClient` checks caches before HTTP; 200s cache as Found, 404s go to a separate negative cache (memory‑only).
  - Config via `AdvisoryCacheConfig` (enable/disable, `ttl_secs`, `negative_ttl_secs`, optional `db_path`); backend builds at startup and reconfigures in `initialize`.

- Bug Fixes
  - Reconfigured advisory caches and `OsvClient` in `initialize` so `AdvisoryCacheConfig` overrides take effect; aborts old cleanup tasks to prevent leaks.
  - Applied `negative_ttl_secs` to 404 entries and fixed stale pre-split NotFound rows: NotFound hits no longer short‑circuit, they fall through to the negative cache + network so fresh 200s can overwrite.
  - Preserved remaining TTL when backfilling L1 from SQLite; skip writes when TTL is zero; run memory cleanup in `spawn_blocking`.
  - Reused the shared `reqwest::Client` (dropped OSV‑specific timeout); `with_endpoint` now returns `Result` and the CLI logs + exits on builder errors instead of panicking.
  - Created parent directories for custom `db_path`; validated advisory IDs (ASCII alnum + `-`, ≤64 chars); removed an unused expiry index from the SQLite schema.

<sup>Written for commit 7a14ed639fd43e08ffe1c0772b3c05d5b574c515. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hybrid memory+SQLite advisory cache with separate positive/negative TTLs, persisted DB path, and configurable enablement.

* **Bug Fixes**
  * Correct TTL/backfill semantics and distinct negative caching for 404s.
  * Prevent leaked background cleanup tasks on reconfigure; reuse HTTP client and avoid blocking runtime.
  * Validate advisory IDs and skip cache writes when TTL is zero.

* **Chores**
  * Added async-trait dependency.

* **Tests**
  * New unit and integration tests stabilizing cache wiring and behavior.

* **Documentation**
  * Updated changelog entry describing advisory cache changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->