### PR TITLE
fix(fuzz): migrate fuzz targets to name_span/version_span API

### DIFF
--- a/dependi-lsp/fuzz/fuzz_targets/fuzz_cargo.rs
+++ b/dependi-lsp/fuzz/fuzz_targets/fuzz_cargo.rs
@@ -15,38 +15,28 @@ fuzz_target!(|data: &[u8]| {
             let lines: Vec<&str> = content.lines().collect();
 
             for dep in &deps {
-                assert!(
-                    (dep.line as usize) < lines.len(),
-                    "dep.line out of range"
-                );
+                for span in [&dep.name_span, &dep.version_span] {
+                    assert!(
+                        (span.line as usize) < lines.len(),
+                        "span.line out of range"
+                    );
 
-                let line = lines[dep.line as usize];
-                let line_len = line.len() as u32;
+                    let line = lines[span.line as usize];
+                    let line_len = line.len() as u32;
 
-                assert!(
-                    dep.name_start <= dep.name_end,
-                    "name_start must be <= name_end"
-                );
-                assert!(
-                    dep.name_start <= line_len,
-                    "name_start must be within line bounds"
-                );
-                assert!(
-                    dep.name_end <= line_len,
-                    "name_end must be within line bounds"
-                );
-                assert!(
-                    dep.version_start <= dep.version_end,
-                    "version_start must be <= version_end"
-                );
-                assert!(
-                    dep.version_start <= line_len,
-                    "version_start must be within line bounds"
-                );
-                assert!(
-                    dep.version_end <= line_len,
-                    "version_end must be within line bounds"
-                );
+                    assert!(
+                        span.line_start <= span.line_end,
+                        "line_start must be <= line_end"
+                    );
+                    assert!(
+                        span.line_start <= line_len,
+                        "line_start must be within line bounds"
+                    );
+                    assert!(
+                        span.line_end <= line_len,
+                        "line_end must be within line bounds"
+                    );
+                }
             }
         }
     }

--- a/dependi-lsp/fuzz/fuzz_targets/fuzz_csharp.rs
+++ b/dependi-lsp/fuzz/fuzz_targets/fuzz_csharp.rs
@@ -15,38 +15,28 @@ fuzz_target!(|data: &[u8]| {
             let lines: Vec<&str> = content.lines().collect();
 
             for dep in &deps {
-                assert!(
-                    (dep.line as usize) < lines.len(),
-                    "dep.line out of range"
-                );
+                for span in [&dep.name_span, &dep.version_span] {
+                    assert!(
+                        (span.line as usize) < lines.len(),
+                        "span.line out of range"
+                    );
 
-                let line = lines[dep.line as usize];
-                let line_len = line.len() as u32;
+                    let line = lines[span.line as usize];
+                    let line_len = line.len() as u32;
 
-                assert!(
-                    dep.name_start <= dep.name_end,
-                    "name_start must be <= name_end"
-                );
-                assert!(
-                    dep.name_start <= line_len,
-                    "name_start must be within line bounds"
-                );
-                assert!(
-                    dep.name_end <= line_len,
-                    "name_end must be within line bounds"
-                );
-                assert!(
-                    dep.version_start <= dep.version_end,
-                    "version_start must be <= version_end"
-                );
-                assert!(
-                    dep.version_start <= line_len,
-                    "version_start must be within line bounds"
-                );
-                assert!(
-                    dep.version_end <= line_len,
-                    "version_end must be within line bounds"
-                );
+                    assert!(
+                        span.line_start <= span.line_end,
+                        "line_start must be <= line_end"
+                    );
+                    assert!(
+                        span.line_start <= line_len,
+                        "line_start must be within line bounds"
+                    );
+                    assert!(
+                        span.line_end <= line_len,
+                        "line_end must be within line bounds"
+                    );
+                }
             }
         }
     }

