### PR TITLE
green(R-01): default catalog shapes determine discovered npm dependencies

### DIFF
--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -151,6 +151,7 @@ pub mod npm;
 pub mod npm_lock;
 pub mod packages_lock_json;
 pub mod php;
+pub mod pnpm_workspace;
 pub mod pubspec_lock;
 pub mod python;
 pub mod python_lock;

--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -1,0 +1,85 @@
+//! Parser for pnpm `pnpm-workspace.yaml` catalog dependencies.
+
+use super::{Dependency, Parser, Span};
+
+/// Parser for pnpm workspace catalog dependency files.
+#[derive(Debug, Default)]
+pub struct PnpmWorkspaceParser;
+
+impl PnpmWorkspaceParser {
+    /// Creates a new [`PnpmWorkspaceParser`] instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Parser for PnpmWorkspaceParser {
+    fn parse(&self, content: &str) -> Vec<Dependency> {
+        parse_default_catalog(content)
+    }
+}
+
+fn parse_default_catalog(content: &str) -> Vec<Dependency> {
+    let mut dependencies = Vec::new();
+    let mut in_catalog = false;
+    let mut catalog_indent = 0usize;
+
+    for (line_number, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let indent = line.len() - line.trim_start().len();
+        if in_catalog && indent <= catalog_indent {
+            in_catalog = false;
+        }
+
+        if !in_catalog {
+            if trimmed == "catalog:" {
+                in_catalog = true;
+                catalog_indent = indent;
+            }
+            continue;
+        }
+
+        if let Some(dependency) = parse_catalog_entry(line_number as u32, line) {
+            dependencies.push(dependency);
+        }
+    }
+
+    dependencies
+}
+
+fn parse_catalog_entry(line_number: u32, line: &str) -> Option<Dependency> {
+    let indent = line.len() - line.trim_start().len();
+    let trimmed = line.trim();
+    let (name, version) = trimmed.split_once(':')?;
+    let name = name.trim();
+    let version = version.trim();
+    if name.is_empty() || version.is_empty() {
+        return None;
+    }
+
+    let name_start = indent + trimmed.find(name)?;
+    let version_start = line.find(version)?;
+
+    Some(Dependency {
+        name: name.to_string(),
+        version: version.to_string(),
+        name_span: Span {
+            line: line_number,
+            line_start: name_start as u32,
+            line_end: (name_start + name.len()) as u32,
+        },
+        version_span: Span {
+            line: line_number,
+            line_start: version_start as u32,
+            line_end: (version_start + version.len()) as u32,
+        },
+        dev: false,
+        optional: false,
+        registry: None,
+        resolved_version: None,
+    })
+}

