### PR TITLE
green(R-02): react catalog shorthand resolves through default catalog

### DIFF
--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -19,6 +19,32 @@ impl Parser for PnpmWorkspaceParser {
     }
 }
 
+/// Resolve npm `catalog:` dependency references against a pnpm workspace file.
+pub fn resolve_catalog_references(
+    dependencies: Vec<Dependency>,
+    workspace_content: Option<&str>,
+) -> Vec<Dependency> {
+    let Some(workspace_content) = workspace_content else {
+        return dependencies;
+    };
+
+    let catalog_dependencies = PnpmWorkspaceParser::new().parse(workspace_content);
+
+    dependencies
+        .into_iter()
+        .map(|mut dependency| {
+            if dependency.version == "catalog:"
+                && let Some(catalog_dependency) = catalog_dependencies
+                    .iter()
+                    .find(|catalog_dependency| catalog_dependency.name == dependency.name)
+            {
+                dependency.version = catalog_dependency.version.clone();
+            }
+            dependency
+        })
+        .collect()
+}
+
 fn parse_default_catalog(content: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
     let mut in_catalog = false;

--- a/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
+++ b/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
@@ -1,5 +1,6 @@
 use dependi_lsp::parsers::Parser;
-use dependi_lsp::parsers::pnpm_workspace::PnpmWorkspaceParser;
+use dependi_lsp::parsers::npm::NpmParser;
+use dependi_lsp::parsers::pnpm_workspace::{PnpmWorkspaceParser, resolve_catalog_references};
 
 fn dependency_pairs(content: &str) -> Vec<(String, String)> {
     PnpmWorkspaceParser::new()
@@ -47,4 +48,47 @@ fn default_catalog_shapes_determine_discovered_npm_dependencies() {
     for (workspace_yaml, expected_dependencies) in cases {
         assert_eq!(dependency_pairs(workspace_yaml), expected_dependencies);
     }
+}
+
+#[test]
+fn react_catalog_shorthand_resolves_through_the_default_catalog() {
+    // Given a workspace file "pnpm-workspace.yaml" containing:
+    //   packages:
+    //     - packages/*
+    //
+    //   catalog:
+    //     react: ^18.3.1
+    //     redux: ^5.0.1
+    // And a package file "packages/example-app/package.json" containing:
+    //   {
+    //     "name": "@example/app",
+    //     "dependencies": {
+    //       "react": "catalog:"
+    //     }
+    //   }
+    // When Dependi inspects "packages/example-app/package.json"
+    // Then the dependency "react" resolves to npm version range "^18.3.1"
+    let workspace_yaml = r#"
+packages:
+  - packages/*
+
+catalog:
+  react: ^18.3.1
+  redux: ^5.0.1
+"#;
+    let package_json = r#"{
+  "name": "@example/app",
+  "dependencies": {
+    "react": "catalog:"
+  }
+}"#;
+
+    let dependencies =
+        resolve_catalog_references(NpmParser::new().parse(package_json), Some(workspace_yaml));
+
+    let react = dependencies
+        .iter()
+        .find(|dependency| dependency.name == "react")
+        .unwrap();
+    assert_eq!(react.version, "^18.3.1");
 }


### PR DESCRIPTION
Closes #295

Implements the ATDD scenario for resolving `"react": "catalog:"` from the default catalog in `pnpm-workspace.yaml`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for resolving the `catalog:` shorthand via the default catalog in `pnpm-workspace.yaml`, so deps like `react` set to `catalog:` resolve to the catalog’s version. Completes ATDD scenario for #295.

- **New Features**
  - Introduced `resolve_catalog_references` to map `catalog:` dependencies to versions from the workspace catalog.
  - Added a test confirming `react` resolves to `^18.3.1` from the default catalog.

<sup>Written for commit 1dfab36ce0d15a72c1e589e01a8b5341a1dd7a4f. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/zed-dependi/pull/315?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