--- a/dependi-lsp/fuzz/fuzz_targets/fuzz_dart.rs
+++ b/dependi-lsp/fuzz/fuzz_targets/fuzz_dart.rs
@@ -15,38 +15,28 @@ fuzz_target!(|data: &[u8]| {
             let lines: Vec<&str> = content.lines().collect();
 
             for dep in &deps {
-                assert!(
-                    (dep.line as usize) < lines.len(),
-                    "dep.line out of range"
-                );
+                for span in [&dep.name_span, &dep.version_span] {
+                    assert!(
+                        (span.line as usize) < lines.len(),
+                        "span.line out of range"
+                    );
 
-                let line = lines[dep.line as usize];
-                let line_len = line.len() as u32;
+                    let line = lines[span.line as usize];
+                    let line_len = line.len() as u32;
 
-                assert!(
-                    dep.name_start <= dep.name_end,
-                    "name_start must be <= name_end"
-                );
-                assert!(
-                    dep.name_start <= line_len,
-                    "name_start must be within line bounds"
-                );
-                assert!(
-                    dep.name_end <= line_len,
-                    "name_end must be within line bounds"
-                );
-                assert!(
-                    dep.version_start <= dep.version_end,
-                    "version_start must be <= version_end"
-                );
-                assert!(
-                    dep.version_start <= line_len,
-                    "version_start must be within line bounds"
-                );
-                assert!(
-                    dep.version_end <= line_len,
-                    "version_end must be within line bounds"
-                );
+                    assert!(
+                        span.line_start <= span.line_end,
+                        "line_start must be <= line_end"
+                    );
+                    assert!(
+                        span.line_start <= line_len,
+                        "line_start must be within line bounds"
+                    );
+                    assert!(
+                        span.line_end <= line_len,
+                        "line_end must be within line bounds"
+                    );
+                }
             }
         }
     }

--- a/dependi-lsp/fuzz/fuzz_targets/fuzz_go.rs
+++ b/dependi-lsp/fuzz/fuzz_targets/fuzz_go.rs
@@ -15,38 +15,28 @@ fuzz_target!(|data: &[u8]| {
             let lines: Vec<&str> = content.lines().collect();
 
             for dep in &deps {
-                assert!(
-                    (dep.line as usize) < lines.len(),
-                    "dep.line out of range"
-                );
+                for span in [&dep.name_span, &dep.version_span] {
+                    assert!(
+                        (span.line as usize) < lines.len(),
+                        "span.line out of range"
+                    );
 
-                let line = lines[dep.line as usize];
-                let line_len = line.len() as u32;
+                    let line = lines[span.line as usize];
+                    let line_len = line.len() as u32;
 
-                assert!(
-                    dep.name_start <= dep.name_end,
-                    "name_start must be <= name_end"
-                );
-                assert!(
-                    dep.name_start <= line_len,
-                    "name_start must be within line bounds"
-                );
-                assert!(
-                    dep.name_end <= line_len,
-                    "name_end must be within line bounds"
-                );
-                assert!(
-                    dep.version_start <= dep.version_end,
-                    "version_start must be <= version_end"
-                );
-                assert!(
-                    dep.version_start <= line_len,
-                    "version_start must be within line bounds"
-                );
-                assert!(
-                    dep.version_end <= line_len,
-                    "version_end must be within line bounds"
-                );
+                    assert!(
+                        span.line_start <= span.line_end,
+                        "line_start must be <= line_end"
+                    );
+                    assert!(
+                        span.line_start <= line_len,
+                        "line_start must be within line bounds"
+                    );
+                    assert!(
+                        span.line_end <= line_len,
+                        "line_end must be within line bounds"
+                    );
+                }
             }
         }
     }

--- a/dependi-lsp/fuzz/fuzz_targets/fuzz_npm.rs
+++ b/dependi-lsp/fuzz/fuzz_targets/fuzz_npm.rs
@@ -15,38 +15,28 @@ fuzz_target!(|data: &[u8]| {
             let lines: Vec<&str> = content.lines().collect();
 
             for dep in &deps {
-                assert!(
-                    (dep.line as usize) < lines.len(),
-                    "dep.line out of range"
-                );
+                for span in [&dep.name_span, &dep.version_span] {
+                    assert!(
+                        (span.line as usize) < lines.len(),
+                        "span.line out of range"
+                    );
 
-                let line = lines[dep.line as usize];
-                let line_len = line.len() as u32;
+                    let line = lines[span.line as usize];
+                    let line_len = line.len() as u32;
 
-                assert!(
-                    dep.name_start <= dep.name_end,
-                    "name_start must be <= name_end"
-                );
-                assert!(
-                    dep.name_start <= line_len,
-                    "name_start must be within line bounds"
-                );
-                assert!(
-                    dep.name_end <= line_len,
-                    "name_end must be within line bounds"
-                );
-                assert!(
-                    dep.version_start <= dep.version_end,
-                    "version_start must be <= version_end"
-                );
-                assert!(
-                    dep.version_start <= line_len,
-                    "version_start must be within line bounds"
-                );
-                assert!(
-                    dep.version_end <= line_len,
-                    "version_end must be within line bounds"
-                );
+                    assert!(
+                        span.line_start <= span.line_end,
+                        "line_start must be <= line_end"
+                    );
+                    assert!(
+                        span.line_start <= line_len,
+                        "line_start must be within line bounds"
+                    );
+                    assert!(
+                        span.line_end <= line_len,
+                        "line_end must be within line bounds"
+                    );
+                }
             }
         }
     }

