### PR TITLE
[ATDD] R-04 named catalog shapes determine discovered npm dependencies

### DIFF
--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -15,7 +15,9 @@ impl PnpmWorkspaceParser {
 
 impl Parser for PnpmWorkspaceParser {
     fn parse(&self, content: &str) -> Vec<Dependency> {
-        parse_default_catalog(content)
+        let mut dependencies = parse_default_catalog(content);
+        dependencies.extend(parse_named_catalogs(content));
+        dependencies
     }
 }
 
@@ -76,6 +78,62 @@ fn parse_default_catalog(content: &str) -> Vec<Dependency> {
     }
 
     dependencies
+}
+
+fn parse_named_catalogs(content: &str) -> Vec<Dependency> {
+    let mut dependencies = Vec::new();
+    let mut in_catalogs = false;
+    let mut catalogs_indent = 0usize;
+    let mut in_named_catalog = false;
+    let mut named_catalog_indent = 0usize;
+
+    for (line_number, line) in content.lines().enumerate() {
+        let without_comment = strip_inline_comment(line);
+        let trimmed = without_comment.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let indent = line.len() - line.trim_start().len();
+        if in_catalogs && indent <= catalogs_indent {
+            in_catalogs = false;
+            in_named_catalog = false;
+        }
+
+        if !in_catalogs {
+            if trimmed == "catalogs:" {
+                in_catalogs = true;
+                catalogs_indent = indent;
+            }
+            continue;
+        }
+
+        if in_named_catalog && indent <= named_catalog_indent {
+            in_named_catalog = false;
+        }
+
+        if !in_named_catalog {
+            if is_named_catalog_header(trimmed) {
+                in_named_catalog = true;
+                named_catalog_indent = indent;
+            }
+            continue;
+        }
+
+        if let Some(dependency) = parse_catalog_entry(line_number as u32, line) {
+            dependencies.push(dependency);
+        }
+    }
+
+    dependencies
+}
+
+fn is_named_catalog_header(line: &str) -> bool {
+    let Some((name, value)) = line.split_once(':') else {
+        return false;
+    };
+
+    !name.trim().is_empty() && value.trim().is_empty()
 }
 
 fn parse_catalog_entry(line_number: u32, line: &str) -> Option<Dependency> {

--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -30,7 +30,7 @@ pub fn resolve_catalog_references(
         return dependencies;
     };
 
-    let catalog_dependencies = PnpmWorkspaceParser::new().parse(workspace_content);
+    let catalog_dependencies = parse_default_catalog(workspace_content);
 
     dependencies
         .into_iter()

--- a/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
+++ b/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
@@ -117,3 +117,30 @@ catalog:
         .unwrap();
     assert_eq!(react.version, "^18.3.1");
 }
+
+#[test]
+fn catalog_shorthand_ignores_named_catalog_entries_without_default_catalog() {
+    let workspace_yaml = r#"
+packages:
+  - packages/*
+
+catalogs:
+  react18:
+    react: ^18.2.0
+"#;
+    let package_json = r#"{
+  "name": "@example/app",
+  "dependencies": {
+    "react": "catalog:"
+  }
+}"#;
+
+    let dependencies =
+        resolve_catalog_references(NpmParser::new().parse(package_json), Some(workspace_yaml));
+
+    let react = dependencies
+        .iter()
+        .find(|dependency| dependency.name == "react")
+        .unwrap();
+    assert_eq!(react.version, "catalog:");
+}

--- a/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
+++ b/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
@@ -51,6 +51,31 @@ fn default_catalog_shapes_determine_discovered_npm_dependencies() {
 }
 
 #[test]
+fn named_catalog_shapes_determine_discovered_npm_dependencies() {
+    // Given a workspace file "pnpm-workspace.yaml" represented as compact YAML "<workspace_yaml>"
+    // When Dependi inspects "pnpm-workspace.yaml"
+    // Then the discovered npm dependencies are "<expected_dependencies>"
+    let cases = [
+        (
+            "packages: [packages/*]\ncatalogs:\n  react18:\n    react: ^18.2.0\n    react-dom: ^18.2.0\n",
+            vec![
+                ("react".to_string(), "^18.2.0".to_string()),
+                ("react-dom".to_string(), "^18.2.0".to_string()),
+            ],
+        ),
+        (
+            "packages: [packages/*]\ncatalogs:\n  react18: {}\n",
+            Vec::new(),
+        ),
+        ("packages: [packages/*]\ncatalogs: {}\n", Vec::new()),
+    ];
+
+    for (workspace_yaml, expected_dependencies) in cases {
+        assert_eq!(dependency_pairs(workspace_yaml), expected_dependencies);
+    }
+}
+
+#[test]
 fn react_catalog_shorthand_resolves_through_the_default_catalog() {
     // Given a workspace file "pnpm-workspace.yaml" containing:
     //   packages:


### PR DESCRIPTION
Closes #303

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for named catalogs in `pnpm-workspace.yaml`, merging their dependencies with the default catalog during discovery. Also restricts `catalog:` shorthand resolution to the default catalog, per R-04 in scenario 303.

- **New Features**
  - Parse `catalogs:` and named catalog headers; merge discovered dependencies with the default catalog.
  - Handle empty `catalogs` and empty named catalogs; inline comments are ignored.

- **Bug Fixes**
  - Restrict `catalog:` shorthand resolution to default catalog entries; named catalogs are ignored.
  - Tests cover resolving via the default catalog and ignoring named catalogs for shorthand.

<sup>Written for commit 588a81f3cf2b03b18b24ce2326d6558c72850644. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/zed-dependi/pull/316?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