--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -25,7 +25,8 @@ fn parse_default_catalog(content: &str) -> Vec<Dependency> {
     let mut catalog_indent = 0usize;
 
     for (line_number, line) in content.lines().enumerate() {
-        let trimmed = line.trim();
+        let without_comment = strip_inline_comment(line);
+        let trimmed = without_comment.trim();
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
@@ -53,16 +54,20 @@ fn parse_default_catalog(content: &str) -> Vec<Dependency> {
 
 fn parse_catalog_entry(line_number: u32, line: &str) -> Option<Dependency> {
     let indent = line.len() - line.trim_start().len();
-    let trimmed = line.trim();
+    let without_comment = strip_inline_comment(line);
+    let trimmed = without_comment.trim();
     let (name, version) = trimmed.split_once(':')?;
     let name = name.trim();
-    let version = version.trim();
+    let raw_version = version.trim();
+    let version = trim_quotes(raw_version);
     if name.is_empty() || version.is_empty() {
         return None;
     }
 
     let name_start = indent + trimmed.find(name)?;
-    let version_start = line.find(version)?;
+    let raw_version_start = line.find(raw_version)?;
+    let quote_offset = raw_version.len() - raw_version.trim_start_matches(['"', '\'']).len();
+    let version_start = raw_version_start + quote_offset;
 
     Some(Dependency {
         name: name.to_string(),
@@ -82,4 +87,21 @@ fn parse_catalog_entry(line_number: u32, line: &str) -> Option<Dependency> {
         registry: None,
         resolved_version: None,
     })
+}
+
+fn strip_inline_comment(line: &str) -> &str {
+    line.split_once('#')
+        .map_or(line, |(before_comment, _)| before_comment)
+}
+
+fn trim_quotes(value: &str) -> &str {
+    value
+        .strip_prefix('"')
+        .and_then(|unquoted| unquoted.strip_suffix('"'))
+        .or_else(|| {
+            value
+                .strip_prefix('\'')
+                .and_then(|unquoted| unquoted.strip_suffix('\''))
+        })
+        .unwrap_or(value)
 }

--- a/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
+++ b/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
@@ -10,6 +10,24 @@ fn dependency_pairs(content: &str) -> Vec<(String, String)> {
 }
 
 #[test]
+fn default_catalog_entries_accept_inline_comments_and_quoted_versions() {
+    let workspace_yaml = r#"
+packages: [packages/*]
+catalog: # shared dependency versions
+  react: "^18.3.1" # pinned for React 18 apps
+  redux: '^5.0.1'
+"#;
+
+    assert_eq!(
+        dependency_pairs(workspace_yaml),
+        vec![
+            ("react".to_string(), "^18.3.1".to_string()),
+            ("redux".to_string(), "^5.0.1".to_string()),
+        ]
+    );
+}
+
+#[test]
 fn default_catalog_shapes_determine_discovered_npm_dependencies() {
     // Given a workspace file "pnpm-workspace.yaml" represented as compact YAML "<workspace_yaml>"
     // When Dependi inspects "pnpm-workspace.yaml"

--- a/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
+++ b/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
@@ -1,0 +1,32 @@
+use dependi_lsp::parsers::Parser;
+use dependi_lsp::parsers::pnpm_workspace::PnpmWorkspaceParser;
+
+fn dependency_pairs(content: &str) -> Vec<(String, String)> {
+    PnpmWorkspaceParser::new()
+        .parse(content)
+        .into_iter()
+        .map(|dependency| (dependency.name, dependency.version))
+        .collect()
+}
+
+#[test]
+fn default_catalog_shapes_determine_discovered_npm_dependencies() {
+    // Given a workspace file "pnpm-workspace.yaml" represented as compact YAML "<workspace_yaml>"
+    // When Dependi inspects "pnpm-workspace.yaml"
+    // Then the discovered npm dependencies are "<expected_dependencies>"
+    let cases = [
+        (
+            "packages: [packages/*]\ncatalog:\n  react: ^18.3.1\n  redux: ^5.0.1\n",
+            vec![
+                ("react".to_string(), "^18.3.1".to_string()),
+                ("redux".to_string(), "^5.0.1".to_string()),
+            ],
+        ),
+        ("packages: [packages/*]\ncatalog: {}\n", Vec::new()),
+        ("packages: [packages/*]\n", Vec::new()),
+    ];
+
+    for (workspace_yaml, expected_dependencies) in cases {
+        assert_eq!(dependency_pairs(workspace_yaml), expected_dependencies);
+    }
+}


### PR DESCRIPTION
Closes #292

Implements the first ATDD scenario for pnpm-workspace default catalog dependency discovery.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables discovery of npm dependencies from the default `catalog` in `pnpm-workspace.yaml` via a new parser, so Dependi picks up workspace-wide catalog versions. Implements the first ATDD scenario for #292.

- **New Features**
  - Added `pnpm_workspace` parser to read `catalog:` entries and emit dependencies with accurate name/version spans.
  - Supports inline comments and quoted versions; gracefully handles empty or missing `catalog` (no discoveries).

<sup>Written for commit 39ddea426ce34563d083b58b816ab8bdedeb42af. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/zed-dependi/pull/314?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