--- a/dependi-lsp/fuzz/fuzz_targets/fuzz_php.rs
+++ b/dependi-lsp/fuzz/fuzz_targets/fuzz_php.rs
@@ -15,38 +15,28 @@ fuzz_target!(|data: &[u8]| {
             let lines: Vec<&str> = content.lines().collect();
 
             for dep in &deps {
-                assert!(
-                    (dep.line as usize) < lines.len(),
-                    "dep.line out of range"
-                );
+                for span in [&dep.name_span, &dep.version_span] {
+                    assert!(
+                        (span.line as usize) < lines.len(),
+                        "span.line out of range"
+                    );
 
-                let line = lines[dep.line as usize];
-                let line_len = line.len() as u32;
+                    let line = lines[span.line as usize];
+                    let line_len = line.len() as u32;
 
-                assert!(
-                    dep.name_start <= dep.name_end,
-                    "name_start must be <= name_end"
-                );
-                assert!(
-                    dep.name_start <= line_len,
-                    "name_start must be within line bounds"
-                );
-                assert!(
-                    dep.name_end <= line_len,
-                    "name_end must be within line bounds"
-                );
-                assert!(
-                    dep.version_start <= dep.version_end,
-                    "version_start must be <= version_end"
-                );
-                assert!(
-                    dep.version_start <= line_len,
-                    "version_start must be within line bounds"
-                );
-                assert!(
-                    dep.version_end <= line_len,
-                    "version_end must be within line bounds"
-                );
+                    assert!(
+                        span.line_start <= span.line_end,
+                        "line_start must be <= line_end"
+                    );
+                    assert!(
+                        span.line_start <= line_len,
+                        "line_start must be within line bounds"
+                    );
+                    assert!(
+                        span.line_end <= line_len,
+                        "line_end must be within line bounds"
+                    );
+                }
             }
         }
     }

--- a/dependi-lsp/fuzz/fuzz_targets/fuzz_python.rs
+++ b/dependi-lsp/fuzz/fuzz_targets/fuzz_python.rs
@@ -15,38 +15,28 @@ fuzz_target!(|data: &[u8]| {
             let lines: Vec<&str> = content.lines().collect();
 
             for dep in &deps {
-                assert!(
-                    (dep.line as usize) < lines.len(),
-                    "dep.line out of range"
-                );
+                for span in [&dep.name_span, &dep.version_span] {
+                    assert!(
+                        (span.line as usize) < lines.len(),
+                        "span.line out of range"
+                    );
 
-                let line = lines[dep.line as usize];
-                let line_len = line.len() as u32;
+                    let line = lines[span.line as usize];
+                    let line_len = line.len() as u32;
 
-                assert!(
-                    dep.name_start <= dep.name_end,
-                    "name_start must be <= name_end"
-                );
-                assert!(
-                    dep.name_start <= line_len,
-                    "name_start must be within line bounds"
-                );
-                assert!(
-                    dep.name_end <= line_len,
-                    "name_end must be within line bounds"
-                );
-                assert!(
-                    dep.version_start <= dep.version_end,
-                    "version_start must be <= version_end"
-                );
-                assert!(
-                    dep.version_start <= line_len,
-                    "version_start must be within line bounds"
-                );
-                assert!(
-                    dep.version_end <= line_len,
-                    "version_end must be within line bounds"
-                );
+                    assert!(
+                        span.line_start <= span.line_end,
+                        "line_start must be <= line_end"
+                    );
+                    assert!(
+                        span.line_start <= line_len,
+                        "line_start must be within line bounds"
+                    );
+                    assert!(
+                        span.line_end <= line_len,
+                        "line_end must be within line bounds"
+                    );
+                }
             }
         }
     }

