### PR TITLE
chore(release): v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-05-01
+
 ### Fixed
 
 - npm registry client now accepts both string and boolean values for the
@@ -653,7 +655,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory caching for version data
 - Parallel registry requests (5 concurrent)
 
-[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.8.1...HEAD
+[1.8.1]: https://github.com/mpiton/zed-dependi/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/mpiton/zed-dependi/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/mpiton/zed-dependi/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/mpiton/zed-dependi/compare/v1.6.0...v1.6.1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Dependency management extension for the [Zed](https://zed.dev) editor.
 
-**Version:** 1.8.0
+**Version:** 1.8.1
 
 ![Demo](docs/demo.gif)
 

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -508,7 +508,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "dependi-lsp"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-lsp"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/dependi-zed/Cargo.lock
+++ b/dependi-zed/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-zed"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "hex",
  "sha2",

--- a/dependi-zed/Cargo.toml
+++ b/dependi-zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-zed"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT"

--- a/dependi-zed/extension.toml
+++ b/dependi-zed/extension.toml
@@ -1,7 +1,7 @@
 id = "dependi"
 name = "Dependi"
 description = "Dependency management for Zed - version hints, updates, and vulnerability detection"
-version = "1.8.0"
+version = "1.8.1"
 schema_version = 1
 authors = ["Mathieu Piton"]
 repository = "https://github.com/mpiton/zed-dependi"


### PR DESCRIPTION
## Summary

Patch release v1.8.1. Ships the npm `deprecated` field deserialization fix (#278), which restores version resolution for react, react-dom, and any npm package publishing `"deprecated": false` on individual versions.

## Why

Users editing `package.json` files containing `react` saw `? Unknown` next to versions and repeated `WARN dependi_lsp::backend: Failed to fetch version info for react: error decoding response body` in server logs. Cutting 1.8.1 ships the fix to end users.

## Changes

- Bump `dependi-lsp`, `dependi-zed`, and `dependi-zed/extension.toml` from `1.8.0` to `1.8.1`.
- Refresh both `Cargo.lock` files for the new package versions.
- Move CHANGELOG `[Unreleased]` Fixed entry into `[1.8.1] - 2026-05-01` and add the `1.8.0...1.8.1` compare link.
- Update README version badge.

## Testing

```bash
cargo build --release --package dependi-lsp
cargo build --package dependi-zed
cargo test --lib                    # 790 passed, 1 ignored
cargo clippy --all-targets -- -D warnings
cargo fmt --all -- --check
```

All green.

## Related Issues

- Includes #278

## Notes for Reviewer

After merge, tag `v1.8.1` on `main` to trigger any release automation, then publish the Zed extension manifest update.

## Checklist

- [x] Versions bumped consistently across all manifests
- [x] CHANGELOG section dated and link added
- [x] Cargo.lock files updated
- [x] Tests + clippy + fmt clean
- [x] No stray debug code or secrets
- [x] Self-reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.8.1 - Updated all documentation and package metadata to reflect the new version number. Added corresponding changelog entry dated May 1, 2026. Adjusted unreleased development range tracking to reflect changes since version 1.8.1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->