### PR TITLE
chore(docs): enforce rustdoc quality via lints + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
           cd dependi-lsp
           cargo test
 
+      - name: Check rustdoc
+        run: |
+          cd dependi-lsp
+          cargo doc --no-deps
+
   security-audit:
     runs-on: ubuntu-latest
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Enforce rustdoc quality via `[lints.rustdoc]` in `dependi-lsp/Cargo.toml`
+  (`broken_intra_doc_links`, `invalid_codeblock_attributes`,
+  `invalid_html_tags`, `invalid_rust_codeblocks`, `bare_urls` set to `deny`)
+  and a `cargo doc --no-deps` step in the CI workflow. Fixes 5 pre-existing
+  rustdoc warnings (`AdvisoryCacheConfig` intra-doc links in
+  `cache/advisory/`, bare URL in `registries/npm.rs`, empty Rust code block
+  in `bin/test_dates.rs`).
 - Add comprehensive Rustdoc comments to `dependi-lsp` core modules
   (`lib.rs`, `backend.rs`, `parsers/`, `providers/`): every public item
   now has `///` docs covering summary, parameters, return value, errors,

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -56,3 +56,11 @@ uninlined_format_args = "warn"
 unnecessary_debug_formatting = "warn"
 disallowed_types = "warn"
 disallowed_methods = "warn"
+
+[lints.rustdoc]
+broken_intra_doc_links = "deny"
+private_intra_doc_links = "warn"
+invalid_codeblock_attributes = "deny"
+invalid_html_tags = "deny"
+invalid_rust_codeblocks = "deny"
+bare_urls = "deny"

--- a/dependi-lsp/src/bin/test_dates.rs
+++ b/dependi-lsp/src/bin/test_dates.rs
@@ -12,9 +12,9 @@ use dependi_lsp::registries::{
 ///
 /// # Examples
 ///
-/// ```no_run
-/// // Run the compiled binary to see registry outputs:
-/// // cargo run --bin registry_test
+/// ```text
+/// # Run the compiled binary to see registry outputs:
+/// cargo run --bin registry_test
 /// ```
 #[tokio::main]
 async fn main() {

--- a/dependi-lsp/src/cache/advisory/mod.rs
+++ b/dependi-lsp/src/cache/advisory/mod.rs
@@ -154,7 +154,7 @@ impl HybridAdvisoryCache {
         Self { memory, sqlite }
     }
 
-    /// Build a hybrid cache from an [`AdvisoryCacheConfig`] (issue #237).
+    /// Build a hybrid cache from an [`crate::config::AdvisoryCacheConfig`] (issue #237).
     ///
     /// When `config.enabled` is `false`, returns a hybrid whose memory layer
     /// has a zero-second TTL and no SQLite backing. Every read therefore
@@ -189,7 +189,7 @@ impl HybridAdvisoryCache {
         Self::from_parts(memory, sqlite)
     }
 
-    /// Build a *negative* advisory cache from an [`AdvisoryCacheConfig`].
+    /// Build a *negative* advisory cache from an [`crate::config::AdvisoryCacheConfig`].
     ///
     /// 404 OSV responses live on a different freshness schedule than real
     /// `Found` entries: a missing advisory might just mean OSV has not yet

--- a/dependi-lsp/src/cache/advisory/sqlite.rs
+++ b/dependi-lsp/src/cache/advisory/sqlite.rs
@@ -35,7 +35,7 @@ impl SqliteAdvisoryCache {
         Self::with_path(path, DEFAULT_ADVISORY_TTL_SECS)
     }
 
-    /// Build a cache from an [`AdvisoryCacheConfig`] (issue #237).
+    /// Build a cache from an [`crate::config::AdvisoryCacheConfig`] (issue #237).
     ///
     /// Uses `config.db_path` if set, otherwise the default cache location.
     /// Returns an error if the database directory cannot be created or the

--- a/dependi-lsp/src/registries/npm.rs
+++ b/dependi-lsp/src/registries/npm.rs
@@ -80,7 +80,7 @@ use crate::registries::url_sanitizer::{sanitize_external_url, sanitize_repo_url}
 pub struct NpmRegistry {
     client: Arc<Client>,
     base_url: String,
-    /// Scope to URL mapping for scoped packages (e.g., "company" -> "https://npm.company.com")
+    /// Scope to URL mapping for scoped packages (e.g., `"company"` -> <https://npm.company.com>)
     scoped_registries: HashMap<String, String>,
     /// Authentication headers per registry URL (URL prefix -> headers)
     auth_headers: HashMap<String, HeaderMap>,


### PR DESCRIPTION
## Summary

Stacked on top of #273. Locks in rustdoc hygiene so future drift is caught at build/CI time.

- Adds `[lints.rustdoc]` to `dependi-lsp/Cargo.toml` denying `broken_intra_doc_links`, `invalid_codeblock_attributes`, `invalid_html_tags`, `invalid_rust_codeblocks`, `bare_urls` (and warning on `private_intra_doc_links`).
- Adds a `Check rustdoc` step (`cargo doc --no-deps`) to `.github/workflows/ci.yml` so the lints are enforced in CI on every push and PR.
- Fixes the 5 remaining pre-existing rustdoc warnings that were blocking strict enforcement:
  - `cache/advisory/mod.rs:157,192`: qualify `AdvisoryCacheConfig` intra-doc link with `crate::config::`.
  - `cache/advisory/sqlite.rs:38`: same.
  - `registries/npm.rs:83`: wrap example URL in angle brackets.
  - `bin/test_dates.rs:15`: switch comment-only ```` ```no_run ```` fence to ```` ```text ````.

## Why lints in `Cargo.toml`?

`[lints.*]` is the idiomatic Rust 1.74+ mechanism. Lints apply to every `cargo doc` invocation (local or CI) without bespoke flags, and they are version-controlled alongside the code.

## Merge order

Merge **after #273**. Branched off `docs/issue-231-rustdoc`; rebase onto `main` is trivial once #273 lands (no overlap).

## Test plan

- [x] `cargo build -p dependi-lsp` — clean
- [x] `cargo test --lib -p dependi-lsp` — 781 passed
- [x] `cargo test --doc -p dependi-lsp` — 43 passed, 20 ignored
- [x] `cargo doc --no-deps -p dependi-lsp` — 0 warnings, 0 errors
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce rustdoc quality for `dependi-lsp` by enabling strict `[lints.rustdoc]` in `Cargo.toml` and adding a `cargo doc --no-deps` check in CI. CI now fails on `broken_intra_doc_links`, `invalid_codeblock_attributes`, `invalid_html_tags`, `invalid_rust_codeblocks`, and `bare_urls` (warns on `private_intra_doc_links`).

- **Bug Fixes**
  - Qualify `AdvisoryCacheConfig` links as `crate::config::AdvisoryCacheConfig` in `cache/advisory/{mod,sqlite}.rs`.
  - Wrap example URL in angle brackets in `registries/npm.rs`.
  - Replace comment-only Rust fence with `text` in `bin/test_dates.rs`.

<sup>Written for commit a873fb397379b311e14140f721d155d65099f89d. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/zed-dependi/pull/274?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enforced stricter rustdoc linting to improve doc quality and fix existing warnings.
  * Added a CI verification step to ensure documentation builds succeed.
  * Updated several documentation examples and cross-references for clarity.

* **Chores**
  * Configured rustdoc lint rules to maintain consistent documentation standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->