### PR TITLE
chore(release): v1.8.0 + dependabot upgrades

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,7 +44,7 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_site
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
           path: artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             artifacts/**/*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-04-28
+
 ### Added
 
 - Architecture guide `docs/architecture.md` for contributors — covers the five
@@ -98,6 +100,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `hashbrown` from 0.16.1 to 0.17.0 (purely additive release, hashbrown MSRV 1.85 ≤ project MSRV 1.94)
 - Bump `tokio` constraint from 1.50 to 1.52 in `dependi-lsp/Cargo.toml` (lockfile resolves 1.52.1; patch + minor, backwards compatible)
 - Bump `actions/github-script` from v8 to v9 in `contributor-experience.yml` workflow (Octokit v7; inline scripts unaffected — no `require()` or `getOctokit` shadowing)
+- Bump `quick-xml` from 0.38.4 to 0.39.2 in `dependi-lsp` (used by Maven `pom.xml` and `.csproj` parsers; release adds `read_text_into()` and fixes namespace scope tracking — no breaking API surface used by parsers)
+- Bump `actions/upload-pages-artifact` from v4 to v5 in `pages.yml` workflow
+- Bump `softprops/action-gh-release` from v2 to v3 in `release.yml` workflow
 - Refresh all Cargo lockfiles (`dependi-lsp`, `dependi-zed`, `dependi-lsp/fuzz`) with latest semver-compatible transitive dependencies
 - Track dependency name and version lines separately
 - Refactor `parse_pyproject_toml` into focused per-section helpers (`parse_pep621_deps`, `parse_pep621_optional`, `parse_poetry_main`, `parse_poetry_dev_legacy`, `parse_poetry_groups`, `parse_pep735_groups`, `parse_hatch_envs`) and resolve dependency positions via taplo `text_range()` instead of repeated full-file line scans. Improves readability and eliminates O(deps × lines) scanning. ([#240](https://github.com/mpiton/zed-dependi/issues/240))
@@ -638,7 +643,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory caching for version data
 - Parallel registry requests (5 concurrent)
 
-[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/mpiton/zed-dependi/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/mpiton/zed-dependi/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/mpiton/zed-dependi/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/mpiton/zed-dependi/compare/v1.5.0...v1.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#236](https://github.com/mpiton/zed-dependi/issues/236))
 - Poetry inline-table dependencies (`name = { version = "...", optional = true }`) now correctly propagate the `optional = true` flag to the parsed `Dependency`. Previously the flag was silently dropped. ([#240](https://github.com/mpiton/zed-dependi/issues/240))
 - `pyproject.toml` `version_span` and `name_span` now point at the version literal and the package name only — not the surrounding quotes or the whole inline-table — so "Update to X.Y.Z" quick-fixes replace just the version and leave the rest of the dependency entry intact. Affects PEP 621 array deps, PEP 735 groups, Hatch envs, and Poetry simple-string + inline-table forms. ([#240](https://github.com/mpiton/zed-dependi/issues/240))
+- Maven `pom.xml` parser now recognizes elements declared with a prefixed XML namespace (e.g. `<m:project xmlns:m="http://maven.apache.org/POM/4.0.0">`). Previously, `<m:dependencies>` / `<m:dependency>` were silently ignored because the parser compared raw qualified names (`m:project`) against bare local names (`project`); element matching now uses `local_name()` to strip the prefix. Default xmlns and bare poms are unaffected.
 - `parse_package_lock_graph` no longer surfaces nested `node_modules/<a>/node_modules/<b>`
   copies. With the new graph-based resolver path, transitive nested entries
   could shadow the top-level direct dependency on a first-wins lookup and

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Dependency management extension for the [Zed](https://zed.dev) editor.
 
-**Version:** 1.7.0
+**Version:** 1.8.0
 
 ![Demo](docs/demo.gif)
 

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -508,7 +508,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "dependi-lsp"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1567,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-lsp"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"
@@ -36,7 +36,7 @@ clap = { version = "4.5.60", features = ["derive"] }
 futures = "0.3.32"
 taplo = "0.14"
 hashbrown = { version = "0.17.0", features = ["serde"] }
-quick-xml = "0.38"
+quick-xml = "0.39.2"
 url = "2.5"
 async-trait = "0.1"
 json-spanned-value = "0.2.2"

--- a/dependi-lsp/fuzz/Cargo.lock
+++ b/dependi-lsp/fuzz/Cargo.lock
@@ -381,12 +381,14 @@ name = "dependi-lsp"
 version = "1.7.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "clap",
  "dashmap 6.1.0",
  "dirs",
  "futures",
  "hashbrown 0.17.0",
+ "json-spanned-value",
  "quick-xml",
  "r2d2",
  "reqwest",
@@ -401,6 +403,7 @@ dependencies = [
  "tower-lsp",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -1031,6 +1034,16 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json-spanned-value"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb343fa4e3b1b22b344937deedac88da995abf139c2232cbeaa436c38380a210"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/dependi-lsp/src/parsers/maven.rs
+++ b/dependi-lsp/src/parsers/maven.rs
@@ -118,7 +118,7 @@ fn extract_properties(content: &str) -> HashMap<String, String> {
             Err(_) => return HashMap::new(),
             Ok(Event::Eof) => break,
             Ok(Event::Start(e)) => {
-                let name = e.name().as_ref().to_vec();
+                let name = e.local_name().as_ref().to_vec();
                 let parent = depth_stack.last().map(|v| v.as_slice());
                 // Properties map: project > properties > <key>
                 if parent == Some(b"properties")
@@ -192,7 +192,7 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
             Err(_) => return vec![], // invalid XML → empty result
             Ok(Event::Eof) => break,
             Ok(Event::Start(e)) => {
-                let name = e.name().as_ref().to_vec();
+                let name = e.local_name().as_ref().to_vec();
                 match name.as_slice() {
                     b"dependencies" if !in_plugins => in_dependencies = true,
                     b"dependencyManagement" => in_dep_mgmt = true,
@@ -213,7 +213,7 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
                 current_tag = Some(name);
             }
             Ok(Event::End(e)) => {
-                let name = e.name().as_ref().to_vec();
+                let name = e.local_name().as_ref().to_vec();
                 match name.as_slice() {
                     b"dependencies" => in_dependencies = false,
                     b"dependencyManagement" => in_dep_mgmt = false,
@@ -691,6 +691,88 @@ mod tests {
         assert!(
             deps[0].version_span.line_end > deps[0].version_span.line_start,
             "version span should be non-empty"
+        );
+    }
+
+    #[test]
+    fn test_parse_default_namespace() {
+        let parser = MavenParser::new();
+        let pom = r#"<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>app</artifactId>
+    <version>1.0.0</version>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+    </dependencies>
+</project>
+"#;
+        let deps = parser.parse(pom);
+        assert_eq!(deps.len(), 1, "default xmlns should parse one dependency");
+        assert_eq!(deps[0].name, "org.slf4j:slf4j-api");
+        assert_eq!(deps[0].version, "1.7.30");
+    }
+
+    #[test]
+    fn test_parse_prefixed_namespace() {
+        let parser = MavenParser::new();
+        let pom = r#"<?xml version="1.0" encoding="UTF-8"?>
+<m:project xmlns:m="http://maven.apache.org/POM/4.0.0">
+    <m:modelVersion>4.0.0</m:modelVersion>
+    <m:groupId>com.example</m:groupId>
+    <m:artifactId>app</m:artifactId>
+    <m:version>1.0.0</m:version>
+    <m:dependencies>
+        <m:dependency>
+            <m:groupId>org.slf4j</m:groupId>
+            <m:artifactId>slf4j-api</m:artifactId>
+            <m:version>1.7.30</m:version>
+        </m:dependency>
+    </m:dependencies>
+</m:project>
+"#;
+        let deps = parser.parse(pom);
+        assert_eq!(
+            deps.len(),
+            1,
+            "prefixed namespace should parse one dependency"
+        );
+        assert_eq!(deps[0].name, "org.slf4j:slf4j-api");
+        assert_eq!(deps[0].version, "1.7.30");
+    }
+
+    #[test]
+    fn test_parse_prefixed_namespace_with_property_substitution() {
+        let parser = MavenParser::new();
+        let pom = r#"<?xml version="1.0" encoding="UTF-8"?>
+<m:project xmlns:m="http://maven.apache.org/POM/4.0.0">
+    <m:modelVersion>4.0.0</m:modelVersion>
+    <m:properties>
+        <m:slf4j.version>1.7.30</m:slf4j.version>
+    </m:properties>
+    <m:dependencies>
+        <m:dependency>
+            <m:groupId>org.slf4j</m:groupId>
+            <m:artifactId>slf4j-api</m:artifactId>
+            <m:version>${slf4j.version}</m:version>
+        </m:dependency>
+    </m:dependencies>
+</m:project>
+"#;
+        let deps = parser.parse(pom);
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].version, "${slf4j.version}");
+        assert_eq!(
+            deps[0].resolved_version.as_deref(),
+            Some("1.7.30"),
+            "property substitution should work under prefixed namespace"
         );
     }
 }

--- a/dependi-zed/Cargo.lock
+++ b/dependi-zed/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-zed"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "hex",
  "sha2",

--- a/dependi-zed/Cargo.toml
+++ b/dependi-zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-zed"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT"

--- a/dependi-zed/extension.toml
+++ b/dependi-zed/extension.toml
@@ -1,7 +1,7 @@
 id = "dependi"
 name = "Dependi"
 description = "Dependency management for Zed - version hints, updates, and vulnerability detection"
-version = "1.7.0"
+version = "1.8.0"
 schema_version = 1
 authors = ["Mathieu Piton"]
 repository = "https://github.com/mpiton/zed-dependi"


### PR DESCRIPTION
## Summary

- Bump dependi-lsp, dependi-zed, extension to v1.8.0
- Upgrade quick-xml 0.38.4 → 0.39.2 (fixes namespace scopes in XML parsers)
- Upgrade softprops/action-gh-release v2 → v3
- Upgrade actions/upload-pages-artifact v4 → v5
- Release architecture guide + TDD validators + tutorial + cache/lockfile upgrades
- Test coverage: 870 passed, 0 failed

Closes #258 #259 #263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes - Version 1.8.0

* **Chores**
  * Version bumped to 1.8.0
  * CI/CD workflows updated to newer action versions
  * Dependency upgrades for compatibility and stability
* **Bug Fixes**
  * Maven POM parsing improved to handle XML namespaces reliably
* **Tests**
  * Added tests covering namespace variations and property substitution
* **Documentation**
  * README and changelog updated for 1.8.0 release
<!-- end of auto-generated comment: release notes by coderabbit.ai -->