### PR TITLE
docs: enhance API documentation with Rustdoc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collapse to a bare host after stripping a trailing `.git`
   ([#230](https://github.com/mpiton/zed-dependi/issues/230), CWE-20).
 
+### Documentation
+
+- Add comprehensive Rustdoc comments to `dependi-lsp` core modules
+  (`lib.rs`, `backend.rs`, `parsers/`, `providers/`): every public item
+  now has `///` docs covering summary, parameters, return value, errors,
+  and panics where applicable; every module file has a `//!` header; 43
+  doctests added on pure functions across manifest parsers, lockfile
+  parsers, and provider helpers
+  ([#231](https://github.com/mpiton/zed-dependi/issues/231)).
+
 ## [1.7.0] - 2026-04-07
 
 ### Added

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -10,12 +10,15 @@
 //! # Concurrency model
 //!
 //! All mutable state is shared via `Arc`. Most collections use
-//! [`dashmap::DashMap`] for lock-free concurrent access. Fields that require
-//! full replacement at runtime (e.g. `osv_client`, `advisory_cache`) are
-//! wrapped in [`tokio::sync::RwLock`] so [`crate::backend::DependiBackend`]`::initialize`
-//! can atomically swap in a reconfigured instance. The backend itself is `Clone`
-//! only in the sense that tower-lsp clones the handler type; each clone shares
-//! the same underlying `Arc` handles — there is no deep copy.
+//! [`dashmap::DashMap`] — a sharded `RwLock`-backed concurrent hashmap that
+//! lets disjoint shards proceed in parallel without locking the whole map.
+//! Fields that require full replacement at runtime (e.g. `osv_client`,
+//! `advisory_cache`) are wrapped in [`tokio::sync::RwLock`]; each is swapped
+//! atomically on its own when [`crate::backend::DependiBackend`]`::initialize`
+//! reconfigures the server, but the swaps happen sequentially — there is no
+//! single global atomic replacement of the runtime. The backend itself is
+//! `Clone` only in the sense that tower-lsp clones the handler type; each
+//! clone shares the same underlying `Arc` handles — there is no deep copy.
 //!
 //! Document processing is debounced: `did_change` spawns a [`tokio`] task that
 //! waits for a configurable idle period before calling the full

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -1,18 +1,19 @@
 //! LSP backend — the central [`LanguageServer`](tower_lsp::LanguageServer) implementation.
 //!
-//! [`DependiBackend`] owns all shared state and routes LSP notifications and
-//! requests to the appropriate parsers, registry clients, and providers. The
-//! public surface is intentionally small: callers construct the backend with
-//! [`DependiBackend::new`] (or [`DependiBackend::with_http_client`] for tests)
-//! and hand it to [`tower_lsp::LspService::new`].
+//! [`crate::backend::DependiBackend`] owns all shared state and routes LSP
+//! notifications and requests to the appropriate parsers, registry clients,
+//! and providers. The public surface is intentionally small: callers construct
+//! the backend with [`crate::backend::DependiBackend::new`] (or
+//! [`crate::backend::DependiBackend::with_http_client`] for tests) and hand it
+//! to [`tower_lsp::LspService::new`].
 //!
 //! # Concurrency model
 //!
 //! All mutable state is shared via `Arc`. Most collections use
 //! [`dashmap::DashMap`] for lock-free concurrent access. Fields that require
 //! full replacement at runtime (e.g. `osv_client`, `advisory_cache`) are
-//! wrapped in [`tokio::sync::RwLock`] so [`DependiBackend`]`::initialize` can
-//! atomically swap in a reconfigured instance. The backend itself is `Clone`
+//! wrapped in [`tokio::sync::RwLock`] so [`crate::backend::DependiBackend`]`::initialize`
+//! can atomically swap in a reconfigured instance. The backend itself is `Clone`
 //! only in the sense that tower-lsp clones the handler type; each clone shares
 //! the same underlying `Arc` handles — there is no deep copy.
 //!

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -1,3 +1,36 @@
+//! LSP backend — the central [`LanguageServer`](tower_lsp::LanguageServer) implementation.
+//!
+//! [`DependiBackend`] owns all shared state and routes LSP notifications and
+//! requests to the appropriate parsers, registry clients, and providers. The
+//! public surface is intentionally small: callers construct the backend with
+//! [`DependiBackend::new`] (or [`DependiBackend::with_http_client`] for tests)
+//! and hand it to [`tower_lsp::LspService::new`].
+//!
+//! # Concurrency model
+//!
+//! All mutable state is shared via `Arc`. Most collections use
+//! [`dashmap::DashMap`] for lock-free concurrent access. Fields that require
+//! full replacement at runtime (e.g. `osv_client`, `advisory_cache`) are
+//! wrapped in [`tokio::sync::RwLock`] so [`DependiBackend`]`::initialize` can
+//! atomically swap in a reconfigured instance. The backend itself is `Clone`
+//! only in the sense that tower-lsp clones the handler type; each clone shares
+//! the same underlying `Arc` handles — there is no deep copy.
+//!
+//! Document processing is debounced: `did_change` spawns a [`tokio`] task that
+//! waits for a configurable idle period before calling the full
+//! parse→fetch→diagnose pipeline. Vulnerability queries are always fired as a
+//! second background `tokio::spawn` so they never block the initial inlay-hint
+//! refresh.
+//!
+//! # Error handling at the LSP boundary
+//!
+//! [`tower_lsp::jsonrpc::Result`] is used as the return type for handler
+//! methods. Internal errors are logged with `tracing` and either converted
+//! to an LSP error response or silently swallowed (for notifications, which
+//! have no response channel). Registry and network errors are `anyhow::Result`
+//! internally and are downgraded to `tracing::warn!` / `tracing::error!` logs
+//! so a single failing registry never crashes the server.
+
 use core::fmt;
 use std::time::Duration;
 use std::{
@@ -443,6 +476,33 @@ struct VulnBgContext {
     >,
 }
 
+/// The main LSP backend for Dependi.
+///
+/// `DependiBackend` implements [`tower_lsp::LanguageServer`] and owns every
+/// piece of shared state required to serve LSP requests: parsed document state,
+/// version and advisory caches, registry clients, parsers, and the OSV
+/// vulnerability client.
+///
+/// # Responsibilities
+///
+/// - Parsing manifest files into [`crate::parsers::Dependency`] lists via
+///   ecosystem-specific parsers.
+/// - Fetching and caching package metadata from remote registries.
+/// - Running vulnerability queries against the OSV API and caching results.
+/// - Publishing diagnostics, inlay hints, code actions, and completions.
+/// - Managing per-URI debounce tasks so rapid edits do not flood the network.
+///
+/// # Cloning
+///
+/// `DependiBackend` is `Clone` (required by tower-lsp) but cloning is cheap:
+/// every field is either `Clone` by value (primitives, `Client`) or an `Arc`
+/// handle. All clones share the same underlying state.
+///
+/// # Construction
+///
+/// Use [`DependiBackend::new`] for production. Use
+/// [`DependiBackend::with_http_client`] in tests to inject a pre-built
+/// `reqwest::Client` (e.g. one backed by a mock server).
 pub struct DependiBackend {
     client: Client,
     /// Configuration (Arc-wrapped for sharing with debounce tasks)
@@ -523,23 +583,56 @@ pub struct DependiBackend {
 }
 
 impl DependiBackend {
-    /// Create a new DependiBackend with default configuration, parsers, registry clients,
-    /// caches, and an OSV client.
+    /// Create a new [`DependiBackend`] with default configuration, parsers,
+    /// registry clients, caches, and an OSV client.
     ///
-    /// The provided `client` is used for LSP communication. A shared HTTP client is created
-    /// internally and used to construct registry clients bound to that HTTP client.
+    /// Builds a shared `reqwest::Client` internally (TLS-enabled) and uses it
+    /// for all outbound HTTP traffic. All registry clients, the advisory cache,
+    /// and the OSV client are initialised from [`crate::config::Config::default`].
+    /// The configuration is replaced by the values received in the LSP
+    /// `initialize` request.
+    ///
+    /// # Parameters
+    ///
+    /// - `client`: The tower-lsp [`Client`] handle used to push diagnostics,
+    ///   inlay-hint refresh requests, and other server-initiated messages to the
+    ///   editor.
     ///
     /// # Examples
     ///
-    /// ```
-    /// // Obtain an LSP `Client` from the runtime environment and pass it in:
-    /// // let client = /* LSP client */ ;
-    /// // let backend = DependiBackend::new(client);
+    /// ```text
+    /// // Obtain an LSP `Client` from the tower-lsp runtime and pass it in:
+    /// //
+    /// //   let (service, socket) = LspService::new(DependiBackend::new);
+    /// //   Server::new(stdin, stdout, socket).serve(service).await;
+    /// //
+    /// // See the integration tests under dependi-lsp/tests/ for a full example.
     /// ```
     pub fn new(client: Client) -> Self {
         Self::with_http_client(client, None)
     }
 
+    /// Create a [`DependiBackend`] with an optional pre-built HTTP client.
+    ///
+    /// This is the canonical constructor used by both [`DependiBackend::new`] and
+    /// integration tests. Passing `None` for `http_client` is equivalent to
+    /// calling [`DependiBackend::new`]: a shared `reqwest::Client` is built
+    /// automatically.
+    ///
+    /// Passing `Some(client)` lets tests inject a mock HTTP client (e.g. one
+    /// pointing at a local wiremock server) without touching the network.
+    ///
+    /// # Parameters
+    ///
+    /// - `client`: The tower-lsp [`Client`] handle for server-initiated messages.
+    /// - `http_client`: Optional pre-built `reqwest::Client`. Pass `None` to use
+    ///   the default TLS-enabled client.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `http_client` is `None` and building the default
+    /// `reqwest::Client` fails (e.g. TLS initialisation error on the current
+    /// platform).
     pub fn with_http_client(client: Client, http_client: Option<Arc<HttpClient>>) -> Self {
         let http_client = http_client.unwrap_or_else(|| {
             create_shared_client().expect("Failed to create shared HTTP client")
@@ -609,20 +702,30 @@ impl DependiBackend {
         }
     }
 
-    /// Read access to the advisory cache (issue #237).
+    /// Return a clone of the current positive advisory cache.
     ///
-    /// Used by integration tests and observability tooling. Returns the
-    /// hybrid memory+SQLite cache that `OsvClient` consults before issuing
-    /// HTTP requests for individual RustSec advisories. Async because the
-    /// underlying handle is now wrapped in a `RwLock` to support runtime
-    /// reconfiguration in `initialize`.
+    /// Returns the hybrid memory+SQLite [`crate::cache::HybridAdvisoryCache`]
+    /// that [`crate::vulnerabilities::osv::OsvClient`] consults
+    /// before issuing HTTP requests for individual RustSec advisories.
+    ///
+    /// The cache is wrapped in a [`tokio::sync::RwLock`] so the `initialize`
+    /// handler can atomically swap in a cache built from the user's
+    /// [`crate::config::AdvisoryCacheConfig`]. This method acquires a read
+    /// lock and returns an `Arc` clone — callers do not hold the lock.
+    ///
+    /// Primarily used by integration tests and observability tooling.
     pub async fn advisory_cache(&self) -> Arc<crate::cache::HybridAdvisoryCache> {
         Arc::clone(&*self.advisory_cache.read().await)
     }
 
-    /// Read access to the negative advisory cache (issue #237).
+    /// Return a clone of the current negative advisory cache.
     ///
-    /// Used by integration tests to inspect 404 caching state.
+    /// The negative cache stores "not-found" (HTTP 404) advisory responses so
+    /// the server does not re-query OSV for packages with no known advisories.
+    /// Unlike the positive cache it has no SQLite backing layer — 404 entries
+    /// should not persist across LSP sessions.
+    ///
+    /// Primarily used by integration tests to inspect 404 caching state.
     pub async fn negative_advisory_cache(&self) -> Arc<crate::cache::HybridAdvisoryCache> {
         Arc::clone(&*self.negative_advisory_cache.read().await)
     }

--- a/dependi-lsp/src/lib.rs
+++ b/dependi-lsp/src/lib.rs
@@ -8,31 +8,30 @@
 //!
 //! # Module map
 //!
-//! - [`backend`]: tower-lsp [`LanguageServer`](tower_lsp::LanguageServer)
+//! - [`crate::backend`]: tower-lsp [`LanguageServer`](tower_lsp::LanguageServer)
 //!   implementation wiring document state to providers.
-//! - [`parsers`]: Manifest and lockfile parsers per ecosystem.
-//! - [`providers`]: LSP feature providers (diagnostics, inlay hints,
+//! - [`crate::parsers`]: Manifest and lockfile parsers per ecosystem.
+//! - [`crate::providers`]: LSP feature providers (diagnostics, inlay hints,
 //!   code actions, completion, document links).
-//! - [`registries`]: HTTP clients for package registries.
-//! - [`vulnerabilities`]: OSV vulnerability checks plus caching.
-//! - [`cache`]: Hybrid memory+SQLite version cache and advisory cache.
-//! - [`auth`]: Registry credential resolution (cargo credentials, .npmrc tokens).
-//! - [`config`]: User-facing settings deserialized from LSP `initialize`.
-//! - [`reports`]: JSON and Markdown vulnerability report generation.
-//! - [`document`]: Per-document parsed state shared across providers.
-//! - [`file_types`]: File-type detection from URI and ecosystem mapping.
-//! - [`settings_edit`]: `WorkspaceEdit` helpers for `.zed/settings.json` updates.
-//! - [`utils`]: Shared string utilities (truncation, HTML escaping).
+//! - [`crate::registries`]: HTTP clients for package registries.
+//! - [`crate::vulnerabilities`]: OSV vulnerability checks plus caching.
+//! - [`crate::cache`]: Hybrid memory+SQLite version cache and advisory cache.
+//! - [`crate::auth`]: Registry credential resolution (cargo credentials, .npmrc tokens).
+//! - [`crate::config`]: User-facing settings deserialized from LSP `initialize`.
+//! - [`crate::reports`]: JSON and Markdown vulnerability report generation.
+//! - [`crate::document`]: Per-document parsed state shared across providers.
+//! - [`crate::file_types`]: File-type detection from URI and ecosystem mapping.
+//! - [`crate::settings_edit`]: `WorkspaceEdit` helpers for `.zed/settings.json` updates.
+//! - [`crate::utils`]: Shared string utilities (truncation, HTML escaping).
 //!
 //! # Entry point
 //!
-//! See [`backend::DependiBackend`] for constructing and running the server.
+//! See [`crate::backend::DependiBackend`] for constructing and running the server.
 
 /// tower-lsp [`LanguageServer`](tower_lsp::LanguageServer) implementation
 /// wiring document lifecycle events to parsers, registries, and providers.
 pub mod backend;
 
-/// Registry credential resolution (cargo credentials, .npmrc tokens).
 pub mod auth;
 
 /// Hybrid memory+SQLite version cache and RustSec advisory cache.
@@ -54,8 +53,6 @@ pub mod parsers;
 /// completion, and document links.
 pub mod providers;
 
-/// HTTP clients for fetching package metadata from crates.io, npm,
-/// PyPI, Go Proxy, Packagist, pub.dev, NuGet, Maven Central, and RubyGems.
 pub mod registries;
 
 /// JSON and Markdown vulnerability report generation.

--- a/dependi-lsp/src/lib.rs
+++ b/dependi-lsp/src/lib.rs
@@ -1,18 +1,72 @@
-//! Dependi LSP - Language Server for dependency management
+//! Dependi LSP — Language Server for dependency management.
 //!
-//! This crate provides a Language Server Protocol implementation for
-//! managing dependencies in various package managers (Cargo, npm, etc.)
+//! Provides Language Server Protocol (LSP) features for dependency manifests
+//! across multiple ecosystems: Cargo, npm, PyPI, Go modules, Composer,
+//! pub.dev, NuGet, Maven Central, and RubyGems. Features include version
+//! inlay hints, vulnerability diagnostics, code actions for upgrades, and
+//! registry-aware completion.
+//!
+//! # Module map
+//!
+//! - [`backend`]: tower-lsp [`LanguageServer`](tower_lsp::LanguageServer)
+//!   implementation wiring document state to providers.
+//! - [`parsers`]: Manifest and lockfile parsers per ecosystem.
+//! - [`providers`]: LSP feature providers (diagnostics, inlay hints,
+//!   code actions, completion, document links).
+//! - [`registries`]: HTTP clients for package registries.
+//! - [`vulnerabilities`]: OSV vulnerability checks plus caching.
+//! - [`cache`]: Hybrid memory+SQLite version cache and advisory cache.
+//! - [`auth`]: Registry credential resolution (cargo credentials, .npmrc tokens).
+//! - [`config`]: User-facing settings deserialized from LSP `initialize`.
+//! - [`reports`]: JSON and Markdown vulnerability report generation.
+//! - [`document`]: Per-document parsed state shared across providers.
+//! - [`file_types`]: File-type detection from URI and ecosystem mapping.
+//! - [`settings_edit`]: `WorkspaceEdit` helpers for `.zed/settings.json` updates.
+//! - [`utils`]: Shared string utilities (truncation, HTML escaping).
+//!
+//! # Entry point
+//!
+//! See [`backend::DependiBackend`] for constructing and running the server.
 
-pub mod auth;
+/// tower-lsp [`LanguageServer`](tower_lsp::LanguageServer) implementation
+/// wiring document lifecycle events to parsers, registries, and providers.
 pub mod backend;
+
+/// Registry credential resolution (cargo credentials, .npmrc tokens).
+pub mod auth;
+
+/// Hybrid memory+SQLite version cache and RustSec advisory cache.
 pub mod cache;
+
+/// User-facing settings deserialized from the LSP `initialize` request.
 pub mod config;
+
+/// Per-document parsed state (dependencies, file type, lockfile graph).
 pub mod document;
+
+/// File-type detection from URI path and ecosystem-to-cache-key mapping.
 pub mod file_types;
+
+/// Manifest and lockfile parsers for each supported ecosystem.
 pub mod parsers;
+
+/// LSP feature providers: diagnostics, inlay hints, code actions,
+/// completion, and document links.
 pub mod providers;
+
+/// HTTP clients for fetching package metadata from crates.io, npm,
+/// PyPI, Go Proxy, Packagist, pub.dev, NuGet, Maven Central, and RubyGems.
 pub mod registries;
+
+/// JSON and Markdown vulnerability report generation.
 pub mod reports;
+
+/// `WorkspaceEdit` builder for adding packages to the `.zed/settings.json`
+/// ignore list.
 pub mod settings_edit;
+
+/// Shared string utilities: truncation with ellipsis and HTML escaping.
 pub mod utils;
+
+/// OSV-backed vulnerability scanning and per-package result caching.
 pub mod vulnerabilities;

--- a/dependi-lsp/src/parsers/cargo.rs
+++ b/dependi-lsp/src/parsers/cargo.rs
@@ -1,4 +1,17 @@
-//! Parser for Cargo.toml files using structured TOML parsing
+//! Parser for Cargo.toml files using structured TOML parsing.
+//!
+//! Handles all dependency declaration styles supported by Cargo:
+//!
+//! - Simple version string: `serde = "1.0"`
+//! - Inline table: `serde = { version = "1.0", features = ["derive"] }`
+//! - Section table: `[dependencies.serde]` / `version = "1.0"`
+//! - Package alias: `serde1 = { package = "serde", version = "1.0" }`
+//! - Workspace dependencies: `[workspace.dependencies]`
+//! - All three scopes: `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]`
+//!
+//! Parsing is performed with `taplo` so that byte-accurate [`Span`] values are
+//! available for every token; this allows LSP quick-fix `TextEdit`s to replace
+//! only the version literal without touching surrounding TOML syntax.
 
 use taplo::dom::Node;
 use taplo::dom::node::{Bool, DomNode, Key, Str};
@@ -9,8 +22,27 @@ use taplo::syntax::SyntaxElement;
 
 use super::{Dependency, Parser, Span};
 
-/// Extract the `[package].name` field from a Cargo.toml manifest.
-/// Used to pass the root package name to `parse_cargo_lock` for multi-version disambiguation.
+/// Extracts the `[package].name` field from a `Cargo.toml` manifest.
+///
+/// Returns `None` for virtual workspaces (manifests with no `[package]` section)
+/// or when the TOML is malformed.  The value is forwarded to the lock-file
+/// resolver for multi-version disambiguation.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::cargo::cargo_root_package_name;
+/// let manifest = "[package]\nname = \"my-crate\"\nversion = \"0.1.0\"\n";
+/// assert_eq!(cargo_root_package_name(manifest).as_deref(), Some("my-crate"));
+/// ```
+///
+/// Virtual workspaces (no `[package]` section) return `None`:
+///
+/// ```
+/// use dependi_lsp::parsers::cargo::cargo_root_package_name;
+/// let manifest = "[workspace]\nmembers = [\"crate-a\"]\n";
+/// assert!(cargo_root_package_name(manifest).is_none());
+/// ```
 pub fn cargo_root_package_name(manifest_content: &str) -> Option<String> {
     let value: toml::Value = toml::from_str(manifest_content).ok()?;
     value
@@ -20,11 +52,29 @@ pub fn cargo_root_package_name(manifest_content: &str) -> Option<String> {
         .map(|s| s.to_string())
 }
 
-/// Parser for Rust Cargo.toml dependency files
+/// Parser for Rust `Cargo.toml` dependency files.
+///
+/// Delegates to the `taplo` TOML parser for robust span tracking.
+/// All three standard dependency scopes (`dependencies`, `dev-dependencies`,
+/// `build-dependencies`) as well as `workspace.dependencies` are parsed in a
+/// single pass.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::Parser;
+/// use dependi_lsp::parsers::cargo::CargoParser;
+/// let parser = CargoParser::new();
+/// let deps = parser.parse("[dependencies]\ntokio = { version = \"1.0\", features = [\"full\"] }\n");
+/// assert_eq!(deps.len(), 1);
+/// assert_eq!(deps[0].name, "tokio");
+/// assert_eq!(deps[0].version, "1.0");
+/// ```
 #[derive(Debug, Default)]
 pub struct CargoParser;
 
 impl CargoParser {
+    /// Creates a new [`CargoParser`] instance.
     pub fn new() -> Self {
         Self
     }

--- a/dependi-lsp/src/parsers/cargo.rs
+++ b/dependi-lsp/src/parsers/cargo.rs
@@ -24,9 +24,15 @@ use super::{Dependency, Parser, Span};
 
 /// Extracts the `[package].name` field from a `Cargo.toml` manifest.
 ///
-/// Returns `None` for virtual workspaces (manifests with no `[package]` section)
-/// or when the TOML is malformed.  The value is forwarded to the lock-file
-/// resolver for multi-version disambiguation.
+/// Returns `None` when:
+///
+/// - The TOML is malformed and cannot be parsed.
+/// - The manifest is a virtual workspace (no `[package]` section).
+/// - `[package]` exists but `name` is missing.
+/// - `[package].name` is present but not a string (e.g. an array).
+///
+/// The value is forwarded to the lock-file resolver for multi-version
+/// disambiguation.
 ///
 /// # Examples
 ///

--- a/dependi-lsp/src/parsers/cargo_lock.rs
+++ b/dependi-lsp/src/parsers/cargo_lock.rs
@@ -11,12 +11,33 @@ use crate::parsers::lockfile_resolver::LockfileResolver;
 
 /// Parse a Cargo.lock file and return a map of package name → resolved version.
 ///
-/// Cargo.lock uses `[[package]]` TOML array-of-tables entries with `name` and `version` fields.
-/// When multiple versions of the same package exist, the first one is kept by default.
+/// Cargo.lock uses `[[package]]` TOML array-of-tables entries with `name` and
+/// `version` fields. When multiple versions of the same package exist, the
+/// first entry is kept by default.
 ///
-/// If `root_package` is provided, the root package's `dependencies` list is used to disambiguate:
-/// Cargo writes `"crate_name version"` (with version) in dependencies when multiple versions exist,
-/// so the version referenced by the root package takes precedence over the first-found version.
+/// If `root_package` is provided, the root package's `dependencies` list is
+/// used to disambiguate: Cargo writes `"crate_name version"` (with version)
+/// in the dependencies array when multiple versions exist, so the version
+/// referenced by the root package takes precedence over the first-found entry.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::cargo_lock::parse_cargo_lock;
+///
+/// let lock = r#"
+/// [[package]]
+/// name = "serde"
+/// version = "1.0.195"
+///
+/// [[package]]
+/// name = "tokio"
+/// version = "1.36.0"
+/// "#;
+/// let map = parse_cargo_lock(lock, None);
+/// assert_eq!(map.get("serde").map(String::as_str), Some("1.0.195"));
+/// assert_eq!(map.get("tokio").map(String::as_str), Some("1.36.0"));
+/// ```
 pub fn parse_cargo_lock(content: &str, root_package: Option<&str>) -> HashMap<String, String> {
     let mut map = HashMap::new();
 
@@ -73,12 +94,32 @@ pub fn parse_cargo_lock(content: &str, root_package: Option<&str>) -> HashMap<St
     map
 }
 
-/// Parse Cargo.lock into a full dependency graph.
+/// Parse `Cargo.lock` into a full [`LockfileGraph`].
 ///
 /// Dependency strings are stored as-is (e.g. `"serde"` or `"serde 1.0.195"`).
-/// Cargo writes the version when multiple versions of the same crate are locked,
-/// so preserving it allows correct transitive attribution.  Graph-walk code
-/// normalises to the name portion when resolving edges.
+/// Cargo writes the version suffix when multiple versions of the same crate
+/// are locked; preserving it allows correct transitive attribution. Graph-walk
+/// code strips the version suffix when resolving edges.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::cargo_lock::parse_cargo_lock_graph;
+///
+/// let lock = r#"
+/// [[package]]
+/// name = "demo"
+/// version = "0.1.0"
+/// dependencies = ["serde"]
+///
+/// [[package]]
+/// name = "serde"
+/// version = "1.0.195"
+/// "#;
+/// let graph = parse_cargo_lock_graph(lock);
+/// assert_eq!(graph.packages.len(), 2);
+/// assert!(graph.packages.iter().any(|p| p.name == "serde"));
+/// ```
 pub fn parse_cargo_lock_graph(content: &str) -> LockfileGraph {
     let mut graph = LockfileGraph::default();
 
@@ -121,11 +162,18 @@ pub fn parse_cargo_lock_graph(content: &str) -> LockfileGraph {
     graph
 }
 
-/// Find the Cargo.lock file by walking up from a Cargo.toml path.
+/// Find the `Cargo.lock` file by walking up from a `Cargo.toml` path.
 ///
-/// Handles both single-crate and workspace layouts by searching parent directories.
-/// Uses async I/O to avoid blocking the Tokio executor on slow or networked filesystems.
-/// Stops after 10 levels to prevent infinite traversal on unusual file systems.
+/// Handles both single-crate and workspace layouts by searching parent
+/// directories. Stops after 10 levels to prevent unbounded traversal.
+///
+/// Uses async I/O to avoid blocking the Tokio executor on slow or networked
+/// filesystems.
+///
+/// # Returns
+///
+/// `Some(path)` pointing to the first `Cargo.lock` found, or `None` when
+/// no lockfile exists within 10 directory levels.
 pub async fn find_cargo_lock(cargo_toml_path: &Path) -> Option<PathBuf> {
     let start_dir = cargo_toml_path.parent()?;
 

--- a/dependi-lsp/src/parsers/composer_lock.rs
+++ b/dependi-lsp/src/parsers/composer_lock.rs
@@ -10,20 +10,39 @@ use crate::parsers::lockfile_resolver::LockfileResolver;
 
 /// Normalize a Composer package name to lowercase.
 ///
-/// Composer package names are case-insensitive (e.g., "Vendor/Package" == "vendor/package").
+/// Composer package names are case-insensitive
+/// (e.g., `"Vendor/Package"` == `"vendor/package"`).
 /// This function ensures consistent lookup between manifest and lockfile entries.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::composer_lock::normalize_composer_name;
+/// assert_eq!(normalize_composer_name("Vendor/Package"), "vendor/package");
+/// assert_eq!(normalize_composer_name("symfony/console"), "symfony/console");
+/// ```
 pub fn normalize_composer_name(name: &str) -> String {
     name.to_lowercase()
 }
 
-/// Parse a composer.lock file and return a map of package name → resolved version.
+/// Parse a `composer.lock` file and return a map of package name → resolved version.
 ///
-/// Composer.lock is a JSON file with `"packages"` and `"packages-dev"` arrays.
+/// `composer.lock` is a JSON file with `"packages"` and `"packages-dev"` arrays.
 /// Each entry has `"name"` and `"version"` fields.
 /// Names are normalized to lowercase since Composer is case-insensitive.
-/// Versions with a `v` prefix (e.g., "v3.2.0") are stored as-is since both
-/// Packagist API and composer.lock use the same format per package.
+/// Versions with a `v` prefix (e.g., `"v3.2.0"`) are stored as-is since both
+/// the Packagist API and `composer.lock` use the same format per package.
 /// When a package appears multiple times, the first entry is kept.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::composer_lock::parse_composer_lock;
+///
+/// let lock = r#"{"packages":[{"name":"symfony/console","version":"v6.0.0"}],"packages-dev":[]}"#;
+/// let map = parse_composer_lock(lock);
+/// assert_eq!(map.get("symfony/console").map(String::as_str), Some("v6.0.0"));
+/// ```
 pub fn parse_composer_lock(content: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
 

--- a/dependi-lsp/src/parsers/csharp.rs
+++ b/dependi-lsp/src/parsers/csharp.rs
@@ -1,12 +1,41 @@
-//! Parser for C# .csproj files (NuGet PackageReference format)
+//! Parser for C# `.csproj` files (NuGet `PackageReference` format).
+//!
+//! Two XML formats are supported on the same line:
+//!
+//! ```xml
+//! <!-- Self-closing attribute form -->
+//! <PackageReference Include="Serilog" Version="3.1.1" />
+//!
+//! <!-- Expanded element form -->
+//! <PackageReference Include="Serilog"><Version>3.1.1</Version></PackageReference>
+//! ```
+//!
+//! `PackageReference` entries that have no `Version` attribute or element are
+//! silently skipped (typically managed centrally via `Directory.Packages.props`).
+//! NuGet does not have an explicit dev-dependency concept, so all parsed
+//! dependencies have `dev = false`.
 
 use super::{Dependency, Parser, Span};
 
-/// Parser for C# .csproj files
+/// Parser for C# `.csproj` files.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::Parser;
+/// use dependi_lsp::parsers::csharp::CsharpParser;
+/// let parser = CsharpParser::new();
+/// let content = r#"<Project><ItemGroup><PackageReference Include="Serilog" Version="3.1.1" /></ItemGroup></Project>"#;
+/// let deps = parser.parse(content);
+/// assert_eq!(deps.len(), 1);
+/// assert_eq!(deps[0].name, "Serilog");
+/// assert_eq!(deps[0].version, "3.1.1");
+/// ```
 #[derive(Debug, Default)]
 pub struct CsharpParser;
 
 impl CsharpParser {
+    /// Creates a new [`CsharpParser`] instance.
     pub fn new() -> Self {
         Self
     }
@@ -35,7 +64,10 @@ impl Parser for CsharpParser {
     }
 }
 
-/// Parse a PackageReference XML element
+/// Parses a single `<PackageReference …>` line and returns the corresponding [`Dependency`].
+///
+/// Returns `None` when no `Include` attribute is found, or when no version can
+/// be extracted from either the `Version=""` attribute or a `<Version>` child element.
 fn parse_package_reference(line: &str, line_num: u32) -> Option<Dependency> {
     // Extract Include attribute (package name)
     let include_start = line.find("Include=\"")? + 9;

--- a/dependi-lsp/src/parsers/dart.rs
+++ b/dependi-lsp/src/parsers/dart.rs
@@ -1,12 +1,39 @@
-//! Parser for Dart/Flutter pubspec.yaml files
+//! Parser for Dart/Flutter `pubspec.yaml` files.
+//!
+//! Recognises three top-level sections:
+//!
+//! | YAML key | `dev` |
+//! |----------|-------|
+//! | `dependencies` | `false` |
+//! | `dev_dependencies` | `true` |
+//! | `dependency_overrides` | `false` |
+//!
+//! Complex dependency forms (git, path, SDK, hosted) are silently skipped.
+//! Flutter SDK packages (`flutter`, `flutter_test`, etc.) are also excluded.
+//! Inline YAML comments after a version string are stripped before the version
+//! is recorded.
 
 use super::{Dependency, Parser, Span};
 
-/// Parser for Dart pubspec.yaml dependency files
+/// Parser for Dart `pubspec.yaml` dependency files.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::Parser;
+/// use dependi_lsp::parsers::dart::DartParser;
+/// let parser = DartParser::new();
+/// let content = "dependencies:\n  http: ^1.0.0\n";
+/// let deps = parser.parse(content);
+/// assert_eq!(deps.len(), 1);
+/// assert_eq!(deps[0].name, "http");
+/// assert_eq!(deps[0].version, "^1.0.0");
+/// ```
 #[derive(Debug, Default)]
 pub struct DartParser;
 
 impl DartParser {
+    /// Creates a new [`DartParser`] instance.
     pub fn new() -> Self {
         Self
     }
@@ -87,6 +114,7 @@ impl Parser for DartParser {
     }
 }
 
+/// Tracks which top-level YAML section is currently being parsed.
 #[derive(Debug, Clone, Copy)]
 enum DependencySection {
     Dependencies,
@@ -100,7 +128,11 @@ impl DependencySection {
     }
 }
 
-/// Parse a single dependency line in YAML format
+/// Parses a single indented YAML dependency line.
+///
+/// Returns `None` for lines without a version (complex dependencies handled
+/// by the caller as nested blocks), for complex inline forms (`sdk:`, `git:`,
+/// etc.), and for path/absolute-path version values.
 fn parse_dart_dependency_line(line: &str, line_num: u32, dev: bool) -> Option<Dependency> {
     let trimmed = line.trim();
 
@@ -176,7 +208,7 @@ fn parse_dart_dependency_line(line: &str, line_num: u32, dev: bool) -> Option<De
     })
 }
 
-/// Check if a line indicates a complex dependency (git, path, sdk)
+/// Returns `true` when `line` indicates a complex dependency form (git, path, sdk, hosted).
 fn is_complex_dependency(line: &str) -> bool {
     let trimmed = line.trim();
     trimmed.ends_with(':') && !trimmed.contains(' ')
@@ -186,7 +218,8 @@ fn is_complex_dependency(line: &str) -> bool {
         || trimmed.contains("hosted:")
 }
 
-/// Check if a package is a Flutter SDK dependency
+/// Returns `true` for packages that are part of the Flutter SDK and therefore
+/// have no pub.dev entry.
 fn is_flutter_sdk_dependency(name: &str) -> bool {
     matches!(
         name,

--- a/dependi-lsp/src/parsers/gemfile_lock.rs
+++ b/dependi-lsp/src/parsers/gemfile_lock.rs
@@ -50,22 +50,39 @@ fn strip_platform_suffix(version: &str) -> &str {
 }
 
 /// Normalize a Ruby gem name to lowercase for case-insensitive matching.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::gemfile_lock::normalize_gem_name;
+/// assert_eq!(normalize_gem_name("ActiveRecord"), "activerecord");
+/// assert_eq!(normalize_gem_name("rails"), "rails");
+/// ```
 pub fn normalize_gem_name(name: &str) -> String {
     name.to_lowercase()
 }
 
-/// Parse a Gemfile.lock file and return a map of gem name → resolved version.
+/// Parse a `Gemfile.lock` file and return a map of gem name → resolved version.
 ///
 /// Only `GEM` (registry) sections are resolved. `PATH` and `GIT` sourced
-/// gems are intentionally excluded — they are also skipped by the Gemfile manifest
-/// parser (`ruby.rs`) and do not need version resolution against a registry.
+/// gems are intentionally excluded — they are also skipped by the Gemfile
+/// manifest parser and do not need version resolution against a registry.
 ///
-/// Extracts versions from the GEM specs section where each gem appears as:
-///   `    gem_name (VERSION)`
-/// with exactly 4 spaces of indentation.
+/// Extracts versions from the `GEM specs:` section where each gem appears as
+/// `    gem_name (VERSION)` with exactly 4 spaces of indentation.
 ///
 /// Gem names are stored in lowercase for case-insensitive matching.
 /// Platform suffixes (e.g., `-x86_64-linux`) are stripped from versions.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::gemfile_lock::parse_gemfile_lock;
+///
+/// let lock = "GEM\n  remote: https://rubygems.org/\n  specs:\n    rails (7.0.4)\n\nPLATFORMS\n  ruby\n";
+/// let map = parse_gemfile_lock(lock);
+/// assert_eq!(map.get("rails").map(String::as_str), Some("7.0.4"));
+/// ```
 pub fn parse_gemfile_lock(content: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
 

--- a/dependi-lsp/src/parsers/go.rs
+++ b/dependi-lsp/src/parsers/go.rs
@@ -1,14 +1,41 @@
-//! Parser for Go module files (go.mod)
+//! Parser for Go module files (`go.mod`).
 //!
-//! Optimized for performance with pre-allocation and reduced string searches.
+//! Recognises both single-line and block `require` directives:
+//!
+//! ```text
+//! require github.com/pkg/errors v0.9.1
+//!
+//! require (
+//!     github.com/gin-gonic/gin v1.9.1
+//!     golang.org/x/text v0.14.0 // indirect
+//! )
+//! ```
+//!
+//! Indirect dependencies are surfaced with `optional = true`.
+//! `replace` directives and comment-only lines are silently skipped.
+//! Optimised for performance with pre-allocation and a single byte scan per line.
 
 use super::{Dependency, Parser, Span};
 
-/// Parser for Go go.mod dependency files
+/// Parser for Go `go.mod` dependency files.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::Parser;
+/// use dependi_lsp::parsers::go::GoParser;
+/// let parser = GoParser::new();
+/// let content = "require github.com/pkg/errors v0.9.1\n";
+/// let deps = parser.parse(content);
+/// assert_eq!(deps.len(), 1);
+/// assert_eq!(deps[0].name, "github.com/pkg/errors");
+/// assert_eq!(deps[0].version, "v0.9.1");
+/// ```
 #[derive(Debug, Default)]
 pub struct GoParser;
 
 impl GoParser {
+    /// Creates a new [`GoParser`] instance.
     pub fn new() -> Self {
         Self
     }
@@ -61,8 +88,11 @@ impl Parser for GoParser {
     }
 }
 
-/// Parse a require line (either standalone or inside a block)
-/// Format: module/path v1.2.3 [// indirect]
+/// Parses a single `require` entry (standalone or inside a block).
+///
+/// Expected format: `module/path v1.2.3 [// indirect]`
+///
+/// Returns `None` for comments, blank lines, and `replace` directives.
 fn parse_require_line(line: &str, content: &str, line_num: u32) -> Option<Dependency> {
     // Skip empty lines, comments, and replace directives
     if content.is_empty() || content.starts_with("//") || content.starts_with("replace") {
@@ -108,7 +138,8 @@ fn parse_require_line(line: &str, content: &str, line_num: u32) -> Option<Depend
     parse_require_with_positions(line, module_path, version, line_num, is_indirect)
 }
 
-/// Calculate positions and create Dependency
+/// Resolves byte positions for `module_path` and `version` within `line` and
+/// constructs the [`Dependency`].
 fn parse_require_with_positions(
     line: &str,
     module_path: &str,

--- a/dependi-lsp/src/parsers/go_sum.rs
+++ b/dependi-lsp/src/parsers/go_sum.rs
@@ -9,14 +9,28 @@ use crate::parsers::Dependency;
 use crate::parsers::lockfile_graph::{LockfileGraph, LockfilePackage};
 use crate::parsers::lockfile_resolver::LockfileResolver;
 
-/// Parse a go.sum file and return a map of module path → all observed versions.
+/// Parse a `go.sum` file and return a map of module path → all observed versions.
 ///
-/// go.sum format: `<module> <version>[/go.mod] <hash>`
-/// Lines with `/go.mod` suffix on the version are skipped to avoid duplicates.
+/// `go.sum` format: `<module> <version>[/go.mod] <hash>`
 ///
-/// Go 1.17+ with lazy module loading can record multiple versions of the same
-/// module in go.sum (direct + transitive dependencies at different versions).
-/// We collect all versions so the caller can choose the right one.
+/// Lines whose version string ends with `/go.mod` are skipped to avoid
+/// duplicates — only the `h1:` (tree hash) lines contribute a version entry.
+///
+/// Go 1.17+ with lazy module loading may record multiple versions of the same
+/// module (direct + transitive at different versions). All non-`/go.mod`
+/// versions are collected so the caller can choose the right one.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::go_sum::parse_go_sum;
+///
+/// let sum = "github.com/pkg/errors v0.9.1 h1:abc=\n\
+///            github.com/pkg/errors v0.9.1/go.mod h1:def=\n";
+/// let map = parse_go_sum(sum);
+/// // /go.mod line is skipped; only the h1: line contributes.
+/// assert_eq!(map.get("github.com/pkg/errors").unwrap().as_slice(), &["v0.9.1"]);
+/// ```
 pub fn parse_go_sum(content: &str) -> HashMap<String, Vec<String>> {
     let mut map: HashMap<String, Vec<String>> = HashMap::new();
 

--- a/dependi-lsp/src/parsers/go_sum.rs
+++ b/dependi-lsp/src/parsers/go_sum.rs
@@ -14,7 +14,9 @@ use crate::parsers::lockfile_resolver::LockfileResolver;
 /// `go.sum` format: `<module> <version>[/go.mod] <hash>`
 ///
 /// Lines whose version string ends with `/go.mod` are skipped to avoid
-/// duplicates — only the `h1:` (tree hash) lines contribute a version entry.
+/// duplicates with the matching tree-hash line; every other entry contributes
+/// a version regardless of its hash prefix (typically `h1:`, but the parser
+/// does not inspect or validate the hash type).
 ///
 /// Go 1.17+ with lazy module loading may record multiple versions of the same
 /// module (direct + transitive at different versions). All non-`/go.mod`
@@ -28,7 +30,7 @@ use crate::parsers::lockfile_resolver::LockfileResolver;
 /// let sum = "github.com/pkg/errors v0.9.1 h1:abc=\n\
 ///            github.com/pkg/errors v0.9.1/go.mod h1:def=\n";
 /// let map = parse_go_sum(sum);
-/// // /go.mod line is skipped; only the h1: line contributes.
+/// // /go.mod line is skipped; the tree-hash line contributes the version.
 /// assert_eq!(map.get("github.com/pkg/errors").unwrap().as_slice(), &["v0.9.1"]);
 /// ```
 pub fn parse_go_sum(content: &str) -> HashMap<String, Vec<String>> {

--- a/dependi-lsp/src/parsers/json_spans.rs
+++ b/dependi-lsp/src/parsers/json_spans.rs
@@ -1,4 +1,14 @@
-//! Shared helpers for span-aware JSON parsing (used by npm and php parsers).
+//! Shared helpers for span-aware JSON parsing.
+//!
+//! Used by the npm (`package-lock.json`) and PHP (`composer.lock`) lockfile parsers
+//! to convert byte-range information returned by the JSON parser into [`super::Span`]
+//! values that the LSP layer can attach to diagnostic and inlay-hint positions.
+//!
+//! The key types are:
+//! - `LineIndex` — pre-computes line-start byte offsets so that O(log n)
+//!   `position()` calls can convert any byte offset to a `(line, column)` pair.
+//! - `span_to_span` / `string_inner_to_span` — convert raw byte ranges into
+//!   [`super::Span`] instances, returning `None` for multi-line ranges.
 
 use super::Span;
 

--- a/dependi-lsp/src/parsers/lockfile_graph.rs
+++ b/dependi-lsp/src/parsers/lockfile_graph.rs
@@ -1,10 +1,25 @@
 //! Shared graph representation for lockfile contents.
+//!
+//! [`LockfileGraph`] stores the full set of packages recorded in a lockfile as a
+//! flat [`Vec`] of [`LockfilePackage`] nodes with explicit dependency edges.
+//! Graph algorithms (DFS, reachability, reverse index) are implemented as methods
+//! on [`LockfileGraph`] and are used for transitive vulnerability attribution.
 
 use hashbrown::HashSet;
 use tokio::io::AsyncReadExt;
 
-/// Read a lockfile with a 50 MiB size cap to prevent OOM on hostile inputs.
-/// The cap is enforced DURING the read, not before, to avoid TOCTOU races.
+/// Read a lockfile into a `String`, refusing content larger than 50 MiB.
+///
+/// The cap is enforced **during** the read rather than by checking the file
+/// size beforehand, which avoids TOCTOU races on network filesystems.
+///
+/// # Errors
+///
+/// Returns `Err` with `ErrorKind::InvalidData` when:
+/// - The file content exceeds 50 MiB.
+/// - The file content is not valid UTF-8.
+///
+/// Propagates any I/O errors from opening or reading the file.
 pub async fn read_lockfile_capped(path: &std::path::Path) -> std::io::Result<String> {
     const MAX_LOCKFILE_BYTES: u64 = 50 * 1024 * 1024;
     let file = tokio::fs::File::open(path).await?;
@@ -26,25 +41,67 @@ pub async fn read_lockfile_capped(path: &std::path::Path) -> std::io::Result<Str
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.utf8_error()))
 }
 
+/// A single package entry in a resolved lockfile.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LockfilePackage {
+    /// Package name as recorded in the lockfile (may be pre-normalized by the parser).
     pub name: String,
+    /// Exact locked version string (e.g., `"1.0.195"` or `"v0.14.0"`).
     pub version: String,
-    /// Names of packages directly required by this one (no version info).
+    /// Names of packages directly required by this one.
+    ///
+    /// For Cargo, entries may include a version token (`"serde 1.0.195"`) when
+    /// multiple versions of the same crate are locked. Graph-walk code strips
+    /// the version token when resolving edges.
     pub dependencies: Vec<String>,
-    /// True when this package is declared in the manifest (a direct dependency).
+    /// `true` when this package is declared directly in the manifest.
+    ///
+    /// Currently unused by most parsers (defaults to `false`); reserved for
+    /// future use when distinguishing direct from transitive dependencies.
     pub is_root: bool,
 }
 
+/// The full set of packages from a resolved lockfile, with dependency edges.
+///
+/// Built by ecosystem-specific parsers (see [`crate::parsers::cargo_lock`],
+/// [`crate::parsers::npm_lock`], etc.) and consumed by vulnerability attribution
+/// logic to determine which manifest dependencies transitively pull in a
+/// vulnerable package.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::lockfile_graph::LockfileGraph;
+/// let graph = LockfileGraph::default();
+/// assert!(graph.packages.is_empty());
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct LockfileGraph {
+    /// All packages present in the lockfile, including transitive dependencies.
     pub packages: Vec<LockfilePackage>,
 }
 
 impl LockfileGraph {
-    /// Returns all packages sharing the given name (0 or more). Some lockfiles
-    /// pin multiple versions of the same crate/package — e.g. Cargo's
-    /// transitive resolution.
+    /// Return all packages in the graph that match `name` (0 or more).
+    ///
+    /// Some lockfiles pin multiple versions of the same crate — e.g. Cargo's
+    /// transitive resolution — so `find_all` can return more than one entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dependi_lsp::parsers::lockfile_graph::{LockfileGraph, LockfilePackage};
+    /// let graph = LockfileGraph {
+    ///     packages: vec![
+    ///         LockfilePackage { name: "serde".into(), version: "1.0.195".into(), dependencies: vec![], is_root: false },
+    ///         LockfilePackage { name: "serde".into(), version: "1.0.100".into(), dependencies: vec![], is_root: false },
+    ///         LockfilePackage { name: "tokio".into(), version: "1.36.0".into(), dependencies: vec![], is_root: false },
+    ///     ],
+    /// };
+    /// assert_eq!(graph.find_all("serde").len(), 2);
+    /// assert_eq!(graph.find_all("tokio").len(), 1);
+    /// assert_eq!(graph.find_all("absent").len(), 0);
+    /// ```
     pub fn find_all(&self, name: &str) -> Vec<&LockfilePackage> {
         self.packages.iter().filter(|p| p.name == name).collect()
     }

--- a/dependi-lsp/src/parsers/lockfile_resolver.rs
+++ b/dependi-lsp/src/parsers/lockfile_resolver.rs
@@ -1,8 +1,15 @@
 //! Generic lockfile resolution trait + dispatch helper.
 //!
-//! Abstracts the per-ecosystem lockfile lookup/parse logic so that
-//! [`crate::backend::ProcessingContext::process_document`] can resolve
-//! versions through a single code path regardless of the manifest format.
+//! Abstracts the per-ecosystem lockfile lookup/parse logic so that the LSP
+//! backend can resolve versions through a single code path regardless of the
+//! manifest format.
+//!
+//! The primary entry points are:
+//!
+//! - [`select_resolver`] — picks the right [`LockfileResolver`] for a given
+//!   [`crate::file_types::FileType`].
+//! - [`resolve_versions_from_lockfile`] — runs the full resolve pipeline,
+//!   mutating each [`crate::parsers::Dependency`]'s `resolved_version` field in place.
 
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
@@ -12,27 +19,50 @@ use crate::file_types::FileType;
 use crate::parsers::Dependency;
 use crate::parsers::lockfile_graph::LockfileGraph;
 
+/// Per-ecosystem lockfile resolver.
+///
+/// Each ecosystem that supports lockfiles provides a concrete implementation.
+/// The three methods work together: [`find_lockfile`](LockfileResolver::find_lockfile)
+/// locates the file on disk, [`parse_graph`](LockfileResolver::parse_graph) converts
+/// its text into a [`LockfileGraph`], and [`resolve_version`](LockfileResolver::resolve_version)
+/// maps a manifest dependency to its exact locked version.
+///
+/// Name normalization (lowercase, separator collapsing, etc.) is exposed through
+/// [`normalize_name`](LockfileResolver::normalize_name) so that both sides of the
+/// comparison use the same canonical form.
 #[async_trait]
 pub trait LockfileResolver: Send + Sync {
     /// Locate the lockfile relative to the manifest path.
-    /// Returns `None` when no lockfile exists for this ecosystem.
+    ///
+    /// Returns `None` when no lockfile exists for this ecosystem (or when the
+    /// filesystem probe fails).
     async fn find_lockfile(&self, manifest_path: &Path) -> Option<PathBuf>;
 
-    /// Parse lockfile contents into a `LockfileGraph`.
+    /// Parse lockfile contents into a [`LockfileGraph`].
+    ///
     /// On parse failure, returns an empty graph (silent — matches existing parser behavior).
     fn parse_graph(&self, lock_content: &str) -> LockfileGraph;
 
     /// Normalize a package name for version-map lookup.
-    /// Default: identity. Override for PEP 503 (Python), lowercase (Ruby/NuGet/Composer).
+    ///
+    /// Default implementation is the identity function.
+    /// Override for ecosystems with case-insensitive or separator-normalized names:
+    /// - Python: PEP 503 (`_`/`.`/`-` → `-`, lowercase)
+    /// - Ruby/NuGet/Composer: lowercase
     fn normalize_name(&self, name: &str) -> String {
         name.to_string()
     }
 
-    /// Resolve the version for a single dependency from a parsed graph.
-    /// Default: first-wins lookup by normalized name. Normalizes BOTH `dep.name`
-    /// and each `LockfilePackage.name` so the comparison is consistent regardless
-    /// of whether the parser pre-normalized graph entries.
-    /// Override for ecosystems with multi-version semantics (e.g., Go).
+    /// Resolve the locked version for a single dependency from a parsed graph.
+    ///
+    /// The default implementation performs a first-wins lookup by normalized name,
+    /// applying [`normalize_name`](LockfileResolver::normalize_name) to **both**
+    /// `dep.name` and each [`crate::parsers::lockfile_graph::LockfilePackage`]`::name`
+    /// so the comparison is consistent regardless of whether the parser pre-normalized
+    /// graph entries.
+    ///
+    /// Override for ecosystems with multi-version semantics (e.g., Go) or
+    /// root-package disambiguation (e.g., Cargo).
     fn resolve_version(&self, dep: &Dependency, graph: &LockfileGraph) -> Option<String> {
         let normalized = self.normalize_name(&dep.name);
         graph
@@ -43,10 +73,16 @@ pub trait LockfileResolver: Send + Sync {
     }
 }
 
-/// Pick the resolver matching `file_type`.
-/// For Npm/Python the on-disk sub-format is probed eagerly so the resolver
-/// caches the lockfile path + sub-format variant.
-/// Returns `None` for `FileType::Maven` (unsupported).
+/// Return the [`LockfileResolver`] that matches `file_type`.
+///
+/// For `Npm` and `Python`, the on-disk sub-format is probed eagerly at call
+/// time so the resolver can cache the lockfile path and sub-format variant
+/// (e.g., `package-lock.json` vs `yarn.lock`).
+///
+/// # Returns
+///
+/// `Some(resolver)` for all supported ecosystems; `None` for
+/// [`FileType::Maven`] which has no lockfile support.
 pub async fn select_resolver(
     file_type: FileType,
     manifest_path: &Path,
@@ -85,8 +121,17 @@ pub async fn select_resolver(
     }
 }
 
-/// Run the resolver against `dependencies`, mutating `resolved_version` in place.
-/// Returns the parsed `Arc<LockfileGraph>` for downstream consumers (vuln attribution).
+/// Resolve locked versions for all `dependencies` using the provided resolver.
+///
+/// Locates the lockfile, parses it into a [`LockfileGraph`], then sets each
+/// `dependency.resolved_version` to the exact version pinned in the lockfile.
+/// Dependencies that are absent from the lockfile are left unchanged.
+///
+/// # Returns
+///
+/// `Some(Arc<LockfileGraph>)` on success so that downstream consumers (e.g.,
+/// vulnerability attribution) can reuse the already-parsed graph.
+/// Returns `None` when no lockfile is found or the lockfile cannot be read.
 pub async fn resolve_versions_from_lockfile(
     dependencies: &mut [Dependency],
     resolver: Box<dyn LockfileResolver>,

--- a/dependi-lsp/src/parsers/lockfile_resolver.rs
+++ b/dependi-lsp/src/parsers/lockfile_resolver.rs
@@ -129,8 +129,11 @@ pub async fn select_resolver(
 ///
 /// # Returns
 ///
-/// `Some(Arc<LockfileGraph>)` on success so that downstream consumers (e.g.,
-/// vulnerability attribution) can reuse the already-parsed graph.
+/// `Some(Arc<LockfileGraph>)` whenever the lockfile is located and read
+/// successfully, so downstream consumers (e.g., vulnerability attribution) can
+/// reuse the already-parsed graph. The wrapped graph may still be empty — most
+/// resolvers swallow parse failures silently and return an empty
+/// [`LockfileGraph`] rather than propagating the error.
 /// Returns `None` when no lockfile is found or the lockfile cannot be read.
 pub async fn resolve_versions_from_lockfile(
     dependencies: &mut [Dependency],

--- a/dependi-lsp/src/parsers/maven.rs
+++ b/dependi-lsp/src/parsers/maven.rs
@@ -85,6 +85,11 @@ fn line_offsets(content: &str) -> Vec<usize> {
 /// Converts a flat `byte_offset` to `(line, column)`, both 0-indexed.
 ///
 /// Uses a binary search over the `offsets` table produced by [`line_offsets`].
+///
+/// **Precondition:** `offsets` must be non-empty and `byte_offset` must be a
+/// valid index into the same buffer that produced `offsets` (i.e. `0 ..=
+/// content.len()`). Out-of-bounds offsets are clamped via `saturating_sub` and
+/// will return the last known line, but the resulting column is meaningless.
 fn offset_to_position(offsets: &[usize], byte_offset: usize) -> (u32, u32) {
     let line_idx = match offsets.binary_search(&byte_offset) {
         Ok(i) => i,

--- a/dependi-lsp/src/parsers/maven.rs
+++ b/dependi-lsp/src/parsers/maven.rs
@@ -20,10 +20,41 @@ use quick_xml::reader::Reader;
 use crate::parsers::{Dependency, Parser, Span};
 
 /// Parser for Maven `pom.xml` files.
+///
+/// Performs two sequential passes over the XML:
+/// 1. Collect `<properties>` for `${...}` substitution (`extract_properties`).
+/// 2. Extract `<dependency>` blocks from `<dependencies>` and
+///    `<dependencyManagement>`, substituting property references
+///    (`extract_dependencies`).
+///
+/// The dependency `name` uses the Maven `groupId:artifactId` convention.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::Parser;
+/// use dependi_lsp::parsers::maven::MavenParser;
+/// let parser = MavenParser::new();
+/// let pom = r#"<?xml version="1.0"?>
+/// <project>
+///   <dependencies>
+///     <dependency>
+///       <groupId>org.slf4j</groupId>
+///       <artifactId>slf4j-api</artifactId>
+///       <version>1.7.30</version>
+///     </dependency>
+///   </dependencies>
+/// </project>"#;
+/// let deps = parser.parse(pom);
+/// assert_eq!(deps.len(), 1);
+/// assert_eq!(deps[0].name, "org.slf4j:slf4j-api");
+/// assert_eq!(deps[0].version, "1.7.30");
+/// ```
 #[derive(Debug, Default)]
 pub struct MavenParser;
 
 impl MavenParser {
+    /// Creates a new [`MavenParser`] instance.
     pub fn new() -> Self {
         Self
     }
@@ -36,8 +67,11 @@ impl Parser for MavenParser {
     }
 }
 
-/// Precomputed byte-offset → (line, column) mapping for a source string.
-/// Lines are 0-indexed, columns are character-based within each line.
+/// Builds a sorted list of byte offsets where each new line begins.
+///
+/// The first element is always `0`.  Used as a lookup table by
+/// [`offset_to_position`] to convert flat byte offsets into `(line, column)`
+/// pairs without scanning from the start each time.
 fn line_offsets(content: &str) -> Vec<usize> {
     let mut offsets = vec![0usize];
     for (i, b) in content.bytes().enumerate() {
@@ -48,7 +82,9 @@ fn line_offsets(content: &str) -> Vec<usize> {
     offsets
 }
 
-/// Convert a byte offset to (line, column), both 0-indexed.
+/// Converts a flat `byte_offset` to `(line, column)`, both 0-indexed.
+///
+/// Uses a binary search over the `offsets` table produced by [`line_offsets`].
 fn offset_to_position(offsets: &[usize], byte_offset: usize) -> (u32, u32) {
     let line_idx = match offsets.binary_search(&byte_offset) {
         Ok(i) => i,

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -58,16 +58,18 @@ pub struct Dependency {
 
 /// A half-open byte range within a single source line.
 ///
-/// Both `line_start` and `line_end` are 0-indexed character offsets measured
-/// from the beginning of the line (not the file), and the range is end-exclusive:
-/// `line[line_start..line_end]` yields the covered text.
+/// `line_start` and `line_end` are 0-indexed **byte** offsets measured from the
+/// beginning of the line (not the file). The range is end-exclusive:
+/// `line[line_start..line_end]` yields the covered text. ASCII input therefore
+/// maps 1:1 to LSP UTF-16 character offsets, but non-ASCII content is not
+/// transcoded — callers that need exact LSP character columns must convert.
 #[derive(Debug, Clone, Copy)]
 pub struct Span {
     /// 0-indexed line number within the file.
     pub line: u32,
-    /// 0-indexed column of the first character (inclusive).
+    /// 0-indexed byte offset of the first byte (inclusive).
     pub line_start: u32,
-    /// 0-indexed column one past the last character (exclusive).
+    /// 0-indexed byte offset one past the last byte (exclusive).
     pub line_end: u32,
 }
 

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -1,39 +1,81 @@
-//! Parsers for dependency files (Cargo.toml, package.json, etc.)
+//! Shared types and the [`Parser`] trait used by all manifest parsers.
+//!
+//! Each ecosystem parser lives in its own sub-module and produces a
+//! `Vec<`[`Dependency`]`>` from the raw file content.  Span information
+//! (`name_span` / `version_span`) is always anchored to the *inner* text of
+//! each token so that LSP quick-fix [`tower_lsp::lsp_types::TextEdit`]s
+//! replace just the package name or version literal without touching
+//! surrounding quotes or syntax.
+//!
+//! # Supported ecosystems
+//!
+//! | Module | File | Registry |
+//! |--------|------|----------|
+//! | [`cargo`] | `Cargo.toml` | crates.io |
+//! | [`npm`] | `package.json` | npm |
+//! | [`python`] | `requirements.txt`, `pyproject.toml`, `hatch.toml` | PyPI |
+//! | [`go`] | `go.mod` | proxy.golang.org |
+//! | [`php`] | `composer.json` | Packagist |
+//! | [`dart`] | `pubspec.yaml` | pub.dev |
+//! | [`csharp`] | `*.csproj` | NuGet |
+//! | [`ruby`] | `Gemfile` | RubyGems |
+//! | [`maven`] | `pom.xml` | Maven Central |
 
 use tower_lsp::lsp_types;
 
-/// Represents a dependency extracted from a manifest file
+/// A single dependency extracted from a manifest file.
+///
+/// Both `name_span` and `version_span` cover the *inner* content of the token
+/// (no surrounding quotes), so LSP quick-fix edits can safely replace just
+/// the text they target.
 #[derive(Debug, Clone)]
 pub struct Dependency {
-    /// Package name
+    /// Package name as declared in the manifest.
     pub name: String,
-    /// Version specifier (e.g., "1.0.0", "^1.0", ">=1,<2")
+    /// Version specifier as declared (e.g. `"^1.0"`, `">=1,<2"`).
+    ///
+    /// For Maven `pom.xml` files that use `${property}` placeholders, this
+    /// field preserves the raw placeholder text so the code-action layer can
+    /// detect and skip the "update version" quick-fix.  The resolved value is
+    /// available via [`Self::effective_version`].
     pub version: String,
-    /// Package name span
+    /// Source span covering the package name token (inner text, no quotes).
     pub name_span: Span,
-    /// Version string span
+    /// Source span covering the version token (inner text, no quotes).
     pub version_span: Span,
-    /// Whether this is a dev dependency
+    /// Whether this dependency belongs to a dev / test group.
     pub dev: bool,
-    /// Whether this dependency is optional
+    /// Whether this dependency is optional (peer, optional, or indirect).
     pub optional: bool,
-    /// Custom registry name (Cargo only, e.g., "kellnr")
+    /// Custom registry name (Cargo only, e.g. `"kellnr"`).
     pub registry: Option<String>,
-    /// Resolved version from the lock file (e.g., Cargo.lock), if available
+    /// Version resolved from the lock file (e.g. `Cargo.lock`), if available.
+    ///
+    /// When set, [`Self::effective_version`] returns this value instead of
+    /// [`Self::version`] for registry comparisons and hover text.
     pub resolved_version: Option<String>,
 }
 
+/// A half-open byte range within a single source line.
+///
+/// Both `line_start` and `line_end` are 0-indexed character offsets measured
+/// from the beginning of the line (not the file), and the range is end-exclusive:
+/// `line[line_start..line_end]` yields the covered text.
 #[derive(Debug, Clone, Copy)]
 pub struct Span {
-    /// Line number in the file (0-indexed)
+    /// 0-indexed line number within the file.
     pub line: u32,
-    /// Column where the value starts
+    /// 0-indexed column of the first character (inclusive).
     pub line_start: u32,
-    /// Column where the value ends
+    /// 0-indexed column one past the last character (exclusive).
     pub line_end: u32,
 }
 
 impl Span {
+    /// Returns `true` when `position` falls within this span.
+    ///
+    /// Both the line and the column must match: the column is checked against
+    /// the half-open range `[line_start, line_end)`.
     pub fn contains_lsp_position(&self, position: &lsp_types::Position) -> bool {
         self.line == position.line && (self.line_start..self.line_end).contains(&position.character)
     }
@@ -42,14 +84,52 @@ impl Span {
 impl Dependency {
     /// Returns the resolved version (from lock file) if available,
     /// otherwise falls back to the declared version from the manifest.
+    ///
+    /// Use this method whenever a concrete version number is needed for
+    /// registry look-ups or hover text, as it transparently handles both
+    /// lock-file pinned versions and Maven `${property}` substitutions stored
+    /// in [`Self::resolved_version`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dependi_lsp::parsers::{Dependency, Span};
+    /// let dep = Dependency {
+    ///     name: "serde".into(),
+    ///     version: "^1.0".into(),
+    ///     name_span: Span { line: 0, line_start: 0, line_end: 5 },
+    ///     version_span: Span { line: 0, line_start: 8, line_end: 12 },
+    ///     dev: false,
+    ///     optional: false,
+    ///     registry: None,
+    ///     resolved_version: Some("1.0.196".into()),
+    /// };
+    /// assert_eq!(dep.effective_version(), "1.0.196");
+    /// ```
     pub fn effective_version(&self) -> &str {
         self.resolved_version.as_deref().unwrap_or(&self.version)
     }
 }
 
-/// Trait for parsing dependency files
+/// Trait implemented by every ecosystem-specific manifest parser.
+///
+/// Implementors must be both [`Send`] and [`Sync`] so that parsers can be
+/// shared across async tasks in the LSP backend.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::{Parser, cargo::CargoParser};
+/// let parser = CargoParser::new();
+/// let deps = parser.parse("[dependencies]\nserde = \"1.0\"\n");
+/// assert_eq!(deps.len(), 1);
+/// assert_eq!(deps[0].name, "serde");
+/// ```
 pub trait Parser: Send + Sync {
-    /// Parse the given file content and extract dependencies
+    /// Parse `content` and return every dependency found.
+    ///
+    /// Malformed or unrecognised input should be silently ignored rather than
+    /// panicking — return an empty `Vec` when nothing can be extracted.
     fn parse(&self, content: &str) -> Vec<Dependency>;
 }
 

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -1,25 +1,25 @@
-//! Shared types and the [`Parser`] trait used by all manifest parsers.
+//! Shared types and the [`crate::parsers::Parser`] trait used by all manifest parsers.
 //!
 //! Each ecosystem parser lives in its own sub-module and produces a
-//! `Vec<`[`Dependency`]`>` from the raw file content.  Span information
-//! (`name_span` / `version_span`) is always anchored to the *inner* text of
-//! each token so that LSP quick-fix [`tower_lsp::lsp_types::TextEdit`]s
-//! replace just the package name or version literal without touching
-//! surrounding quotes or syntax.
+//! `Vec<`[`crate::parsers::Dependency`]`>` from the raw file content.  Span
+//! information (`name_span` / `version_span`) is always anchored to the *inner*
+//! text of each token so that LSP quick-fix
+//! [`tower_lsp::lsp_types::TextEdit`]s replace just the package name or
+//! version literal without touching surrounding quotes or syntax.
 //!
 //! # Supported ecosystems
 //!
 //! | Module | File | Registry |
 //! |--------|------|----------|
-//! | [`cargo`] | `Cargo.toml` | crates.io |
-//! | [`npm`] | `package.json` | npm |
-//! | [`python`] | `requirements.txt`, `pyproject.toml`, `hatch.toml` | PyPI |
-//! | [`go`] | `go.mod` | proxy.golang.org |
-//! | [`php`] | `composer.json` | Packagist |
-//! | [`dart`] | `pubspec.yaml` | pub.dev |
-//! | [`csharp`] | `*.csproj` | NuGet |
-//! | [`ruby`] | `Gemfile` | RubyGems |
-//! | [`maven`] | `pom.xml` | Maven Central |
+//! | [`crate::parsers::cargo`] | `Cargo.toml` | crates.io |
+//! | [`crate::parsers::npm`] | `package.json` | npm |
+//! | [`crate::parsers::python`] | `requirements.txt`, `pyproject.toml`, `hatch.toml` | PyPI |
+//! | [`crate::parsers::go`] | `go.mod` | proxy.golang.org |
+//! | [`crate::parsers::php`] | `composer.json` | Packagist |
+//! | [`crate::parsers::dart`] | `pubspec.yaml` | pub.dev |
+//! | [`crate::parsers::csharp`] | `*.csproj` | NuGet |
+//! | [`crate::parsers::ruby`] | `Gemfile` | RubyGems |
+//! | [`crate::parsers::maven`] | `pom.xml` | Maven Central |
 
 use tower_lsp::lsp_types;
 

--- a/dependi-lsp/src/parsers/npm.rs
+++ b/dependi-lsp/src/parsers/npm.rs
@@ -1,7 +1,23 @@
-//! Parser for package.json files
+//! Parser for npm `package.json` files.
 //!
 //! Uses `json-spanned-value` to obtain dependency name/version spans directly
 //! from the parser output, removing the need for a manual string scan.
+//! This approach correctly handles packages whose name or version appears more
+//! than once in the file (e.g. a package pinned to the same version in both
+//! `dependencies` and `devDependencies`).
+//!
+//! The following sections are recognised:
+//!
+//! | JSON key | `dev` | `optional` |
+//! |----------|-------|------------|
+//! | `dependencies` | `false` | `false` |
+//! | `devDependencies` | `true` | `false` |
+//! | `peerDependencies` | `false` | `true` |
+//! | `optionalDependencies` | `false` | `true` |
+//!
+//! Both plain string values (`"^1.0"`) and single-field object values
+//! (`{ "version": "^1.0" }`) are supported as long as the `"version"` key
+//! appears on the same line as the surrounding package-name key.
 
 use json_spanned_value as jsv;
 use json_spanned_value::spanned;
@@ -9,11 +25,25 @@ use json_spanned_value::spanned;
 use super::json_spans::{LineIndex, string_inner_to_span};
 use super::{Dependency, Parser, Span};
 
-/// Parser for npm package.json dependency files.
+/// Parser for npm `package.json` dependency files.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::Parser;
+/// use dependi_lsp::parsers::npm::NpmParser;
+/// let parser = NpmParser::new();
+/// let pkg = r#"{"dependencies": {"lodash": "^4.0.0"}}"#;
+/// let deps = parser.parse(pkg);
+/// assert_eq!(deps.len(), 1);
+/// assert_eq!(deps[0].name, "lodash");
+/// assert_eq!(deps[0].version, "^4.0.0");
+/// ```
 #[derive(Debug, Default)]
 pub struct NpmParser;
 
 impl NpmParser {
+    /// Creates a new [`NpmParser`] instance.
     pub fn new() -> Self {
         Self
     }
@@ -65,7 +95,11 @@ impl Parser for NpmParser {
     }
 }
 
-/// Look up a section in the root object and parse each entry into a `Dependency`.
+/// Looks up a section in the root object and appends each entry to `dependencies`.
+///
+/// Entries whose name and version spans fall on different lines are silently
+/// skipped (multi-line object values that cannot be attributed to a single
+/// source line are out of scope for quick-fix editing).
 fn parse_section(
     root: &spanned::Object,
     section_name: &str,

--- a/dependi-lsp/src/parsers/npm_lock.rs
+++ b/dependi-lsp/src/parsers/npm_lock.rs
@@ -65,6 +65,18 @@ pub async fn find_npm_lockfile(package_json_path: &Path) -> Option<(PathBuf, Npm
 }
 
 /// Parse a Node.js lockfile and return a map of package name → resolved version.
+///
+/// Dispatches to the appropriate sub-parser based on `lockfile_type`.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::npm_lock::{parse_npm_lockfile, NpmLockfileType};
+///
+/// let lock = r#"{"lockfileVersion":3,"packages":{"node_modules/express":{"version":"4.18.2"}}}"#;
+/// let map = parse_npm_lockfile(lock, NpmLockfileType::PackageLock);
+/// assert_eq!(map.get("express").map(String::as_str), Some("4.18.2"));
+/// ```
 pub fn parse_npm_lockfile(
     content: &str,
     lockfile_type: NpmLockfileType,
@@ -390,9 +402,19 @@ fn clean_jsonc(content: &str) -> String {
 // Graph extraction — package-lock.json, pnpm-lock.yaml, yarn.lock v1
 // ---------------------------------------------------------------------------
 
-/// Parse a `package-lock.json` (lockfile v2/v3 flat `packages` format) into a graph.
+/// Parse a `package-lock.json` (lockfile v2/v3 flat `packages` format) into a [`LockfileGraph`].
 ///
-/// v1 nested format is intentionally not supported here (superseded since npm 7, 2020).
+/// v1 nested-`dependencies` format is intentionally not supported (superseded since npm 7, 2020).
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::npm_lock::parse_package_lock_graph;
+///
+/// let lock = r#"{"lockfileVersion":3,"packages":{"node_modules/react":{"version":"18.2.0"}}}"#;
+/// let graph = parse_package_lock_graph(lock);
+/// assert!(graph.packages.iter().any(|p| p.name == "react" && p.version == "18.2.0"));
+/// ```
 pub fn parse_package_lock_graph(content: &str) -> LockfileGraph {
     let mut graph = LockfileGraph::default();
     let value: serde_json::Value = match serde_json::from_str(content) {
@@ -434,9 +456,21 @@ pub fn parse_package_lock_graph(content: &str) -> LockfileGraph {
     graph
 }
 
-/// Parse a pnpm-lock.yaml into a graph. Uses a minimal line-based walker because the
-/// project has no YAML parser in dependencies; this mirrors the approach of existing
-/// pnpm parsing in the file.
+/// Parse a `pnpm-lock.yaml` into a [`LockfileGraph`].
+///
+/// Uses a minimal line-based walker (no YAML parser dependency). Handles both
+/// v6 (`/name@ver:`) and v9 (`name@ver:`) key formats, including quoted scoped
+/// package names.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::npm_lock::parse_pnpm_lock_graph;
+///
+/// let lock = "lockfileVersion: '9.0'\npackages:\n  react@18.2.0:\n    resolution: {}\n";
+/// let graph = parse_pnpm_lock_graph(lock);
+/// assert!(graph.packages.iter().any(|p| p.name == "react" && p.version == "18.2.0"));
+/// ```
 pub fn parse_pnpm_lock_graph(content: &str) -> LockfileGraph {
     let mut graph = LockfileGraph::default();
     let mut in_packages = false;
@@ -541,8 +575,21 @@ fn split_pnpm_key(key: &str) -> Option<(String, String)> {
     Some((base[..at].to_string(), base[at + 1..].to_string()))
 }
 
-/// Parse yarn.lock (v1 format) into a graph. v2+ (Berry) uses a different format,
-/// out of scope here.
+/// Parse a `yarn.lock` (Yarn Classic v1 format) into a [`LockfileGraph`].
+///
+/// Yarn Berry v2+ uses a different YAML-based format and is not handled here.
+/// For version-only extraction that also covers Berry, use the private
+/// `parse_yarn_lock` helper (called internally by `NpmResolver::parse_graph`).
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::npm_lock::parse_yarn_lock_graph;
+///
+/// let lock = "\"react@^18.0.0\":\n  version \"18.2.0\"\n";
+/// let graph = parse_yarn_lock_graph(lock);
+/// assert!(graph.packages.iter().any(|p| p.name == "react" && p.version == "18.2.0"));
+/// ```
 pub fn parse_yarn_lock_graph(content: &str) -> LockfileGraph {
     let mut graph = LockfileGraph::default();
     let mut current: Option<LockfilePackage> = None;

--- a/dependi-lsp/src/parsers/npm_lock.rs
+++ b/dependi-lsp/src/parsers/npm_lock.rs
@@ -577,9 +577,8 @@ fn split_pnpm_key(key: &str) -> Option<(String, String)> {
 
 /// Parse a `yarn.lock` (Yarn Classic v1 format) into a [`LockfileGraph`].
 ///
-/// Yarn Berry v2+ uses a different YAML-based format and is not handled here.
-/// For version-only extraction that also covers Berry, use the private
-/// `parse_yarn_lock` helper (called internally by `NpmResolver::parse_graph`).
+/// Yarn Berry v2+ uses a different YAML-based format and is not handled by
+/// this entry point.
 ///
 /// # Examples
 ///

--- a/dependi-lsp/src/parsers/packages_lock_json.rs
+++ b/dependi-lsp/src/parsers/packages_lock_json.rs
@@ -32,7 +32,8 @@ pub fn normalize_nuget_name(name: &str) -> String {
 /// package names to objects with a `"resolved"` version field. Both `"Direct"`
 /// and `"Transitive"` entries are included. Names are normalized to lowercase
 /// since NuGet is case-insensitive. When a package appears in multiple target
-/// frameworks, the first entry is kept.
+/// frameworks, the first entry encountered during JSON object iteration order
+/// is kept.
 ///
 /// # Examples
 ///

--- a/dependi-lsp/src/parsers/packages_lock_json.rs
+++ b/dependi-lsp/src/parsers/packages_lock_json.rs
@@ -10,19 +10,39 @@ use crate::parsers::lockfile_resolver::LockfileResolver;
 
 /// Normalize a NuGet package name to lowercase.
 ///
-/// NuGet package names are case-insensitive (e.g., "Newtonsoft.Json" == "newtonsoft.json").
+/// NuGet package names are case-insensitive
+/// (e.g., `"Newtonsoft.Json"` == `"newtonsoft.json"`).
 /// This function ensures consistent lookup between manifest and lockfile entries.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::packages_lock_json::normalize_nuget_name;
+/// assert_eq!(normalize_nuget_name("Newtonsoft.Json"), "newtonsoft.json");
+/// assert_eq!(normalize_nuget_name("microsoft.extensions.logging"), "microsoft.extensions.logging");
+/// ```
 pub fn normalize_nuget_name(name: &str) -> String {
     name.to_lowercase()
 }
 
-/// Parse a packages.lock.json file and return a map of package name → resolved version.
+/// Parse a `packages.lock.json` file and return a map of package name → resolved version.
 ///
-/// packages.lock.json is a JSON file with a `"dependencies"` object whose keys are
-/// target framework monikers (e.g., "net8.0"). Each framework maps package names to
-/// objects with a `"resolved"` version field. Both "Direct" and "Transitive" entries
-/// are included. Names are normalized to lowercase since NuGet is case-insensitive.
-/// When a package appears in multiple target frameworks, the first entry is kept.
+/// `packages.lock.json` is a JSON file with a `"dependencies"` object whose
+/// keys are target framework monikers (e.g., `"net8.0"`). Each framework maps
+/// package names to objects with a `"resolved"` version field. Both `"Direct"`
+/// and `"Transitive"` entries are included. Names are normalized to lowercase
+/// since NuGet is case-insensitive. When a package appears in multiple target
+/// frameworks, the first entry is kept.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::packages_lock_json::parse_packages_lock;
+///
+/// let lock = r#"{"version":1,"dependencies":{"net8.0":{"Newtonsoft.Json":{"type":"Direct","resolved":"13.0.1"}}}}"#;
+/// let map = parse_packages_lock(lock);
+/// assert_eq!(map.get("newtonsoft.json").map(String::as_str), Some("13.0.1"));
+/// ```
 pub fn parse_packages_lock(content: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
 

--- a/dependi-lsp/src/parsers/php.rs
+++ b/dependi-lsp/src/parsers/php.rs
@@ -1,8 +1,18 @@
-//! Parser for PHP Composer files (composer.json)
+//! Parser for PHP Composer files (`composer.json`).
 //!
 //! Uses `json-spanned-value` for span tracking; the PHP-specific filter rules
 //! (skip `php` and `ext-*` keys) are applied before any work is done with the
 //! span info.
+//!
+//! The following sections are recognised:
+//!
+//! | JSON key | `dev` |
+//! |----------|-------|
+//! | `require` | `false` |
+//! | `require-dev` | `true` |
+//!
+//! Platform requirements (`"php"` key and any key starting with `"ext-"`) are
+//! silently ignored as they do not correspond to Packagist packages.
 
 use json_spanned_value as jsv;
 use json_spanned_value::spanned;
@@ -10,11 +20,25 @@ use json_spanned_value::spanned;
 use super::json_spans::{LineIndex, string_inner_to_span};
 use super::{Dependency, Parser};
 
-/// Parser for PHP composer.json dependency files.
+/// Parser for PHP `composer.json` dependency files.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::Parser;
+/// use dependi_lsp::parsers::php::PhpParser;
+/// let parser = PhpParser::new();
+/// let content = r#"{"require": {"laravel/framework": "^10.0"}}"#;
+/// let deps = parser.parse(content);
+/// assert_eq!(deps.len(), 1);
+/// assert_eq!(deps[0].name, "laravel/framework");
+/// assert_eq!(deps[0].version, "^10.0");
+/// ```
 #[derive(Debug, Default)]
 pub struct PhpParser;
 
 impl PhpParser {
+    /// Creates a new [`PhpParser`] instance.
     pub fn new() -> Self {
         Self
     }
@@ -36,6 +60,10 @@ impl Parser for PhpParser {
     }
 }
 
+/// Looks up `section_name` in `root` and appends each entry to `dependencies`.
+///
+/// Keys equal to `"php"` or starting with `"ext-"` are skipped.
+/// Entries whose name and version spans fall on different lines are also skipped.
 fn parse_section(
     root: &spanned::Object,
     section_name: &str,

--- a/dependi-lsp/src/parsers/php.rs
+++ b/dependi-lsp/src/parsers/php.rs
@@ -63,6 +63,7 @@ impl Parser for PhpParser {
 /// Looks up `section_name` in `root` and appends each entry to `dependencies`.
 ///
 /// Keys equal to `"php"` or starting with `"ext-"` are skipped.
+/// Entries whose version is not a JSON string are skipped.
 /// Entries whose name and version spans fall on different lines are also skipped.
 fn parse_section(
     root: &spanned::Object,

--- a/dependi-lsp/src/parsers/pubspec_lock.rs
+++ b/dependi-lsp/src/parsers/pubspec_lock.rs
@@ -8,14 +8,24 @@ use hashbrown::HashMap;
 use crate::parsers::lockfile_graph::{LockfileGraph, LockfilePackage};
 use crate::parsers::lockfile_resolver::LockfileResolver;
 
-/// Parse a pubspec.lock file and return a map of package name → resolved version.
+/// Parse a `pubspec.lock` file and return a map of package name → resolved version.
 ///
-/// pubspec.lock is a YAML file with a `packages:` top-level section.
+/// `pubspec.lock` is a YAML file with a `packages:` top-level section.
 /// Each package name appears at 2-space indent, ending with `:`.
 /// The version is at 4-space indent: `    version: "X.Y.Z"`.
 /// Quotes around version values are stripped.
 /// Dart package names are case-sensitive — no normalization is applied.
 /// When a package appears multiple times, the first entry is kept.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::pubspec_lock::parse_pubspec_lock;
+///
+/// let lock = "packages:\n  http:\n    source: hosted\n    version: \"1.2.0\"\n";
+/// let map = parse_pubspec_lock(lock);
+/// assert_eq!(map.get("http").map(String::as_str), Some("1.2.0"));
+/// ```
 pub fn parse_pubspec_lock(content: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
     let mut in_packages = false;

--- a/dependi-lsp/src/parsers/python.rs
+++ b/dependi-lsp/src/parsers/python.rs
@@ -1,4 +1,20 @@
-//! Parser for Python dependency files (requirements.txt, constraints.txt, pyproject.toml, hatch.toml)
+//! Parser for Python dependency files.
+//!
+//! Supports four file formats detected heuristically from content:
+//!
+//! | Format | Detection | Key spec |
+//! |--------|-----------|----------|
+//! | `pyproject.toml` | `[project]`, `[tool.poetry]`, `[dependency-groups]`, `[tool.hatch]` headers | PEP 621, Poetry, PEP 735, Hatch |
+//! | `hatch.toml` | `[envs.<name>]` top-level header | Hatch standalone config |
+//! | `requirements.txt` / `constraints.txt` | default | PEP 508 one-package-per-line |
+//!
+//! Detection is content-based (line-anchored section headers) so that packages
+//! whose *extras* resemble section headers (e.g. `mypkg[project]==1.2`) are never
+//! misrouted to the TOML parsers.
+//!
+//! Parsing is performed with `taplo` for TOML formats, giving byte-accurate
+//! [`Span`] values that let LSP quick-fix `TextEdit`s replace only the version
+//! literal inside the surrounding quotes.
 
 use taplo::dom::Node;
 use taplo::dom::node::DomNode;
@@ -7,11 +23,27 @@ use taplo::syntax::SyntaxElement;
 
 use super::{Dependency, Parser, Span};
 
-/// Parser for Python dependency files
+/// Parser for Python dependency files.
+///
+/// Dispatches to one of three sub-parsers based on content detection:
+/// `parse_pyproject_toml`, `parse_hatch_toml`, or `parse_requirements_txt`.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::Parser;
+/// use dependi_lsp::parsers::python::PythonParser;
+/// let parser = PythonParser::new();
+/// let deps = parser.parse("flask==2.0.0\nrequests>=2.25.0\n");
+/// assert_eq!(deps.len(), 2);
+/// assert_eq!(deps[0].name, "flask");
+/// assert_eq!(deps[0].version, "==2.0.0");
+/// ```
 #[derive(Debug, Default)]
 pub struct PythonParser;
 
 impl PythonParser {
+    /// Creates a new [`PythonParser`] instance.
     pub fn new() -> Self {
         Self
     }

--- a/dependi-lsp/src/parsers/python_lock.rs
+++ b/dependi-lsp/src/parsers/python_lock.rs
@@ -84,7 +84,10 @@ fn is_tool_section(line: &str, tool: &str) -> bool {
 /// manifest-derived tool detection to override the static priority list.
 ///
 /// Uses async I/O to avoid blocking the Tokio executor on slow or networked filesystems.
-/// Stops after 10 levels to prevent infinite traversal on unusual file systems.
+///
+/// Walks at most `MAX_DEPTH = 10` directories — the manifest's parent counts as
+/// the first level, so the search inspects the start directory plus up to 9
+/// ancestor directories before giving up.
 pub async fn find_python_lockfile(
     manifest_path: &Path,
     preferred: Option<PythonLockfileType>,

--- a/dependi-lsp/src/parsers/python_lock.rs
+++ b/dependi-lsp/src/parsers/python_lock.rs
@@ -35,11 +35,21 @@ const LOCKFILE_CANDIDATES: &[(&str, PythonLockfileType)] = &[
     ("Pipfile.lock", PythonLockfileType::PipfileLock),
 ];
 
-/// Detect which Python tool manages the project by inspecting pyproject.toml content.
+/// Detect which Python tool manages the project by inspecting `pyproject.toml` content.
 ///
-/// Looks for `[tool.poetry]`, `[tool.uv]`, or `[tool.pdm]` section headers to determine
-/// which lockfile should be preferred. Returns `None` for requirements.txt or when no
-/// tool-specific section is found (falls back to filename-priority discovery).
+/// Looks for `[tool.poetry]`, `[tool.uv]`, or `[tool.pdm]` TOML section headers
+/// to determine which lockfile should be preferred. Returns `None` for
+/// `requirements.txt` or when no tool-specific section is found (in which case
+/// [`find_python_lockfile`] falls back to the static filename-priority list).
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::python_lock::{detect_python_tool, PythonLockfileType};
+/// assert_eq!(detect_python_tool("[tool.poetry]\n"), Some(PythonLockfileType::PoetryLock));
+/// assert_eq!(detect_python_tool("[tool.uv]\n"), Some(PythonLockfileType::UvLock));
+/// assert_eq!(detect_python_tool("[project]\n"), None);
+/// ```
 pub fn detect_python_tool(manifest_content: &str) -> Option<PythonLockfileType> {
     for line in manifest_content.lines() {
         let trimmed = line.trim();
@@ -121,8 +131,19 @@ pub async fn find_python_lockfile(
 
 /// Parse a Python lockfile and return a map of normalized package name → resolved version.
 ///
-/// Package names are normalized per PEP 503 (lowercase, `_`/`.`/`-` → `-`) so that
-/// lookups match regardless of how the manifest or lockfile spells the name.
+/// Package names are normalized per PEP 503 (lowercase, `_`/`.`/`-` → `-`) so
+/// that lookups match regardless of how the manifest or lockfile spells the name.
+/// Dispatches to the appropriate sub-parser based on `lockfile_type`.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::python_lock::{parse_python_lockfile, PythonLockfileType};
+///
+/// let lock = "[[package]]\nname = \"requests\"\nversion = \"2.31.0\"\n";
+/// let map = parse_python_lockfile(lock, PythonLockfileType::PoetryLock);
+/// assert_eq!(map.get("requests").map(String::as_str), Some("2.31.0"));
+/// ```
 pub fn parse_python_lockfile(
     content: &str,
     lockfile_type: PythonLockfileType,
@@ -144,6 +165,15 @@ pub fn parse_python_lockfile(
 /// Normalize a Python package name per PEP 503.
 ///
 /// Lowercases the name and replaces runs of `_`, `.`, and `-` with a single `-`.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::python_lock::normalize_python_name;
+/// assert_eq!(normalize_python_name("typing_extensions"), "typing-extensions");
+/// assert_eq!(normalize_python_name("Jinja2"), "jinja2");
+/// assert_eq!(normalize_python_name("zope.interface"), "zope-interface");
+/// ```
 pub fn normalize_python_name(name: &str) -> String {
     let mut result = String::with_capacity(name.len());
     let mut prev_was_separator = false;
@@ -257,7 +287,20 @@ fn parse_pipfile_lock(content: &str) -> HashMap<String, String> {
 // Graph parsers (lockfile → LockfileGraph)
 // ---------------------------------------------------------------------------
 
-/// Parse poetry.lock into a graph.
+/// Parse `poetry.lock` into a [`LockfileGraph`].
+///
+/// Normalizes package names per PEP 503 and records `dependencies` table keys
+/// as outgoing edges.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::python_lock::parse_poetry_lock_graph;
+///
+/// let lock = "[[package]]\nname = \"requests\"\nversion = \"2.31.0\"\n";
+/// let graph = parse_poetry_lock_graph(lock);
+/// assert!(graph.packages.iter().any(|p| p.name == "requests"));
+/// ```
 pub fn parse_poetry_lock_graph(content: &str) -> LockfileGraph {
     let mut graph = LockfileGraph::default();
     let value: toml::Value = match toml::from_str(content) {
@@ -293,8 +336,21 @@ pub fn parse_poetry_lock_graph(content: &str) -> LockfileGraph {
     graph
 }
 
-/// Parse Pipfile.lock into a graph. Pipfile.lock does NOT record sub-deps natively;
-/// the graph will include all packages but edges are limited to what's explicitly present.
+/// Parse `Pipfile.lock` into a [`LockfileGraph`].
+///
+/// `Pipfile.lock` does not record sub-dependencies natively, so the graph
+/// includes all packages from `default` and `develop` sections but edges are
+/// limited to what is explicitly recorded in the file (usually none).
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::python_lock::parse_pipfile_lock_graph;
+///
+/// let lock = r#"{"default":{"requests":{"version":"==2.31.0"}},"develop":{}}"#;
+/// let graph = parse_pipfile_lock_graph(lock);
+/// assert!(graph.packages.iter().any(|p| p.name == "requests" && p.version == "2.31.0"));
+/// ```
 pub fn parse_pipfile_lock_graph(content: &str) -> LockfileGraph {
     let mut graph = LockfileGraph::default();
     let value: serde_json::Value = match serde_json::from_str(content) {
@@ -331,7 +387,20 @@ pub fn parse_pipfile_lock_graph(content: &str) -> LockfileGraph {
     graph
 }
 
-/// Parse uv.lock into a graph.
+/// Parse `uv.lock` into a [`LockfileGraph`].
+///
+/// uv's `[[package]]` entries record dependencies as an array of
+/// `{ name = "..." }` tables; each `name` becomes an outgoing edge.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::python_lock::parse_uv_lock_graph;
+///
+/// let lock = "version = 1\n[[package]]\nname = \"requests\"\nversion = \"2.31.0\"\n";
+/// let graph = parse_uv_lock_graph(lock);
+/// assert!(graph.packages.iter().any(|p| p.name == "requests"));
+/// ```
 pub fn parse_uv_lock_graph(content: &str) -> LockfileGraph {
     let mut graph = LockfileGraph::default();
     let value: toml::Value = match toml::from_str(content) {

--- a/dependi-lsp/src/parsers/ruby.rs
+++ b/dependi-lsp/src/parsers/ruby.rs
@@ -1,19 +1,36 @@
-//! Parser for Ruby Gemfile files
-//!
-//! Optimized for performance with reduced allocations.
+//! Parser for Ruby `Gemfile` files (Bundler format).
 //!
 //! Supports:
-//! - Gemfile format (Bundler)
-//! - gem declarations with version constraints
-//! - group blocks for development dependencies
+//! - `gem 'name', 'version'` and `gem "name", "version"` declarations.
+//! - Parenthesised form: `gem('name', 'version')`.
+//! - `group :development, :test do … end` blocks — gems inside `dev`/`test`
+//!   groups are emitted with `dev = true`.
+//!
+//! Gems with non-string second arguments (e.g. `git:`, `path:` options) are
+//! silently skipped.  Optimised for reduced allocations with a single byte scan
+//! per token.
 
 use super::{Dependency, Parser, Span};
 
-/// Parser for Ruby Gemfile dependency files
+/// Parser for Ruby `Gemfile` dependency files.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::parsers::Parser;
+/// use dependi_lsp::parsers::ruby::RubyParser;
+/// let parser = RubyParser::new();
+/// let content = "gem 'rails', '~> 7.0'\n";
+/// let deps = parser.parse(content);
+/// assert_eq!(deps.len(), 1);
+/// assert_eq!(deps[0].name, "rails");
+/// assert_eq!(deps[0].version, "~> 7.0");
+/// ```
 #[derive(Debug, Default)]
 pub struct RubyParser;
 
 impl RubyParser {
+    /// Creates a new [`RubyParser`] instance.
     pub fn new() -> Self {
         Self
     }
@@ -74,7 +91,10 @@ impl Parser for RubyParser {
     }
 }
 
-/// Parse a gem declaration from a line
+/// Parses a `gem` declaration line and returns the corresponding [`Dependency`].
+///
+/// Handles both `gem 'name', 'version'` and `gem('name', 'version')` forms.
+/// Returns `None` when the line does not start with `gem` or has no version string.
 fn parse_gem_declaration(line: &str, line_num: u32, dev: bool) -> Option<Dependency> {
     let trimmed = line.trim();
 
@@ -110,7 +130,12 @@ fn parse_gem_declaration(line: &str, line_num: u32, dev: bool) -> Option<Depende
     })
 }
 
-/// Parse gem arguments and return (name, version, positions)
+/// Parses the argument list of a `gem` declaration and returns
+/// `(name, version, name_start, name_end, version_start, version_end)`.
+///
+/// Both single-quoted and double-quoted strings are accepted.
+/// Returns `None` when the second argument is absent, unquoted (e.g. a hash
+/// key), or contains a colon (version-as-symbol form).
 fn parse_gem_args(line: &str, args_str: &str) -> Option<(String, String, u32, u32, u32, u32)> {
     let bytes = args_str.as_bytes();
     let len = bytes.len();
@@ -165,7 +190,10 @@ fn parse_gem_args(line: &str, args_str: &str) -> Option<(String, String, u32, u3
     ))
 }
 
-/// Parse a quoted string starting at index, return (string, end_index)
+/// Parses a single- or double-quoted string from `bytes` starting at `start`.
+///
+/// Returns `(content, index_after_closing_quote)` on success, or `None`
+/// when `bytes[start]` is not a quote character or the string is unterminated.
 fn parse_quoted_string(bytes: &[u8], start: usize) -> Option<(String, usize)> {
     let len = bytes.len();
     let mut idx = start;
@@ -196,7 +224,11 @@ fn parse_quoted_string(bytes: &[u8], start: usize) -> Option<(String, usize)> {
     Some((s.to_string(), idx + 1))
 }
 
-/// Find the position of a quoted string in a line
+/// Finds the byte position of `needle` within its surrounding quotes in `line`.
+///
+/// Tries single-quoted form first (`'needle'`), then double-quoted (`"needle"`),
+/// then falls back to a direct substring search.  Returns `(start, end)` as
+/// 0-indexed byte offsets covering the inner text (no quotes).
 fn find_quoted_position(line: &str, needle: &str) -> Option<(u32, u32)> {
     // Look for the string within single quotes first (more common in Ruby)
     let single_quoted = format!("'{needle}'");

--- a/dependi-lsp/src/parsers/ruby.rs
+++ b/dependi-lsp/src/parsers/ruby.rs
@@ -93,8 +93,14 @@ impl Parser for RubyParser {
 
 /// Parses a `gem` declaration line and returns the corresponding [`Dependency`].
 ///
-/// Handles both `gem 'name', 'version'` and `gem('name', 'version')` forms.
-/// Returns `None` when the line does not start with `gem` or has no version string.
+/// Single-line declarations only: the line must start (after trimming) with
+/// the exact prefix `gem(` or `gem ` (one ASCII space). Variants such as
+/// `gem ('name', ...)` (space before `(`) or `gem\t'name'` (tab after `gem`)
+/// are not recognised. The argument list is then parsed by
+/// [`parse_gem_args`] / [`parse_quoted_string`].
+///
+/// Returns `None` when the line does not match either prefix or has no
+/// version string.
 fn parse_gem_declaration(line: &str, line_num: u32, dev: bool) -> Option<Dependency> {
     let trimmed = line.trim();
 

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -1,4 +1,16 @@
-//! Code actions provider for updating dependencies
+//! Code actions provider for updating dependencies.
+//!
+//! Exposes [`create_code_actions`] which produces LSP [`CodeActionOrCommand`]
+//! items for a cursor range in a dependency manifest.  Three kinds of actions
+//! are possible:
+//!
+//! - **Update to X.Y.Z** — one per outdated, non-ignored, non-property-reference
+//!   dependency whose version span overlaps the requested range.
+//! - **Ignore package** — one per in-range, non-ignored dependency when a
+//!   `workspace_root` is supplied so the ignore entry can be written to
+//!   `.zed/settings.json`.
+//! - **Update all N dependencies** — emitted at the front of the list when at
+//!   least two dependencies in the file are outdated.
 
 use futures::stream::{self, StreamExt};
 use tower_lsp::lsp_types::*;
@@ -8,16 +20,35 @@ use crate::file_types::FileType;
 use crate::parsers::Dependency;
 use crate::providers::inlay_hints::{VersionStatus, compare_versions};
 
-/// Type of semantic version update
+/// Classification of a semantic-version bump.
+///
+/// Used to annotate "Update to X.Y.Z" code-action titles and to decide
+/// whether the action should be marked as preferred by the LSP client
+/// (all categories except [`Major`](VersionUpdateType::Major) are preferred).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VersionUpdateType {
+    /// Breaking change: the major component increased (e.g. `1.x.x` → `2.0.0`).
     Major,
+    /// Non-breaking feature: the minor component increased (e.g. `1.2.x` → `1.3.0`).
     Minor,
+    /// Bug-fix: only the patch component increased (e.g. `1.2.3` → `1.2.4`).
     Patch,
+    /// Pre-release version (e.g. `1.0.0-alpha.1`).
     PreRelease,
 }
 
 impl VersionUpdateType {
+    /// Returns a short human-readable prefix used in the code-action title.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dependi_lsp::providers::code_actions::VersionUpdateType;
+    /// assert_eq!(VersionUpdateType::Major.prefix(), "⚠ MAJOR");
+    /// assert_eq!(VersionUpdateType::Minor.prefix(), "+ minor");
+    /// assert_eq!(VersionUpdateType::Patch.prefix(), "· patch");
+    /// assert_eq!(VersionUpdateType::PreRelease.prefix(), "* prerelease");
+    /// ```
     pub fn prefix(&self) -> &'static str {
         match self {
             VersionUpdateType::Major => "⚠ MAJOR",
@@ -27,12 +58,42 @@ impl VersionUpdateType {
         }
     }
 
+    /// Returns `true` when the LSP client should mark this action as preferred.
+    ///
+    /// All categories are preferred except [`Major`](VersionUpdateType::Major)
+    /// because a major bump may be breaking.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dependi_lsp::providers::code_actions::VersionUpdateType;
+    /// assert!(!VersionUpdateType::Major.is_preferred());
+    /// assert!(VersionUpdateType::Minor.is_preferred());
+    /// assert!(VersionUpdateType::Patch.is_preferred());
+    /// assert!(VersionUpdateType::PreRelease.is_preferred());
+    /// ```
     pub fn is_preferred(&self) -> bool {
         !matches!(self, VersionUpdateType::Major)
     }
 }
 
-/// Determine the type of version update between current and new version
+/// Classify the version bump from `current` to `new` as a [`VersionUpdateType`].
+///
+/// Both strings are normalized (leading operators such as `^`, `~=`, `>=` are
+/// stripped) before parsing with [`semver`].  If either string cannot be
+/// parsed after normalization, the function falls back to [`Patch`](VersionUpdateType::Patch).
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::providers::code_actions::{compare_update_type, VersionUpdateType};
+/// assert_eq!(compare_update_type("1.0.0", "2.0.0"), VersionUpdateType::Major);
+/// assert_eq!(compare_update_type("1.5.0", "1.6.0"), VersionUpdateType::Minor);
+/// assert_eq!(compare_update_type("1.5.0", "1.5.1"), VersionUpdateType::Patch);
+/// assert_eq!(compare_update_type("1.5.0", "1.5.1-alpha.1"), VersionUpdateType::PreRelease);
+/// // Version-range operators are stripped before comparison.
+/// assert_eq!(compare_update_type("^1.0.0", "2.0.0"), VersionUpdateType::Major);
+/// ```
 pub fn compare_update_type(current: &str, new: &str) -> VersionUpdateType {
     let current_normalized = normalize_version(current);
     let new_normalized = normalize_version(new);
@@ -88,7 +149,30 @@ fn normalize_version(version: &str) -> String {
     }
 }
 
-/// Create code actions for dependencies in the given range
+/// Build LSP code actions for dependency declarations that fall within `range`.
+///
+/// The function reads from `cache` using keys produced by `cache_key_fn` and
+/// compares each dependency's version against the latest available.
+///
+/// # Parameters
+///
+/// - `dependencies` — all dependencies parsed from the manifest (not filtered to `range`).
+/// - `cache` — read-only cache handle used to look up latest-version info.
+/// - `uri` — document URI inserted into [`WorkspaceEdit`] text-edit maps.
+/// - `range` — LSP selection range; only dependencies whose `version_span` line
+///   falls within this range receive individual Update/Ignore actions.
+/// - `file_type` — governs version-string formatting (e.g. Go prepends `v`).
+/// - `cache_key_fn` — maps a package name to its cache key.
+/// - `ignored` — packages matching any entry (wildcards supported) are skipped.
+/// - `workspace_root` — when `Some`, enables the "Ignore package" action which
+///   writes to `.zed/settings.json`.
+/// - `current_settings` — existing `.zed/settings.json` contents, used by
+///   [`crate::settings_edit::build_ignore_workspace_edit`] to produce a minimal diff.
+///
+/// # Returns
+///
+/// A [`Vec`] of [`CodeActionOrCommand`].  The "Update all" action, when
+/// present, is always first; individual actions follow in dependency order.
 #[expect(
     clippy::too_many_arguments,
     reason = "LSP context requires passing doc state, cache, range, ignore list, and workspace metadata together; refactoring into a struct is tracked for a follow-up."

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -443,7 +443,9 @@ async fn create_update_all_action(
 fn format_version(version: &str, file_type: FileType) -> String {
     match file_type {
         FileType::Cargo | FileType::Npm | FileType::Php => {
-            // Keep the version as-is - the range already includes the quotes in these formats
+            // Keep the version as-is. version_span covers the inner token text
+            // only (no surrounding quotes), so callers replace just the version
+            // literal and the existing quote pair is preserved.
             version.to_string()
         }
         FileType::Python => {

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -1,8 +1,9 @@
 //! Code actions provider for updating dependencies.
 //!
-//! Exposes [`create_code_actions`] which produces LSP [`CodeActionOrCommand`]
-//! items for a cursor range in a dependency manifest.  Three kinds of actions
-//! are possible:
+//! Exposes [`crate::providers::code_actions::create_code_actions`] which
+//! produces LSP [`tower_lsp::lsp_types::CodeActionOrCommand`] items for a
+//! cursor range in a dependency manifest.  Three kinds of actions are
+//! possible:
 //!
 //! - **Update to X.Y.Z** — one per outdated, non-ignored, non-property-reference
 //!   dependency whose version span overlaps the requested range.

--- a/dependi-lsp/src/providers/completion.rs
+++ b/dependi-lsp/src/providers/completion.rs
@@ -1,4 +1,10 @@
-//! Completion provider for version suggestions
+//! Completion provider for dependency version suggestions.
+//!
+//! When the cursor is positioned inside a version field, [`get_completions`]
+//! returns up to ten recent versions as [`CompletionItem`] entries, ordered
+//! newest-first.  Each item includes the version string, an optional release
+//! age computed by [`fmt_release_age`], and a Markdown documentation block
+//! that marks the latest stable version.
 
 use core::fmt::{self, Write};
 
@@ -71,7 +77,24 @@ pub fn fmt_release_age(released_at: DateTime<Utc>) -> impl fmt::Display + fmt::D
     })
 }
 
-/// Get completions for a position in the document
+/// Return version completions for the dependency whose `version_span` contains `position`.
+///
+/// Looks up the dependency name in `cache` using a key produced by
+/// `cache_key_fn`, then maps the most-recent versions (up to ten) to
+/// [`CompletionItem`] values.  Returns `None` when the cursor is not inside a
+/// version field or when no cached version data is available.
+///
+/// # Parameters
+///
+/// - `dependencies` — all parsed dependencies for the current document.
+/// - `position` — cursor position sent by the LSP client.
+/// - `cache` — read-only cache handle.
+/// - `cache_key_fn` — maps a package name to its cache lookup key.
+///
+/// # Returns
+///
+/// `Some(items)` with items ordered newest-first, or `None` when completion
+/// is not applicable at the given position.
 pub async fn get_completions(
     dependencies: &[Dependency],
     position: Position,

--- a/dependi-lsp/src/providers/completion.rs
+++ b/dependi-lsp/src/providers/completion.rs
@@ -1,10 +1,11 @@
 //! Completion provider for dependency version suggestions.
 //!
-//! When the cursor is positioned inside a version field, [`get_completions`]
-//! returns up to ten recent versions as [`CompletionItem`] entries, ordered
+//! When the cursor is positioned inside a version field,
+//! [`crate::providers::completion::get_completions`] returns up to ten recent
+//! versions as [`tower_lsp::lsp_types::CompletionItem`] entries, ordered
 //! newest-first.  Each item includes the version string, an optional release
-//! age computed by [`fmt_release_age`], and a Markdown documentation block
-//! that marks the latest stable version.
+//! age computed by [`crate::providers::completion::fmt_release_age`], and a
+//! Markdown documentation block that marks the latest stable version.
 
 use core::fmt::{self, Write};
 

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -1,8 +1,10 @@
 //! Diagnostic provider for dependency manifests.
 //!
-//! [`create_diagnostics`] is the main entry point.  It iterates over a parsed
-//! dependency list and, for each non-ignored entry, emits at most one LSP
-//! [`Diagnostic`] chosen by the following priority order:
+//! [`crate::providers::diagnostics::create_diagnostics`] is the main entry
+//! point.  It iterates over a parsed dependency list and, for each
+//! non-ignored entry, emits at most one LSP
+//! [`tower_lsp::lsp_types::Diagnostic`] chosen by the following priority
+//! order:
 //!
 //! 1. **Local/path dependency** — informational `→ Local` hint.
 //! 2. **Yanked version** — warning with a link to the registry page.
@@ -10,8 +12,9 @@
 //! 4. **Vulnerability summary** — error/warning/hint depending on max severity.
 //! 5. **Outdated version** — hint `Update available: X → Y`.
 //!
-//! Helper functions [`build_transitive_summary_message`] is public so the
-//! vulnerability report generator can reuse the formatting logic.
+//! Helper function
+//! [`crate::providers::diagnostics::build_transitive_summary_message`] is
+//! public so the vulnerability report generator can reuse the formatting logic.
 
 use core::fmt;
 

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -1,4 +1,17 @@
-//! Diagnostics provider for outdated dependencies and vulnerabilities
+//! Diagnostic provider for dependency manifests.
+//!
+//! [`create_diagnostics`] is the main entry point.  It iterates over a parsed
+//! dependency list and, for each non-ignored entry, emits at most one LSP
+//! [`Diagnostic`] chosen by the following priority order:
+//!
+//! 1. **Local/path dependency** — informational `→ Local` hint.
+//! 2. **Yanked version** — warning with a link to the registry page.
+//! 3. **Deprecated package** — warning with optional homepage / repository links.
+//! 4. **Vulnerability summary** — error/warning/hint depending on max severity.
+//! 5. **Outdated version** — hint `Update available: X → Y`.
+//!
+//! Helper functions [`build_transitive_summary_message`] is public so the
+//! vulnerability report generator can reuse the formatting logic.
 
 use core::fmt;
 
@@ -11,10 +24,29 @@ use crate::providers::inlay_hints::{VersionStatus, compare_versions, is_local_de
 use crate::registries::{TransitiveVuln, VersionInfo, Vulnerability, VulnerabilitySeverity};
 use crate::utils::fmt_truncate_string;
 
-/// Create diagnostics for a list of dependencies
+/// Build LSP diagnostics for the given dependency list.
 ///
-/// The `min_severity` parameter filters vulnerabilities to only show those
-/// at or above the specified severity level.
+/// For each non-ignored dependency the function performs a single cache lookup
+/// and produces at most one [`Diagnostic`] following the priority order
+/// documented in the [module level docs](self).
+///
+/// # Parameters
+///
+/// - `dependencies` — all dependencies parsed from the current manifest.
+/// - `cache` — read-only cache handle used to look up version metadata.
+/// - `cache_key_fn` — maps a package name to its cache key.
+/// - `min_severity` — when `Some`, vulnerability diagnostics are suppressed
+///   unless at least one vulnerability meets the threshold.
+/// - `file_type` — used to format registry names in yanked-version messages.
+/// - `doc_transitive_vulns` — per-document transitive vulnerability data keyed
+///   by direct-dependency name.  Stored separately from the shared version cache
+///   to avoid cross-workspace contamination.
+/// - `ignored` — package names (wildcards supported) that should be skipped.
+///
+/// # Returns
+///
+/// A [`Vec<Diagnostic>`] in the same order as `dependencies`, with at most
+/// one entry per dependency.
 pub async fn create_diagnostics(
     dependencies: &[Dependency],
     cache: &impl ReadCache,
@@ -348,8 +380,33 @@ fn create_yanked_diagnostic(
     }
 }
 
-/// Build a short message listing transitive vulnerabilities for a direct dep.
-/// Shows up to 3 entries, then "+N more".
+/// Format a short summary of transitive vulnerabilities for display in a diagnostic message.
+///
+/// Lists up to three entries as `pkg@ver (ID)` and appends `+N more` when
+/// there are additional entries.  Returns an empty string when `tv` is empty.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::providers::diagnostics::build_transitive_summary_message;
+/// use dependi_lsp::registries::{TransitiveVuln, Vulnerability, VulnerabilitySeverity};
+///
+/// let tv = vec![TransitiveVuln {
+///     package_name: "scheduler".to_string(),
+///     package_version: "1.2.3".to_string(),
+///     vulnerability: Vulnerability {
+///         id: "CVE-1".to_string(),
+///         severity: VulnerabilitySeverity::High,
+///         description: "desc".to_string(),
+///         url: None,
+///     },
+/// }];
+/// let refs: Vec<&_> = tv.iter().collect();
+/// let msg = build_transitive_summary_message(&refs);
+/// assert!(msg.contains("scheduler@1.2.3"));
+/// assert!(msg.contains("CVE-1"));
+/// assert!(msg.contains("1 transitive"));
+/// ```
 pub fn build_transitive_summary_message(tv: &[&TransitiveVuln]) -> String {
     if tv.is_empty() {
         return String::new();

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -1,18 +1,18 @@
 //! Diagnostic provider for dependency manifests.
 //!
 //! [`crate::providers::diagnostics::create_diagnostics`] is the main entry
-//! point. For each non-ignored dependency it consults the version cache once
-//! and may push one or two LSP
-//! [`tower_lsp::lsp_types::Diagnostic`] entries: an optional **outdated**
-//! hint (`Update available: X → Y`) plus, when applicable, exactly one of the
-//! higher-severity diagnostics below — picked in this priority order:
+//! point. For each non-ignored dependency it pushes LSP
+//! [`tower_lsp::lsp_types::Diagnostic`] entries chosen as follows:
 //!
-//! 1. **Yanked version** — warning with a link to the registry page.
-//! 2. **Deprecated package** — warning with optional homepage / repository links.
-//! 3. **Vulnerability summary** — error/warning/hint depending on max severity.
+//! - **Local / path dependency** — a single informational `→ Local` hint;
+//!   no further diagnostics are emitted for the entry.
+//! - **Registry dependency** — an optional **outdated** hint
+//!   (`Update available: X → Y`) plus, when applicable, exactly one of the
+//!   higher-severity diagnostics below, picked in this priority order:
 //!
-//! Local / path dependencies short-circuit the whole pipeline and contribute
-//! no diagnostic (only an inlay hint, handled elsewhere).
+//!   1. **Yanked version** — warning with a link to the registry page.
+//!   2. **Deprecated package** — warning with optional homepage / repository links.
+//!   3. **Vulnerability summary** — error/warning/hint depending on max severity.
 //!
 //! Helper function
 //! [`crate::providers::diagnostics::build_transitive_summary_message`] is

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -1,16 +1,18 @@
 //! Diagnostic provider for dependency manifests.
 //!
 //! [`crate::providers::diagnostics::create_diagnostics`] is the main entry
-//! point.  It iterates over a parsed dependency list and, for each
-//! non-ignored entry, emits at most one LSP
-//! [`tower_lsp::lsp_types::Diagnostic`] chosen by the following priority
-//! order:
+//! point. For each non-ignored dependency it consults the version cache once
+//! and may push one or two LSP
+//! [`tower_lsp::lsp_types::Diagnostic`] entries: an optional **outdated**
+//! hint (`Update available: X → Y`) plus, when applicable, exactly one of the
+//! higher-severity diagnostics below — picked in this priority order:
 //!
-//! 1. **Local/path dependency** — informational `→ Local` hint.
-//! 2. **Yanked version** — warning with a link to the registry page.
-//! 3. **Deprecated package** — warning with optional homepage / repository links.
-//! 4. **Vulnerability summary** — error/warning/hint depending on max severity.
-//! 5. **Outdated version** — hint `Update available: X → Y`.
+//! 1. **Yanked version** — warning with a link to the registry page.
+//! 2. **Deprecated package** — warning with optional homepage / repository links.
+//! 3. **Vulnerability summary** — error/warning/hint depending on max severity.
+//!
+//! Local / path dependencies short-circuit the whole pipeline and contribute
+//! no diagnostic (only an inlay hint, handled elsewhere).
 //!
 //! Helper function
 //! [`crate::providers::diagnostics::build_transitive_summary_message`] is
@@ -30,8 +32,9 @@ use crate::utils::fmt_truncate_string;
 /// Build LSP diagnostics for the given dependency list.
 ///
 /// For each non-ignored dependency the function performs a single cache lookup
-/// and produces at most one [`Diagnostic`] following the priority order
-/// documented in the [module level docs](self).
+/// and may emit an outdated-version hint plus, when applicable, one
+/// higher-severity diagnostic (yanked, deprecated, or vulnerability summary)
+/// following the priority order documented in the [module level docs](self).
 ///
 /// # Parameters
 ///

--- a/dependi-lsp/src/providers/document_links.rs
+++ b/dependi-lsp/src/providers/document_links.rs
@@ -1,8 +1,9 @@
 //! Document link provider — returns clickable links on dependency names.
 //!
-//! [`create_document_links`] maps each parsed [`Dependency`] to an LSP
-//! [`DocumentLink`] whose target URL points to the package page on the
-//! appropriate registry (crates.io, npm, PyPI, etc.).
+//! [`crate::providers::document_links::create_document_links`] maps each
+//! parsed [`crate::parsers::Dependency`] to an LSP
+//! [`tower_lsp::lsp_types::DocumentLink`] whose target URL points to the
+//! package page on the appropriate registry (crates.io, npm, PyPI, etc.).
 //! Dependencies from alternative/private registries are skipped because their
 //! registry URL is not reliably known.
 

--- a/dependi-lsp/src/providers/document_links.rs
+++ b/dependi-lsp/src/providers/document_links.rs
@@ -1,14 +1,29 @@
 //! Document link provider — returns clickable links on dependency names.
+//!
+//! [`create_document_links`] maps each parsed [`Dependency`] to an LSP
+//! [`DocumentLink`] whose target URL points to the package page on the
+//! appropriate registry (crates.io, npm, PyPI, etc.).
+//! Dependencies from alternative/private registries are skipped because their
+//! registry URL is not reliably known.
 
 use tower_lsp::lsp_types::{DocumentLink, Position, Range, Url};
 
 use crate::file_types::FileType;
 use crate::parsers::Dependency;
 
-/// Build a list of LSP document links for the given dependencies.
+/// Build LSP document links for the given dependencies.
 ///
-/// Each link covers the span of the package name in the source file and
-/// points to the corresponding registry page.
+/// Each link covers the name-span of the package declaration and points to
+/// the corresponding registry page determined by `file_type`.  Dependencies
+/// that carry a `registry` field (alternative/private registries) are skipped
+/// because their registry URL is not known.
+///
+/// A tooltip of the form `"Open <name> on <registry>"` is attached to each link.
+///
+/// # Returns
+///
+/// A [`Vec<DocumentLink>`] with one entry per eligible dependency.  May be
+/// empty when `deps` is empty or all entries belong to alternative registries.
 pub fn create_document_links(deps: &[Dependency], file_type: &FileType) -> Vec<DocumentLink> {
     deps.iter()
         .filter_map(|dep| {

--- a/dependi-lsp/src/providers/inlay_hints.rs
+++ b/dependi-lsp/src/providers/inlay_hints.rs
@@ -1,8 +1,9 @@
 //! Inlay hint provider — displays version status inline next to dependency declarations.
 //!
-//! The central function [`create_inlay_hint`] constructs an [`InlayHint`] for
-//! one dependency using metadata from the version cache.  Status labels follow
-//! a strict priority order:
+//! The central function [`crate::providers::inlay_hints::create_inlay_hint`]
+//! constructs an [`tower_lsp::lsp_types::InlayHint`] for one dependency using
+//! metadata from the version cache.  Status labels follow a strict priority
+//! order:
 //!
 //! 1. **Local/path dependency** — `→ Local` (no registry lookup performed).
 //! 2. **Yanked version** — `⊘ Yanked [→ latest]`.
@@ -12,8 +13,11 @@
 //! 6. **Update available** — `→ X.Y.Z`.
 //! 7. **Unknown** — `? Unknown` (registry unreachable, package not found, etc.).
 //!
-//! Pure helper functions [`is_local_dependency`], [`compare_versions`], and
-//! [`normalize_version`] are public so other providers and tests can reuse them.
+//! Pure helper functions
+//! [`crate::providers::inlay_hints::is_local_dependency`],
+//! [`crate::providers::inlay_hints::compare_versions`], and
+//! [`crate::providers::inlay_hints::normalize_version`] are public so other
+//! providers and tests can reuse them.
 
 use core::fmt::{self, Write};
 

--- a/dependi-lsp/src/providers/inlay_hints.rs
+++ b/dependi-lsp/src/providers/inlay_hints.rs
@@ -1,4 +1,19 @@
-//! Inlay hints provider for dependency versions
+//! Inlay hint provider — displays version status inline next to dependency declarations.
+//!
+//! The central function [`create_inlay_hint`] constructs an [`InlayHint`] for
+//! one dependency using metadata from the version cache.  Status labels follow
+//! a strict priority order:
+//!
+//! 1. **Local/path dependency** — `→ Local` (no registry lookup performed).
+//! 2. **Yanked version** — `⊘ Yanked [→ latest]`.
+//! 3. **Deprecated package** — `⚠ Deprecated [→ latest]`.
+//! 4. **Vulnerabilities** — `⚠ N vuln(s) [→ latest]`.
+//! 5. **Up to date** — `✓`.
+//! 6. **Update available** — `→ X.Y.Z`.
+//! 7. **Unknown** — `? Unknown` (registry unreachable, package not found, etc.).
+//!
+//! Pure helper functions [`is_local_dependency`], [`compare_versions`], and
+//! [`normalize_version`] are public so other providers and tests can reuse them.
 
 use core::fmt::{self, Write};
 
@@ -9,18 +24,54 @@ use crate::registries::{VersionInfo, VulnerabilitySeverity};
 use crate::utils::fmt_truncate_string;
 use crate::{parsers::Dependency, registries::Vulnerability};
 
-/// Result of comparing a dependency version with the latest available
+/// Outcome of comparing a dependency's declared version against the latest available.
+///
+/// Produced by [`compare_versions`] and consumed by [`create_inlay_hint`] as
+/// well as the diagnostics and code-actions providers.
 #[derive(Debug, Clone)]
 pub enum VersionStatus {
-    /// Version is up to date
+    /// The declared version is at least as recent as the latest known version.
     UpToDate,
-    /// Update available to the given version
+    /// A newer version is available; the inner `String` is the latest version string.
     UpdateAvailable(String),
-    /// Could not determine version status
+    /// Version status could not be determined (e.g. no cache entry, no `latest` field).
     Unknown,
 }
 
-/// Generate an inlay hint for a dependency
+/// Build an [`InlayHint`] for a single dependency.
+///
+/// The hint is positioned immediately after the version span and displays a
+/// label chosen by the priority rules documented in the [module level
+/// docs](self).  A tooltip string is attached when additional context is
+/// available (vulnerability details, deprecation reasons, etc.).
+///
+/// # Parameters
+///
+/// - `dep` — parsed dependency; its `version_span` determines hint placement.
+/// - `version_info` — cached registry metadata, or `None` when unavailable.
+/// - `file_type` — used to format registry URLs inside tooltips.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::providers::inlay_hints::create_inlay_hint;
+/// use dependi_lsp::file_types::FileType;
+/// use dependi_lsp::registries::VersionInfo;
+/// use dependi_lsp::parsers::{Dependency, Span};
+/// use tower_lsp::lsp_types::InlayHintLabel;
+///
+/// let dep = Dependency {
+///     name: "serde".to_string(),
+///     version: "1.0.0".to_string(),
+///     name_span: Span { line: 5, line_start: 0, line_end: 5 },
+///     version_span: Span { line: 5, line_start: 9, line_end: 14 },
+///     dev: false, optional: false, registry: None, resolved_version: None,
+/// };
+/// let info = VersionInfo { latest: Some("1.0.0".to_string()), ..Default::default() };
+/// let hint = create_inlay_hint(&dep, Some(&info), FileType::Cargo);
+/// assert_eq!(hint.position.line, 5);
+/// assert!(matches!(hint.label, InlayHintLabel::String(ref s) if s.contains("✓")));
+/// ```
 pub fn create_inlay_hint(
     dep: &Dependency,
     version_info: Option<&VersionInfo>,
@@ -342,7 +393,26 @@ fn fmt_yanked_tooltip(
     })
 }
 
-/// Check if a dependency version string indicates a local/path dependency
+/// Returns `true` when `version` refers to a local path, git repository, or
+/// URL source rather than a plain registry version string.
+///
+/// The following prefixes are recognised as local/non-registry sources:
+/// `./`, `../`, `/`, `file:`, `git+`, `git@`, `git:`, `https://`, `http://`,
+/// `github:`, `gitlab:`, `bitbucket:`, `workspace:`, `link:`, `portal:`, `npm:`.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::providers::inlay_hints::is_local_dependency;
+/// assert!(is_local_dependency("git+https://example.com/foo.git"));
+/// assert!(is_local_dependency("./my-lib"));
+/// assert!(is_local_dependency("../shared"));
+/// assert!(is_local_dependency("workspace:*"));
+/// assert!(is_local_dependency("file:./local-pkg"));
+/// assert!(!is_local_dependency("1.2.3"));
+/// assert!(!is_local_dependency("^1.0.0"));
+/// assert!(!is_local_dependency("latest"));
+/// ```
 pub fn is_local_dependency(version: &str) -> bool {
     // Path-based dependencies
     version.starts_with("./")
@@ -399,7 +469,41 @@ fn strip_python_prerelease(version: &str) -> String {
         .join(".")
 }
 
-/// Compare a dependency version with the latest available
+/// Compare a dependency's declared version against the latest version in `info`.
+///
+/// The comparison handles several version-string formats:
+///
+/// - **Standard semver** — `^`, `~`, `>=`, `<=`, `>`, `<`, `=`, `v` prefixes
+///   are stripped before parsing.
+/// - **Python compatible-release operator** (`~=X.Y`) — compared at the same
+///   granularity as the base specifier (see PEP 440).
+/// - **PEP 440 pre-release suffixes** (`a`, `b`, `rc`, `alpha`, `beta`, `dev`)
+///   — stripped for the semver parse attempt so that e.g. `4.0.0a6` compared
+///   against stable `3.11.2` correctly returns [`VersionStatus::UpToDate`]
+///   rather than suggesting a downgrade.
+/// - **Calendar versions** — four-segment versions like `2024.1.1.5` are not
+///   truncated when they do not contain pre-release markers.
+///
+/// Returns [`VersionStatus::Unknown`] when `info.latest` is `None`.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::providers::inlay_hints::{compare_versions, VersionStatus};
+/// use dependi_lsp::registries::VersionInfo;
+///
+/// let up_to_date = VersionInfo { latest: Some("1.0.0".to_string()), ..Default::default() };
+/// assert!(matches!(compare_versions("1.0.0", &up_to_date), VersionStatus::UpToDate));
+///
+/// let outdated = VersionInfo { latest: Some("2.0.0".to_string()), ..Default::default() };
+/// assert!(matches!(
+///     compare_versions("^1.0.0", &outdated),
+///     VersionStatus::UpdateAvailable(ref v) if v == "2.0.0"
+/// ));
+///
+/// let no_latest = VersionInfo { latest: None, ..Default::default() };
+/// assert!(matches!(compare_versions("1.0.0", &no_latest), VersionStatus::Unknown));
+/// ```
 pub fn compare_versions(current: &str, info: &VersionInfo) -> VersionStatus {
     let Some(latest) = info.latest.as_deref() else {
         return VersionStatus::Unknown;
@@ -523,8 +627,27 @@ fn truncate_version(version: &str, segments: usize) -> String {
     }
 }
 
-/// Normalize a version string for comparison
-/// Handles version specifiers like ^, ~, >=, ~=, ==, etc.
+/// Normalize a version string into a three-component `MAJOR.MINOR.PATCH` form.
+///
+/// Leading range operators (`^`, `~`, `>=`, `<=`, `>`, `<`, `=`, `~=`, `~>`,
+/// `==`, `!=`, `===`) are stripped.  When the string contains a
+/// comma-separated range (e.g. `>=1.0, <2.0`), only the first component is
+/// kept.  One- and two-component versions are padded with `.0` segments.
+///
+/// Note: the bare `v` prefix is **not** stripped by this function; use
+/// `format_version` in the code-actions provider when writing back to the
+/// manifest.
+///
+/// # Examples
+///
+/// ```
+/// use dependi_lsp::providers::inlay_hints::normalize_version;
+/// assert_eq!(normalize_version("1.0.0"),       "1.0.0");
+/// assert_eq!(normalize_version("^1.0"),        "1.0.0");
+/// assert_eq!(normalize_version("~=14.3"),      "14.3.0");
+/// assert_eq!(normalize_version(">=1.0, <2.0"), "1.0.0");
+/// assert_eq!(normalize_version("3"),           "3.0.0");
+/// ```
 pub fn normalize_version(version: &str) -> String {
     let version = version.trim();
 

--- a/dependi-lsp/src/providers/mod.rs
+++ b/dependi-lsp/src/providers/mod.rs
@@ -1,7 +1,20 @@
-//! LSP feature providers (inlay hints, diagnostics, hover, etc.)
+//! LSP feature providers (inlay hints, diagnostics, code actions, completions, and document links).
+//!
+//! Each sub-module handles one LSP capability.  The backend wires them together
+//! by forwarding parsed [`crate::parsers::Dependency`] slices and cache handles
+//! to the appropriate provider function.
 
+/// Code action provider (quick-fix: upgrade to latest, ignore package, etc.).
 pub mod code_actions;
+
+/// Completion provider for dependency names and versions.
 pub mod completion;
+
+/// Diagnostic provider (outdated dependencies, vulnerabilities, deprecated packages).
 pub mod diagnostics;
+
+/// Document link provider (clickable links to registry pages).
 pub mod document_links;
+
+/// Inlay hint provider (latest version shown next to the declared version).
 pub mod inlay_hints;


### PR DESCRIPTION
## Summary

Implements [#231](https://github.com/mpiton/zed-dependi/issues/231): adds comprehensive Rustdoc coverage to `dependi-lsp` core modules.

- Module-level `//!` headers on every file in scope.
- Item-level `///` on every public function, struct, enum, trait, and re-export.
- 43 doctests on pure functions across manifest parsers, lockfile parsers, and provider helpers.
- Pre-existing in-scope rustdoc errors fixed: empty code block in `backend.rs`, broken intra-doc link in `parsers/lockfile_resolver.rs`.
- Zero unresolved-link warnings emitted by `cargo doc --no-deps` for in-scope files.

## Scope

**In:** `dependi-lsp/src/{lib.rs, backend.rs, parsers/, providers/}`.

**Out:** `auth/`, `cache/`, `config.rs`, `registries/`, `vulnerabilities/`, `reports.rs`, `utils.rs`, `settings_edit.rs`, `document.rs`, `file_types.rs`. Pre-existing doc warnings in `cache/advisory/` and `registries/npm.rs` are unchanged and tracked separately.

## Approach

- TDD: doctests added alongside docs assert behavior on pure functions; prose-only `# Examples` for tower-lsp glue requiring runtime setup.
- Parallel implementation: 4 disjoint file groups documented concurrently via isolated worktrees, then cherry-picked onto this branch.
- Three-agent review wave (rust idioms, doc coverage, general quality) all clear.

## Trade-off

The fix-up commit `0af38d5` removes outer `///` lines on `pub mod auth;` and `pub mod registries;` in `lib.rs` because rustdoc concatenates outer `///` with inner `//!` from those out-of-scope modules, surfacing latent broken links there. Module descriptions are preserved in the lib.rs `//!` "Module map". A follow-up PR can fix the inner `//!` of `auth/mod.rs` and `registries/mod.rs` and restore the outer lines.

## Test plan

- [x] `cargo build --release -p dependi-lsp`
- [x] `cargo test --lib -p dependi-lsp` — 781 passed, 0 failed
- [x] `cargo test --doc -p dependi-lsp` — 43 passed, 20 ignored
- [x] `cargo doc --no-deps` — 0 in-scope warnings (29 module headers, 78 documented public items)
- [x] `cargo clippy --all-targets -- -D warnings` — no issues
- [x] `cargo fmt --all -- --check` — clean

Closes #231

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full Rustdoc coverage to `dependi-lsp`, adds a crate-level module map, and clarifies provider/backend behavior, leaving docs warning‑free. Implements #231.

- **Documentation**
  - Module `//!` headers and `///` docs across `lib.rs` (module map), `backend.rs` (concurrency and error model), all `parsers/`, and `providers/` (capabilities, re-exports, and diagnostic priority including the local/path hint).
  - 43 doctests on pure functions; small runnable examples added to parsers and lockfile resolvers; prose-only examples for LSP/tower glue.
  - Fixed intra‑doc links across lib/backend/parsers/providers; clarified edge cases (byte vs UTF‑16 spans, `go.sum` hash lines, npm lockfile dispatch, diagnostics: local/path hint and emit at most two per dep).
  - CHANGELOG updated; `cargo doc --no-deps` now reports zero unresolved links.

<sup>Written for commit c73222e849fbe94180051925827f47638c370aa5. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/zed-dependi/pull/273?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Rustdoc across the crate with module/item-level docs, concrete examples and doctests, clarifying parser/lockfile/provider behaviors, edge cases, and runtime semantics.
* **New Features**
  * Added documented public provider surfaces for code actions, completions, diagnostics, document links, and inlay hints (documentation-only additions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->