--- a/dependi-lsp/fuzz/fuzz_targets/fuzz_ruby.rs
+++ b/dependi-lsp/fuzz/fuzz_targets/fuzz_ruby.rs
@@ -15,38 +15,28 @@ fuzz_target!(|data: &[u8]| {
             let lines: Vec<&str> = content.lines().collect();
 
             for dep in &deps {
-                assert!(
-                    (dep.line as usize) < lines.len(),
-                    "dep.line out of range"
-                );
+                for span in [&dep.name_span, &dep.version_span] {
+                    assert!(
+                        (span.line as usize) < lines.len(),
+                        "span.line out of range"
+                    );
 
-                let line = lines[dep.line as usize];
-                let line_len = line.len() as u32;
+                    let line = lines[span.line as usize];
+                    let line_len = line.len() as u32;
 
-                assert!(
-                    dep.name_start <= dep.name_end,
-                    "name_start must be <= name_end"
-                );
-                assert!(
-                    dep.name_start <= line_len,
-                    "name_start must be within line bounds"
-                );
-                assert!(
-                    dep.name_end <= line_len,
-                    "name_end must be within line bounds"
-                );
-                assert!(
-                    dep.version_start <= dep.version_end,
-                    "version_start must be <= version_end"
-                );
-                assert!(
-                    dep.version_start <= line_len,
-                    "version_start must be within line bounds"
-                );
-                assert!(
-                    dep.version_end <= line_len,
-                    "version_end must be within line bounds"
-                );
+                    assert!(
+                        span.line_start <= span.line_end,
+                        "line_start must be <= line_end"
+                    );
+                    assert!(
+                        span.line_start <= line_len,
+                        "line_start must be within line bounds"
+                    );
+                    assert!(
+                        span.line_end <= line_len,
+                        "line_end must be within line bounds"
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- All 8 fuzz targets failed `cargo +nightly fuzz build` in CI (run [25616033539](https://github.com/mpiton/zed-dependi/actions/runs/25616033539)) with `E0609: no field 'line' / 'name_start' / 'name_end' / 'version_start' / 'version_end' on type '&Dependency'`.
- The `Dependency` struct was refactored to nest span fields inside `name_span` / `version_span` of type `Span { line, line_start, line_end }` (see `dependi-lsp/src/parsers/mod.rs:32`), but fuzz targets still referenced the old flattened fields.
- Updated each target to iterate both spans and assert bounds against the line each span belongs to (name and version can sit on different lines, e.g. multi-line Cargo.toml dep tables).

## Why
Restore CI nightly fuzz coverage across `cargo`, `npm`, `python`, `go`, `php`, `dart`, `csharp`, `ruby`.

## Changes
- `dependi-lsp/fuzz/fuzz_targets/*.rs` (8 files): replace `dep.line` / `dep.name_start` / `dep.name_end` / `dep.version_start` / `dep.version_end` with iteration over `[&dep.name_span, &dep.version_span]` and use `span.line` / `span.line_start` / `span.line_end`.

## Testing
- `cargo +nightly check` in `dependi-lsp/fuzz/` (all 8 bins): `Finished dev [unoptimized + debuginfo]`.

## Checklist
- [x] Local fuzz workspace builds on nightly
- [x] Branch isolated (`fix/fuzz-targets-span-migration`)
- [ ] CI fuzz job green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated all eight `dependi-lsp` fuzz targets to use `name_span`/`version_span` from `Dependency`. This fixes nightly `cargo fuzz` E0609 build errors and restores CI fuzz coverage.

- **Bug Fixes**
  - Replaced `dep.line`/`*_start`/`*_end` with per-span checks via `Span { line, line_start, line_end }` on `dep.name_span` and `dep.version_span`.
  - Validated each span against its own line to handle multi-line dependency entries.

<sup>Written for commit 6574fe3d6952bec1b6793878b7beb7595ec9e90a. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/zed-dependi/pull/287?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored validation logic across fuzz testing targets for multiple package managers to improve bounds-checking consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/zed-dependi/pull/287)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->