### PR TITLE
[US] pnpm-workspace-catalog-support: support pnpm workspace catalog dependencies

### DIFF
--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -61,6 +61,7 @@ use crate::parsers::go::GoParser;
 use crate::parsers::maven::MavenParser;
 use crate::parsers::npm::NpmParser;
 use crate::parsers::php::PhpParser;
+use crate::parsers::pnpm_workspace::{read_pnpm_workspace_for_package, resolve_catalog_references};
 use crate::parsers::python::PythonParser;
 use crate::parsers::ruby::RubyParser;
 use crate::providers::code_actions::create_code_actions;
@@ -179,6 +180,12 @@ impl ProcessingContext {
         };
 
         let mut dependencies = self.parse_document(uri, content);
+        if file_type == FileType::Npm
+            && let Ok(manifest_path) = uri.to_file_path()
+        {
+            let workspace_content = read_pnpm_workspace_for_package(&manifest_path).await;
+            dependencies = resolve_catalog_references(dependencies, workspace_content.as_deref());
+        }
 
         let lockfile_graph = if let Ok(manifest_path) = uri.to_file_path() {
             if let Some(resolver) = crate::parsers::lockfile_resolver::select_resolver(

--- a/dependi-lsp/src/main.rs
+++ b/dependi-lsp/src/main.rs
@@ -213,8 +213,8 @@ async fn run_scan(
         Parser, cargo::CargoParser, cargo_lock, composer_lock, csharp::CsharpParser,
         dart::DartParser, gemfile_lock, go::GoParser, lockfile_graph::LockfileGraph,
         lockfile_graph::LockfilePackage, lockfile_graph::read_lockfile_capped, maven::MavenParser,
-        npm::NpmParser, npm_lock, php::PhpParser, python::PythonParser, python_lock,
-        ruby::RubyParser,
+        npm::NpmParser, npm_lock, php::PhpParser, pnpm_workspace, python::PythonParser,
+        python_lock, ruby::RubyParser,
     };
     use dependi_lsp::registries::VulnerabilitySeverity;
     use dependi_lsp::reports::{
@@ -259,7 +259,12 @@ async fn run_scan(
     let (dependencies, ecosystem) = if file_name == "Cargo.toml" {
         (CargoParser::new().parse(&content), Ecosystem::CratesIo)
     } else if file_name == "package.json" {
-        (NpmParser::new().parse(&content), Ecosystem::Npm)
+        let dependencies = NpmParser::new().parse(&content);
+        let workspace_content = pnpm_workspace::read_pnpm_workspace_for_package(&file).await;
+        (
+            pnpm_workspace::resolve_catalog_references(dependencies, workspace_content.as_deref()),
+            Ecosystem::Npm,
+        )
     } else if file_name == "requirements.txt" || file_name == "pyproject.toml" {
         (PythonParser::new().parse(&content), Ecosystem::PyPI)
     } else if file_name == "go.mod" {

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -151,6 +151,7 @@ pub mod npm;
 pub mod npm_lock;
 pub mod packages_lock_json;
 pub mod php;
+pub mod pnpm_workspace;
 pub mod pubspec_lock;
 pub mod python;
 pub mod python_lock;

--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -187,7 +187,8 @@ fn parse_catalog_entry(line_number: u32, line: &str) -> Option<Dependency> {
     }
 
     let name_start = indent + trimmed.find(name)?;
-    let raw_version_start = line.find(raw_version)?;
+    let delimiter_start = line.find(':')?;
+    let raw_version_start = line[delimiter_start + 1..].find(raw_version)? + delimiter_start + 1;
     let quote_offset = raw_version.len() - raw_version.trim_start_matches(['"', '\'']).len();
     let version_start = raw_version_start + quote_offset;
 
@@ -212,8 +213,26 @@ fn parse_catalog_entry(line_number: u32, line: &str) -> Option<Dependency> {
 }
 
 fn strip_inline_comment(line: &str) -> &str {
-    line.split_once('#')
-        .map_or(line, |(before_comment, _)| before_comment)
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut escaped = false;
+
+    for (index, character) in line.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match character {
+            '\\' => escaped = true,
+            '\'' if !in_double_quote => in_single_quote = !in_single_quote,
+            '"' if !in_single_quote => in_double_quote = !in_double_quote,
+            '#' if !in_single_quote && !in_double_quote => return &line[..index],
+            _ => {}
+        }
+    }
+
+    line
 }
 
 fn trim_quotes(value: &str) -> &str {

--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -398,14 +398,17 @@ fn parse_catalog_entry(line_number: u32, line: &str) -> Option<Dependency> {
     let without_comment = strip_inline_comment(line);
     let trimmed = without_comment.trim();
     let (name, version) = trimmed.split_once(':')?;
-    let name = name.trim();
+    let raw_name = name.trim();
+    let name = trim_quotes(raw_name);
     let raw_version = version.trim();
     let version = trim_quotes(raw_version);
     if name.is_empty() || version.is_empty() {
         return None;
     }
 
-    let name_start = indent + trimmed.find(name)?;
+    let raw_name_start = indent + trimmed.find(raw_name)?;
+    let name_quote_offset = raw_name.len() - raw_name.trim_start_matches(['"', '\'']).len();
+    let name_start = raw_name_start + name_quote_offset;
     let delimiter_start = line.find(':')?;
     let raw_version_start = line[delimiter_start + 1..].find(raw_version)? + delimiter_start + 1;
     let quote_offset = raw_version.len() - raw_version.trim_start_matches(['"', '\'']).len();
@@ -439,14 +442,17 @@ fn parse_flow_catalog_entry(
     let delimiter = find_top_level_colon(segment)?;
     let name_part = &segment[..delimiter];
     let raw_version_part = &segment[delimiter + 1..];
-    let name = name_part.trim();
+    let raw_name = name_part.trim();
+    let name = trim_quotes(raw_name);
     let raw_version = raw_version_part.trim();
     let version = trim_quotes(raw_version);
     if name.is_empty() || version.is_empty() {
         return None;
     }
 
-    let name_start = segment_start + (name_part.len() - name_part.trim_start().len());
+    let raw_name_start = segment_start + (name_part.len() - name_part.trim_start().len());
+    let name_quote_offset = raw_name.len() - raw_name.trim_start_matches(['"', '\'']).len();
+    let name_start = raw_name_start + name_quote_offset;
     let raw_version_start = segment_start
         + delimiter
         + 1
@@ -489,12 +495,22 @@ fn strip_inline_comment(line: &str) -> &str {
             '\\' => escaped = true,
             '\'' if !in_double_quote => in_single_quote = !in_single_quote,
             '"' if !in_single_quote => in_double_quote = !in_double_quote,
-            '#' if !in_single_quote && !in_double_quote => return &line[..index],
+            '#' if !in_single_quote && !in_double_quote && starts_yaml_comment(line, index) => {
+                return &line[..index];
+            }
             _ => {}
         }
     }
 
     line
+}
+
+fn starts_yaml_comment(line: &str, index: usize) -> bool {
+    index == 0
+        || line[..index]
+            .chars()
+            .next_back()
+            .is_some_and(char::is_whitespace)
 }
 
 fn trim_quotes(value: &str) -> &str {

--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -134,10 +134,10 @@ fn parse_named_catalog_collections(content: &str) -> Vec<NamedCatalog> {
             continue;
         }
 
-        if current_catalog.is_some() && indent <= named_catalog_indent {
-            if let Some(catalog) = current_catalog.take() {
-                catalogs.push(catalog);
-            }
+        if indent <= named_catalog_indent
+            && let Some(catalog) = current_catalog.take()
+        {
+            catalogs.push(catalog);
         }
 
         if current_catalog.is_none() {

--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -49,7 +49,7 @@ pub fn resolve_catalog_references(
                     .iter()
                     .find(|catalog_dependency| catalog_dependency.name == dependency.name)
             {
-                dependency.version = catalog_dependency.version.clone();
+                dependency.resolved_version = Some(catalog_dependency.version.clone());
             } else if let Some(catalog_name) = dependency.version.strip_prefix("catalog:")
                 && let Some(named_catalog) = named_catalogs
                     .iter()
@@ -59,7 +59,7 @@ pub fn resolve_catalog_references(
                     .iter()
                     .find(|catalog_dependency| catalog_dependency.name == dependency.name)
             {
-                dependency.version = catalog_dependency.version.clone();
+                dependency.resolved_version = Some(catalog_dependency.version.clone());
             }
             dependency
         })
@@ -238,7 +238,7 @@ fn parse_inline_named_catalog(
     let delimiter = find_top_level_colon(trimmed)?;
     let name_part = &trimmed[..delimiter];
     let value_part = &trimmed[delimiter + 1..];
-    let name = name_part.trim();
+    let name = trim_quotes(name_part.trim());
     if name.is_empty() {
         return None;
     }
@@ -264,7 +264,7 @@ fn parse_flow_named_catalogs(
             let delimiter = find_top_level_colon(segment.text)?;
             let name_part = &segment.text[..delimiter];
             let value_part = &segment.text[delimiter + 1..];
-            let name = name_part.trim();
+            let name = trim_quotes(name_part.trim());
             if name.is_empty() {
                 return None;
             }
@@ -388,7 +388,7 @@ fn find_top_level_colon(value: &str) -> Option<usize> {
 
 fn parse_named_catalog_header(line: &str) -> Option<&str> {
     let (name, value) = line.split_once(':')?;
-    let name = name.trim();
+    let name = trim_quotes(name.trim());
 
     (!name.is_empty() && value.trim().is_empty()).then_some(name)
 }

--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -1,5 +1,7 @@
 //! Parser for pnpm `pnpm-workspace.yaml` catalog dependencies.
 
+use std::path::{Path, PathBuf};
+
 use super::{Dependency, Parser, Span};
 
 /// Parser for pnpm workspace catalog dependency files.
@@ -64,6 +66,30 @@ pub fn resolve_catalog_references(
         .collect()
 }
 
+/// Find the nearest `pnpm-workspace.yaml` for a package manifest.
+pub async fn find_pnpm_workspace(package_json_path: &Path) -> Option<PathBuf> {
+    let mut directory = package_json_path.parent()?.to_path_buf();
+
+    loop {
+        let candidate = directory.join("pnpm-workspace.yaml");
+        if tokio::fs::metadata(&candidate).await.is_ok() {
+            return Some(candidate);
+        }
+
+        if !directory.pop() {
+            return None;
+        }
+    }
+}
+
+/// Read the nearest `pnpm-workspace.yaml` for a package manifest.
+pub async fn read_pnpm_workspace_for_package(package_json_path: &Path) -> Option<String> {
+    let workspace_path = find_pnpm_workspace(package_json_path).await?;
+    super::lockfile_graph::read_lockfile_capped(&workspace_path)
+        .await
+        .ok()
+}
+
 fn parse_default_catalog(content: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
     let mut in_catalog = false;
@@ -76,6 +102,7 @@ fn parse_default_catalog(content: &str) -> Vec<Dependency> {
             continue;
         }
 
+        let trimmed_start = without_comment.len() - without_comment.trim_start().len();
         let indent = line.len() - line.trim_start().len();
         if in_catalog && indent <= catalog_indent {
             in_catalog = false;
@@ -85,6 +112,10 @@ fn parse_default_catalog(content: &str) -> Vec<Dependency> {
             if trimmed == "catalog:" {
                 in_catalog = true;
                 catalog_indent = indent;
+            } else if let Some(flow_dependencies) =
+                parse_inline_default_catalog(line_number as u32, trimmed, trimmed_start)
+            {
+                dependencies.extend(flow_dependencies);
             }
             continue;
         }
@@ -118,6 +149,7 @@ fn parse_named_catalog_collections(content: &str) -> Vec<NamedCatalog> {
             continue;
         }
 
+        let trimmed_start = without_comment.len() - without_comment.trim_start().len();
         let indent = line.len() - line.trim_start().len();
         if in_catalogs && indent <= catalogs_indent {
             in_catalogs = false;
@@ -130,6 +162,10 @@ fn parse_named_catalog_collections(content: &str) -> Vec<NamedCatalog> {
             if trimmed == "catalogs:" {
                 in_catalogs = true;
                 catalogs_indent = indent;
+            } else if let Some(flow_catalogs) =
+                parse_inline_named_catalogs(line_number as u32, trimmed, trimmed_start)
+            {
+                catalogs.extend(flow_catalogs);
             }
             continue;
         }
@@ -141,6 +177,13 @@ fn parse_named_catalog_collections(content: &str) -> Vec<NamedCatalog> {
         }
 
         if current_catalog.is_none() {
+            if let Some(catalog) =
+                parse_inline_named_catalog(line_number as u32, trimmed, trimmed_start)
+            {
+                catalogs.push(catalog);
+                continue;
+            }
+
             if let Some(name) = parse_named_catalog_header(trimmed) {
                 current_catalog = Some(NamedCatalog {
                     name: name.to_string(),
@@ -167,6 +210,182 @@ fn parse_named_catalog_collections(content: &str) -> Vec<NamedCatalog> {
     catalogs
 }
 
+fn parse_inline_default_catalog(
+    line_number: u32,
+    trimmed: &str,
+    trimmed_start: usize,
+) -> Option<Vec<Dependency>> {
+    let value = trimmed.strip_prefix("catalog:")?;
+    let value_start = trimmed_start + "catalog:".len();
+    parse_flow_catalog_dependencies(line_number, value, value_start)
+}
+
+fn parse_inline_named_catalogs(
+    line_number: u32,
+    trimmed: &str,
+    trimmed_start: usize,
+) -> Option<Vec<NamedCatalog>> {
+    let value = trimmed.strip_prefix("catalogs:")?;
+    let value_start = trimmed_start + "catalogs:".len();
+    parse_flow_named_catalogs(line_number, value, value_start)
+}
+
+fn parse_inline_named_catalog(
+    line_number: u32,
+    trimmed: &str,
+    trimmed_start: usize,
+) -> Option<NamedCatalog> {
+    let delimiter = find_top_level_colon(trimmed)?;
+    let name_part = &trimmed[..delimiter];
+    let value_part = &trimmed[delimiter + 1..];
+    let name = name_part.trim();
+    if name.is_empty() {
+        return None;
+    }
+
+    let value_start = trimmed_start + delimiter + 1;
+    let dependencies = parse_flow_catalog_dependencies(line_number, value_part, value_start)?;
+
+    Some(NamedCatalog {
+        name: name.to_string(),
+        dependencies,
+    })
+}
+
+fn parse_flow_named_catalogs(
+    line_number: u32,
+    value: &str,
+    value_start: usize,
+) -> Option<Vec<NamedCatalog>> {
+    let (body, body_start) = flow_map_body(value, value_start)?;
+    let catalogs = split_flow_segments(body)
+        .into_iter()
+        .filter_map(|segment| {
+            let delimiter = find_top_level_colon(segment.text)?;
+            let name_part = &segment.text[..delimiter];
+            let value_part = &segment.text[delimiter + 1..];
+            let name = name_part.trim();
+            if name.is_empty() {
+                return None;
+            }
+
+            let dependencies = parse_flow_catalog_dependencies(
+                line_number,
+                value_part,
+                body_start + segment.start + delimiter + 1,
+            )?;
+
+            Some(NamedCatalog {
+                name: name.to_string(),
+                dependencies,
+            })
+        })
+        .collect();
+
+    Some(catalogs)
+}
+
+fn parse_flow_catalog_dependencies(
+    line_number: u32,
+    value: &str,
+    value_start: usize,
+) -> Option<Vec<Dependency>> {
+    let (body, body_start) = flow_map_body(value, value_start)?;
+    Some(
+        split_flow_segments(body)
+            .into_iter()
+            .filter_map(|segment| {
+                parse_flow_catalog_entry(line_number, segment.text, body_start + segment.start)
+            })
+            .collect(),
+    )
+}
+
+fn flow_map_body(value: &str, value_start: usize) -> Option<(&str, usize)> {
+    let leading = value.len() - value.trim_start().len();
+    let trimmed = value.trim();
+    let body = trimmed.strip_prefix('{')?.strip_suffix('}')?;
+    Some((body, value_start + leading + 1))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FlowSegment<'a> {
+    text: &'a str,
+    start: usize,
+}
+
+fn split_flow_segments(value: &str) -> Vec<FlowSegment<'_>> {
+    let mut segments = Vec::new();
+    let mut start = 0usize;
+    let mut depth = 0usize;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut escaped = false;
+
+    for (index, character) in value.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match character {
+            '\\' => escaped = true,
+            '\'' if !in_double_quote => in_single_quote = !in_single_quote,
+            '"' if !in_single_quote => in_double_quote = !in_double_quote,
+            '{' if !in_single_quote && !in_double_quote => depth += 1,
+            '}' if !in_single_quote && !in_double_quote && depth > 0 => depth -= 1,
+            ',' if !in_single_quote && !in_double_quote && depth == 0 => {
+                push_flow_segment(&mut segments, value, start, index);
+                start = index + character.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    push_flow_segment(&mut segments, value, start, value.len());
+    segments
+}
+
+fn push_flow_segment<'a>(
+    segments: &mut Vec<FlowSegment<'a>>,
+    value: &'a str,
+    start: usize,
+    end: usize,
+) {
+    if !value[start..end].trim().is_empty() {
+        segments.push(FlowSegment {
+            text: &value[start..end],
+            start,
+        });
+    }
+}
+
+fn find_top_level_colon(value: &str) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut escaped = false;
+
+    for (index, character) in value.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match character {
+            '\\' => escaped = true,
+            '\'' if !in_double_quote => in_single_quote = !in_single_quote,
+            '"' if !in_single_quote => in_double_quote = !in_double_quote,
+            '{' if !in_single_quote && !in_double_quote => depth += 1,
+            '}' if !in_single_quote && !in_double_quote && depth > 0 => depth -= 1,
+            ':' if !in_single_quote && !in_double_quote && depth == 0 => return Some(index),
+            _ => {}
+        }
+    }
+
+    None
+}
+
 fn parse_named_catalog_header(line: &str) -> Option<&str> {
     let (name, value) = line.split_once(':')?;
     let name = name.trim();
@@ -189,6 +408,49 @@ fn parse_catalog_entry(line_number: u32, line: &str) -> Option<Dependency> {
     let name_start = indent + trimmed.find(name)?;
     let delimiter_start = line.find(':')?;
     let raw_version_start = line[delimiter_start + 1..].find(raw_version)? + delimiter_start + 1;
+    let quote_offset = raw_version.len() - raw_version.trim_start_matches(['"', '\'']).len();
+    let version_start = raw_version_start + quote_offset;
+
+    Some(Dependency {
+        name: name.to_string(),
+        version: version.to_string(),
+        name_span: Span {
+            line: line_number,
+            line_start: name_start as u32,
+            line_end: (name_start + name.len()) as u32,
+        },
+        version_span: Span {
+            line: line_number,
+            line_start: version_start as u32,
+            line_end: (version_start + version.len()) as u32,
+        },
+        dev: false,
+        optional: false,
+        registry: None,
+        resolved_version: None,
+    })
+}
+
+fn parse_flow_catalog_entry(
+    line_number: u32,
+    segment: &str,
+    segment_start: usize,
+) -> Option<Dependency> {
+    let delimiter = find_top_level_colon(segment)?;
+    let name_part = &segment[..delimiter];
+    let raw_version_part = &segment[delimiter + 1..];
+    let name = name_part.trim();
+    let raw_version = raw_version_part.trim();
+    let version = trim_quotes(raw_version);
+    if name.is_empty() || version.is_empty() {
+        return None;
+    }
+
+    let name_start = segment_start + (name_part.len() - name_part.trim_start().len());
+    let raw_version_start = segment_start
+        + delimiter
+        + 1
+        + (raw_version_part.len() - raw_version_part.trim_start().len());
     let quote_offset = raw_version.len() - raw_version.trim_start_matches(['"', '\'']).len();
     let version_start = raw_version_start + quote_offset;
 

--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -6,6 +6,12 @@ use super::{Dependency, Parser, Span};
 #[derive(Debug, Default)]
 pub struct PnpmWorkspaceParser;
 
+#[derive(Debug)]
+struct NamedCatalog {
+    name: String,
+    dependencies: Vec<Dependency>,
+}
+
 impl PnpmWorkspaceParser {
     /// Creates a new [`PnpmWorkspaceParser`] instance.
     pub fn new() -> Self {
@@ -31,12 +37,23 @@ pub fn resolve_catalog_references(
     };
 
     let catalog_dependencies = parse_default_catalog(workspace_content);
+    let named_catalogs = parse_named_catalog_collections(workspace_content);
 
     dependencies
         .into_iter()
         .map(|mut dependency| {
             if dependency.version == "catalog:"
                 && let Some(catalog_dependency) = catalog_dependencies
+                    .iter()
+                    .find(|catalog_dependency| catalog_dependency.name == dependency.name)
+            {
+                dependency.version = catalog_dependency.version.clone();
+            } else if let Some(catalog_name) = dependency.version.strip_prefix("catalog:")
+                && let Some(named_catalog) = named_catalogs
+                    .iter()
+                    .find(|named_catalog| named_catalog.name == catalog_name)
+                && let Some(catalog_dependency) = named_catalog
+                    .dependencies
                     .iter()
                     .find(|catalog_dependency| catalog_dependency.name == dependency.name)
             {
@@ -81,10 +98,17 @@ fn parse_default_catalog(content: &str) -> Vec<Dependency> {
 }
 
 fn parse_named_catalogs(content: &str) -> Vec<Dependency> {
-    let mut dependencies = Vec::new();
+    parse_named_catalog_collections(content)
+        .into_iter()
+        .flat_map(|catalog| catalog.dependencies)
+        .collect()
+}
+
+fn parse_named_catalog_collections(content: &str) -> Vec<NamedCatalog> {
+    let mut catalogs = Vec::new();
+    let mut current_catalog: Option<NamedCatalog> = None;
     let mut in_catalogs = false;
     let mut catalogs_indent = 0usize;
-    let mut in_named_catalog = false;
     let mut named_catalog_indent = 0usize;
 
     for (line_number, line) in content.lines().enumerate() {
@@ -97,7 +121,9 @@ fn parse_named_catalogs(content: &str) -> Vec<Dependency> {
         let indent = line.len() - line.trim_start().len();
         if in_catalogs && indent <= catalogs_indent {
             in_catalogs = false;
-            in_named_catalog = false;
+            if let Some(catalog) = current_catalog.take() {
+                catalogs.push(catalog);
+            }
         }
 
         if !in_catalogs {
@@ -108,32 +134,44 @@ fn parse_named_catalogs(content: &str) -> Vec<Dependency> {
             continue;
         }
 
-        if in_named_catalog && indent <= named_catalog_indent {
-            in_named_catalog = false;
+        if current_catalog.is_some() && indent <= named_catalog_indent {
+            if let Some(catalog) = current_catalog.take() {
+                catalogs.push(catalog);
+            }
         }
 
-        if !in_named_catalog {
-            if is_named_catalog_header(trimmed) {
-                in_named_catalog = true;
+        if current_catalog.is_none() {
+            if let Some(name) = parse_named_catalog_header(trimmed) {
+                current_catalog = Some(NamedCatalog {
+                    name: name.to_string(),
+                    dependencies: Vec::new(),
+                });
                 named_catalog_indent = indent;
             }
             continue;
         }
 
         if let Some(dependency) = parse_catalog_entry(line_number as u32, line) {
-            dependencies.push(dependency);
+            current_catalog
+                .as_mut()
+                .expect("current named catalog")
+                .dependencies
+                .push(dependency);
         }
     }
 
-    dependencies
+    if let Some(catalog) = current_catalog {
+        catalogs.push(catalog);
+    }
+
+    catalogs
 }
 
-fn is_named_catalog_header(line: &str) -> bool {
-    let Some((name, value)) = line.split_once(':') else {
-        return false;
-    };
+fn parse_named_catalog_header(line: &str) -> Option<&str> {
+    let (name, value) = line.split_once(':')?;
+    let name = name.trim();
 
-    !name.trim().is_empty() && value.trim().is_empty()
+    (!name.is_empty() && value.trim().is_empty()).then_some(name)
 }
 
 fn parse_catalog_entry(line_number: u32, line: &str) -> Option<Dependency> {

--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -1,0 +1,107 @@
+//! Parser for pnpm `pnpm-workspace.yaml` catalog dependencies.
+
+use super::{Dependency, Parser, Span};
+
+/// Parser for pnpm workspace catalog dependency files.
+#[derive(Debug, Default)]
+pub struct PnpmWorkspaceParser;
+
+impl PnpmWorkspaceParser {
+    /// Creates a new [`PnpmWorkspaceParser`] instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Parser for PnpmWorkspaceParser {
+    fn parse(&self, content: &str) -> Vec<Dependency> {
+        parse_default_catalog(content)
+    }
+}
+
+fn parse_default_catalog(content: &str) -> Vec<Dependency> {
+    let mut dependencies = Vec::new();
+    let mut in_catalog = false;
+    let mut catalog_indent = 0usize;
+
+    for (line_number, line) in content.lines().enumerate() {
+        let without_comment = strip_inline_comment(line);
+        let trimmed = without_comment.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let indent = line.len() - line.trim_start().len();
+        if in_catalog && indent <= catalog_indent {
+            in_catalog = false;
+        }
+
+        if !in_catalog {
+            if trimmed == "catalog:" {
+                in_catalog = true;
+                catalog_indent = indent;
+            }
+            continue;
+        }
+
+        if let Some(dependency) = parse_catalog_entry(line_number as u32, line) {
+            dependencies.push(dependency);
+        }
+    }
+
+    dependencies
+}
+
+fn parse_catalog_entry(line_number: u32, line: &str) -> Option<Dependency> {
+    let indent = line.len() - line.trim_start().len();
+    let without_comment = strip_inline_comment(line);
+    let trimmed = without_comment.trim();
+    let (name, version) = trimmed.split_once(':')?;
+    let name = name.trim();
+    let raw_version = version.trim();
+    let version = trim_quotes(raw_version);
+    if name.is_empty() || version.is_empty() {
+        return None;
+    }
+
+    let name_start = indent + trimmed.find(name)?;
+    let raw_version_start = line.find(raw_version)?;
+    let quote_offset = raw_version.len() - raw_version.trim_start_matches(['"', '\'']).len();
+    let version_start = raw_version_start + quote_offset;
+
+    Some(Dependency {
+        name: name.to_string(),
+        version: version.to_string(),
+        name_span: Span {
+            line: line_number,
+            line_start: name_start as u32,
+            line_end: (name_start + name.len()) as u32,
+        },
+        version_span: Span {
+            line: line_number,
+            line_start: version_start as u32,
+            line_end: (version_start + version.len()) as u32,
+        },
+        dev: false,
+        optional: false,
+        registry: None,
+        resolved_version: None,
+    })
+}
+
+fn strip_inline_comment(line: &str) -> &str {
+    line.split_once('#')
+        .map_or(line, |(before_comment, _)| before_comment)
+}
+
+fn trim_quotes(value: &str) -> &str {
+    value
+        .strip_prefix('"')
+        .and_then(|unquoted| unquoted.strip_suffix('"'))
+        .or_else(|| {
+            value
+                .strip_prefix('\'')
+                .and_then(|unquoted| unquoted.strip_suffix('\''))
+        })
+        .unwrap_or(value)
+}

--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -15,7 +15,9 @@ impl PnpmWorkspaceParser {
 
 impl Parser for PnpmWorkspaceParser {
     fn parse(&self, content: &str) -> Vec<Dependency> {
-        parse_default_catalog(content)
+        let mut dependencies = parse_default_catalog(content);
+        dependencies.extend(parse_named_catalogs(content));
+        dependencies
     }
 }
 
@@ -28,7 +30,7 @@ pub fn resolve_catalog_references(
         return dependencies;
     };
 
-    let catalog_dependencies = PnpmWorkspaceParser::new().parse(workspace_content);
+    let catalog_dependencies = parse_default_catalog(workspace_content);
 
     dependencies
         .into_iter()
@@ -76,6 +78,62 @@ fn parse_default_catalog(content: &str) -> Vec<Dependency> {
     }
 
     dependencies
+}
+
+fn parse_named_catalogs(content: &str) -> Vec<Dependency> {
+    let mut dependencies = Vec::new();
+    let mut in_catalogs = false;
+    let mut catalogs_indent = 0usize;
+    let mut in_named_catalog = false;
+    let mut named_catalog_indent = 0usize;
+
+    for (line_number, line) in content.lines().enumerate() {
+        let without_comment = strip_inline_comment(line);
+        let trimmed = without_comment.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let indent = line.len() - line.trim_start().len();
+        if in_catalogs && indent <= catalogs_indent {
+            in_catalogs = false;
+            in_named_catalog = false;
+        }
+
+        if !in_catalogs {
+            if trimmed == "catalogs:" {
+                in_catalogs = true;
+                catalogs_indent = indent;
+            }
+            continue;
+        }
+
+        if in_named_catalog && indent <= named_catalog_indent {
+            in_named_catalog = false;
+        }
+
+        if !in_named_catalog {
+            if is_named_catalog_header(trimmed) {
+                in_named_catalog = true;
+                named_catalog_indent = indent;
+            }
+            continue;
+        }
+
+        if let Some(dependency) = parse_catalog_entry(line_number as u32, line) {
+            dependencies.push(dependency);
+        }
+    }
+
+    dependencies
+}
+
+fn is_named_catalog_header(line: &str) -> bool {
+    let Some((name, value)) = line.split_once(':') else {
+        return false;
+    };
+
+    !name.trim().is_empty() && value.trim().is_empty()
 }
 
 fn parse_catalog_entry(line_number: u32, line: &str) -> Option<Dependency> {

--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -19,6 +19,32 @@ impl Parser for PnpmWorkspaceParser {
     }
 }
 
+/// Resolve npm `catalog:` dependency references against a pnpm workspace file.
+pub fn resolve_catalog_references(
+    dependencies: Vec<Dependency>,
+    workspace_content: Option<&str>,
+) -> Vec<Dependency> {
+    let Some(workspace_content) = workspace_content else {
+        return dependencies;
+    };
+
+    let catalog_dependencies = PnpmWorkspaceParser::new().parse(workspace_content);
+
+    dependencies
+        .into_iter()
+        .map(|mut dependency| {
+            if dependency.version == "catalog:"
+                && let Some(catalog_dependency) = catalog_dependencies
+                    .iter()
+                    .find(|catalog_dependency| catalog_dependency.name == dependency.name)
+            {
+                dependency.version = catalog_dependency.version.clone();
+            }
+            dependency
+        })
+        .collect()
+}
+
 fn parse_default_catalog(content: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
     let mut in_catalog = false;

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -194,7 +194,7 @@ pub async fn create_code_actions(
     //   - ignore_candidates:  in-range, non-ignored — eligible for the Ignore action
     //                         (property refs CAN still be ignored even though they
     //                         can't safely be Updated)
-    //   - update_candidates:  in-range, non-ignored, NOT property reference —
+    //   - update_candidates:  in-range, non-ignored, NOT managed indirectly —
     //                         eligible for individual Update actions
     let non_ignored: Vec<&Dependency> = dependencies
         .iter()
@@ -210,7 +210,7 @@ pub async fn create_code_actions(
     let update_candidates: Vec<&Dependency> = ignore_candidates
         .iter()
         .copied()
-        .filter(|dep| !is_property_reference(dep))
+        .filter(|dep| !is_indirectly_managed_version(dep))
         .collect();
 
     let mut actions: Vec<CodeActionOrCommand> = Vec::new();
@@ -245,6 +245,14 @@ pub async fn create_code_actions(
 /// sharing the same property — so the "update version" quick-fix is suppressed.
 fn is_property_reference(dep: &Dependency) -> bool {
     dep.version.starts_with("${") && dep.version.ends_with('}')
+}
+
+fn is_catalog_reference(dep: &Dependency) -> bool {
+    dep.version.starts_with("catalog:")
+}
+
+fn is_indirectly_managed_version(dep: &Dependency) -> bool {
+    is_property_reference(dep) || is_catalog_reference(dep)
 }
 
 /// Extract Python version operator prefix from a version string (e.g., "~=" from "~=14.3")
@@ -362,7 +370,7 @@ async fn create_update_all_action(
     let filtered: Vec<&Dependency> = dependencies
         .iter()
         .copied()
-        .filter(|dep| !is_property_reference(dep))
+        .filter(|dep| !is_indirectly_managed_version(dep))
         .collect();
 
     let cache_keys: Vec<String> = filtered.iter().map(|dep| cache_key_fn(&dep.name)).collect();
@@ -569,6 +577,50 @@ mod tests {
             }
             _ => panic!("Expected CodeAction"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_no_update_action_for_catalog_reference() {
+        let cache = MemoryCache::new();
+        cache
+            .insert(
+                "test:react".to_string(),
+                VersionInfo {
+                    latest: Some("19.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        let mut react = create_test_dependency("react", "catalog:", 5);
+        react.resolved_version = Some("^18.3.1".to_string());
+        let deps = vec![react];
+        let uri = Url::parse("file:///test/package.json").unwrap();
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 10,
+                character: 0,
+            },
+        };
+
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Npm,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        )
+        .await;
+
+        assert_eq!(actions.len(), 0);
     }
 
     #[tokio::test]

--- a/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
+++ b/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
@@ -51,6 +51,31 @@ fn default_catalog_shapes_determine_discovered_npm_dependencies() {
 }
 
 #[test]
+fn named_catalog_shapes_determine_discovered_npm_dependencies() {
+    // Given a workspace file "pnpm-workspace.yaml" represented as compact YAML "<workspace_yaml>"
+    // When Dependi inspects "pnpm-workspace.yaml"
+    // Then the discovered npm dependencies are "<expected_dependencies>"
+    let cases = [
+        (
+            "packages: [packages/*]\ncatalogs:\n  react18:\n    react: ^18.2.0\n    react-dom: ^18.2.0\n",
+            vec![
+                ("react".to_string(), "^18.2.0".to_string()),
+                ("react-dom".to_string(), "^18.2.0".to_string()),
+            ],
+        ),
+        (
+            "packages: [packages/*]\ncatalogs:\n  react18: {}\n",
+            Vec::new(),
+        ),
+        ("packages: [packages/*]\ncatalogs: {}\n", Vec::new()),
+    ];
+
+    for (workspace_yaml, expected_dependencies) in cases {
+        assert_eq!(dependency_pairs(workspace_yaml), expected_dependencies);
+    }
+}
+
+#[test]
 fn react_catalog_shorthand_resolves_through_the_default_catalog() {
     // Given a workspace file "pnpm-workspace.yaml" containing:
     //   packages:
@@ -91,4 +116,31 @@ catalog:
         .find(|dependency| dependency.name == "react")
         .unwrap();
     assert_eq!(react.version, "^18.3.1");
+}
+
+#[test]
+fn catalog_shorthand_ignores_named_catalog_entries_without_default_catalog() {
+    let workspace_yaml = r#"
+packages:
+  - packages/*
+
+catalogs:
+  react18:
+    react: ^18.2.0
+"#;
+    let package_json = r#"{
+  "name": "@example/app",
+  "dependencies": {
+    "react": "catalog:"
+  }
+}"#;
+
+    let dependencies =
+        resolve_catalog_references(NpmParser::new().parse(package_json), Some(workspace_yaml));
+
+    let react = dependencies
+        .iter()
+        .find(|dependency| dependency.name == "react")
+        .unwrap();
+    assert_eq!(react.version, "catalog:");
 }

--- a/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
+++ b/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
@@ -1,0 +1,50 @@
+use dependi_lsp::parsers::Parser;
+use dependi_lsp::parsers::pnpm_workspace::PnpmWorkspaceParser;
+
+fn dependency_pairs(content: &str) -> Vec<(String, String)> {
+    PnpmWorkspaceParser::new()
+        .parse(content)
+        .into_iter()
+        .map(|dependency| (dependency.name, dependency.version))
+        .collect()
+}
+
+#[test]
+fn default_catalog_entries_accept_inline_comments_and_quoted_versions() {
+    let workspace_yaml = r#"
+packages: [packages/*]
+catalog: # shared dependency versions
+  react: "^18.3.1" # pinned for React 18 apps
+  redux: '^5.0.1'
+"#;
+
+    assert_eq!(
+        dependency_pairs(workspace_yaml),
+        vec![
+            ("react".to_string(), "^18.3.1".to_string()),
+            ("redux".to_string(), "^5.0.1".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn default_catalog_shapes_determine_discovered_npm_dependencies() {
+    // Given a workspace file "pnpm-workspace.yaml" represented as compact YAML "<workspace_yaml>"
+    // When Dependi inspects "pnpm-workspace.yaml"
+    // Then the discovered npm dependencies are "<expected_dependencies>"
+    let cases = [
+        (
+            "packages: [packages/*]\ncatalog:\n  react: ^18.3.1\n  redux: ^5.0.1\n",
+            vec![
+                ("react".to_string(), "^18.3.1".to_string()),
+                ("redux".to_string(), "^5.0.1".to_string()),
+            ],
+        ),
+        ("packages: [packages/*]\ncatalog: {}\n", Vec::new()),
+        ("packages: [packages/*]\n", Vec::new()),
+    ];
+
+    for (workspace_yaml, expected_dependencies) in cases {
+        assert_eq!(dependency_pairs(workspace_yaml), expected_dependencies);
+    }
+}

--- a/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
+++ b/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
@@ -1,5 +1,6 @@
 use dependi_lsp::parsers::Parser;
-use dependi_lsp::parsers::pnpm_workspace::PnpmWorkspaceParser;
+use dependi_lsp::parsers::npm::NpmParser;
+use dependi_lsp::parsers::pnpm_workspace::{PnpmWorkspaceParser, resolve_catalog_references};
 
 fn dependency_pairs(content: &str) -> Vec<(String, String)> {
     PnpmWorkspaceParser::new()
@@ -47,4 +48,47 @@ fn default_catalog_shapes_determine_discovered_npm_dependencies() {
     for (workspace_yaml, expected_dependencies) in cases {
         assert_eq!(dependency_pairs(workspace_yaml), expected_dependencies);
     }
+}
+
+#[test]
+fn react_catalog_shorthand_resolves_through_the_default_catalog() {
+    // Given a workspace file "pnpm-workspace.yaml" containing:
+    //   packages:
+    //     - packages/*
+    //
+    //   catalog:
+    //     react: ^18.3.1
+    //     redux: ^5.0.1
+    // And a package file "packages/example-app/package.json" containing:
+    //   {
+    //     "name": "@example/app",
+    //     "dependencies": {
+    //       "react": "catalog:"
+    //     }
+    //   }
+    // When Dependi inspects "packages/example-app/package.json"
+    // Then the dependency "react" resolves to npm version range "^18.3.1"
+    let workspace_yaml = r#"
+packages:
+  - packages/*
+
+catalog:
+  react: ^18.3.1
+  redux: ^5.0.1
+"#;
+    let package_json = r#"{
+  "name": "@example/app",
+  "dependencies": {
+    "react": "catalog:"
+  }
+}"#;
+
+    let dependencies =
+        resolve_catalog_references(NpmParser::new().parse(package_json), Some(workspace_yaml));
+
+    let react = dependencies
+        .iter()
+        .find(|dependency| dependency.name == "react")
+        .unwrap();
+    assert_eq!(react.version, "^18.3.1");
 }

--- a/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
+++ b/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
@@ -19,20 +19,27 @@ fn default_catalog_entries_accept_inline_comments_and_quoted_versions() {
     let workspace_yaml = r#"
 packages: [packages/*]
 catalog: # shared dependency versions
+  "@types/node": "^20.0.0"
   git-dep: "github:example/repo#v1.2.3" # pinned git ref
   react: "^18.3.1" # pinned for React 18 apps
   redux: '^5.0.1'
+  unquoted-git: github:example/repo#v1.2.3 # plain scalar keeps git ref
 "#;
 
     assert_eq!(
         dependency_pairs(workspace_yaml),
         vec![
+            ("@types/node".to_string(), "^20.0.0".to_string()),
             (
                 "git-dep".to_string(),
                 "github:example/repo#v1.2.3".to_string(),
             ),
             ("react".to_string(), "^18.3.1".to_string()),
             ("redux".to_string(), "^5.0.1".to_string()),
+            (
+                "unquoted-git".to_string(),
+                "github:example/repo#v1.2.3".to_string(),
+            ),
         ]
     );
 }
@@ -51,8 +58,13 @@ fn default_catalog_shapes_determine_discovered_npm_dependencies() {
             ],
         ),
         (
-            "packages: [packages/*]\ncatalog: { react: ^18.3.1, redux: ^5.0.1 }\n",
+            "packages: [packages/*]\ncatalog: { \"@types/node\": ^20.0.0, git-dep: github:example/repo#v1.2.3, react: ^18.3.1, redux: ^5.0.1 }\n",
             vec![
+                ("@types/node".to_string(), "^20.0.0".to_string()),
+                (
+                    "git-dep".to_string(),
+                    "github:example/repo#v1.2.3".to_string(),
+                ),
                 ("react".to_string(), "^18.3.1".to_string()),
                 ("redux".to_string(), "^5.0.1".to_string()),
             ],

--- a/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
+++ b/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
@@ -144,3 +144,48 @@ catalogs:
         .unwrap();
     assert_eq!(react.version, "catalog:");
 }
+
+#[test]
+fn react_dom_named_catalog_reference_resolves_through_react18() {
+    // Given a workspace file "pnpm-workspace.yaml" containing:
+    //   packages:
+    //     - packages/*
+    //
+    //   catalogs:
+    //     react18:
+    //       react: ^18.2.0
+    //       react-dom: ^18.2.0
+    // And a package file "packages/example-components/package.json" containing:
+    //   {
+    //     "name": "@example/components",
+    //     "dependencies": {
+    //       "react-dom": "catalog:react18"
+    //     }
+    //   }
+    // When Dependi inspects "packages/example-components/package.json"
+    // Then the dependency "react-dom" resolves to npm version range "^18.2.0"
+    let workspace_yaml = r#"
+packages:
+  - packages/*
+
+catalogs:
+  react18:
+    react: ^18.2.0
+    react-dom: ^18.2.0
+"#;
+    let package_json = r#"{
+  "name": "@example/components",
+  "dependencies": {
+    "react-dom": "catalog:react18"
+  }
+}"#;
+
+    let dependencies =
+        resolve_catalog_references(NpmParser::new().parse(package_json), Some(workspace_yaml));
+
+    let react_dom = dependencies
+        .iter()
+        .find(|dependency| dependency.name == "react-dom")
+        .unwrap();
+    assert_eq!(react_dom.version, "^18.2.0");
+}

--- a/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
+++ b/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
@@ -1,6 +1,8 @@
 use dependi_lsp::parsers::Parser;
 use dependi_lsp::parsers::npm::NpmParser;
-use dependi_lsp::parsers::pnpm_workspace::{PnpmWorkspaceParser, resolve_catalog_references};
+use dependi_lsp::parsers::pnpm_workspace::{
+    PnpmWorkspaceParser, read_pnpm_workspace_for_package, resolve_catalog_references,
+};
 
 fn dependency_pairs(content: &str) -> Vec<(String, String)> {
     let mut pairs = PnpmWorkspaceParser::new()
@@ -48,6 +50,13 @@ fn default_catalog_shapes_determine_discovered_npm_dependencies() {
                 ("redux".to_string(), "^5.0.1".to_string()),
             ],
         ),
+        (
+            "packages: [packages/*]\ncatalog: { react: ^18.3.1, redux: ^5.0.1 }\n",
+            vec![
+                ("react".to_string(), "^18.3.1".to_string()),
+                ("redux".to_string(), "^5.0.1".to_string()),
+            ],
+        ),
         ("packages: [packages/*]\ncatalog: {}\n", Vec::new()),
         ("packages: [packages/*]\n", Vec::new()),
     ];
@@ -65,6 +74,20 @@ fn named_catalog_shapes_determine_discovered_npm_dependencies() {
     let cases = [
         (
             "packages: [packages/*]\ncatalogs:\n  react18:\n    react: ^18.2.0\n    react-dom: ^18.2.0\n",
+            vec![
+                ("react".to_string(), "^18.2.0".to_string()),
+                ("react-dom".to_string(), "^18.2.0".to_string()),
+            ],
+        ),
+        (
+            "packages: [packages/*]\ncatalogs: { react18: { react: ^18.2.0, react-dom: ^18.2.0 } }\n",
+            vec![
+                ("react".to_string(), "^18.2.0".to_string()),
+                ("react-dom".to_string(), "^18.2.0".to_string()),
+            ],
+        ),
+        (
+            "packages: [packages/*]\ncatalogs:\n  react18: { react: ^18.2.0, react-dom: ^18.2.0 }\n",
             vec![
                 ("react".to_string(), "^18.2.0".to_string()),
                 ("react-dom".to_string(), "^18.2.0".to_string()),
@@ -195,4 +218,41 @@ catalogs:
         .find(|dependency| dependency.name == "react-dom")
         .unwrap();
     assert_eq!(react_dom.version, "^18.2.0");
+}
+
+#[tokio::test]
+async fn package_json_catalog_resolution_reads_nearest_workspace_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let workspace_path = tmp.path().join("pnpm-workspace.yaml");
+    let package_dir = tmp.path().join("packages").join("example-app");
+    let package_path = package_dir.join("package.json");
+
+    std::fs::create_dir_all(&package_dir).expect("create package dir");
+    std::fs::write(
+        &workspace_path,
+        "packages: [packages/*]\ncatalog: { react: ^18.3.1 }\n",
+    )
+    .expect("write workspace");
+    std::fs::write(
+        &package_path,
+        r#"{
+  "dependencies": {
+    "react": "catalog:"
+  }
+}"#,
+    )
+    .expect("write package");
+
+    let package_json = std::fs::read_to_string(&package_path).expect("read package");
+    let workspace_content = read_pnpm_workspace_for_package(&package_path).await;
+    let dependencies = resolve_catalog_references(
+        NpmParser::new().parse(&package_json),
+        workspace_content.as_deref(),
+    );
+
+    let react = dependencies
+        .iter()
+        .find(|dependency| dependency.name == "react")
+        .unwrap();
+    assert_eq!(react.version, "^18.3.1");
 }

--- a/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
+++ b/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
@@ -3,11 +3,13 @@ use dependi_lsp::parsers::npm::NpmParser;
 use dependi_lsp::parsers::pnpm_workspace::{PnpmWorkspaceParser, resolve_catalog_references};
 
 fn dependency_pairs(content: &str) -> Vec<(String, String)> {
-    PnpmWorkspaceParser::new()
+    let mut pairs = PnpmWorkspaceParser::new()
         .parse(content)
         .into_iter()
         .map(|dependency| (dependency.name, dependency.version))
-        .collect()
+        .collect::<Vec<_>>();
+    pairs.sort_unstable();
+    pairs
 }
 
 #[test]
@@ -15,6 +17,7 @@ fn default_catalog_entries_accept_inline_comments_and_quoted_versions() {
     let workspace_yaml = r#"
 packages: [packages/*]
 catalog: # shared dependency versions
+  git-dep: "github:example/repo#v1.2.3" # pinned git ref
   react: "^18.3.1" # pinned for React 18 apps
   redux: '^5.0.1'
 "#;
@@ -22,6 +25,10 @@ catalog: # shared dependency versions
     assert_eq!(
         dependency_pairs(workspace_yaml),
         vec![
+            (
+                "git-dep".to_string(),
+                "github:example/repo#v1.2.3".to_string(),
+            ),
             ("react".to_string(), "^18.3.1".to_string()),
             ("redux".to_string(), "^5.0.1".to_string()),
         ]

--- a/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
+++ b/dependi-lsp/tests/pnpm_workspace_catalog_test.rs
@@ -157,7 +157,9 @@ catalog:
         .iter()
         .find(|dependency| dependency.name == "react")
         .unwrap();
-    assert_eq!(react.version, "^18.3.1");
+    assert_eq!(react.version, "catalog:");
+    assert_eq!(react.resolved_version.as_deref(), Some("^18.3.1"));
+    assert_eq!(react.effective_version(), "^18.3.1");
 }
 
 #[test]
@@ -185,6 +187,7 @@ catalogs:
         .find(|dependency| dependency.name == "react")
         .unwrap();
     assert_eq!(react.version, "catalog:");
+    assert_eq!(react.resolved_version, None);
 }
 
 #[test]
@@ -229,7 +232,37 @@ catalogs:
         .iter()
         .find(|dependency| dependency.name == "react-dom")
         .unwrap();
-    assert_eq!(react_dom.version, "^18.2.0");
+    assert_eq!(react_dom.version, "catalog:react18");
+    assert_eq!(react_dom.resolved_version.as_deref(), Some("^18.2.0"));
+    assert_eq!(react_dom.effective_version(), "^18.2.0");
+}
+
+#[test]
+fn quoted_named_catalog_reference_resolves_through_unquoted_catalog_name() {
+    let workspace_yaml = r#"
+packages:
+  - packages/*
+
+catalogs:
+  "react18":
+    react: ^18.2.0
+"#;
+    let package_json = r#"{
+  "name": "@example/app",
+  "dependencies": {
+    "react": "catalog:react18"
+  }
+}"#;
+
+    let dependencies =
+        resolve_catalog_references(NpmParser::new().parse(package_json), Some(workspace_yaml));
+
+    let react = dependencies
+        .iter()
+        .find(|dependency| dependency.name == "react")
+        .unwrap();
+    assert_eq!(react.version, "catalog:react18");
+    assert_eq!(react.resolved_version.as_deref(), Some("^18.2.0"));
 }
 
 #[tokio::test]
@@ -266,5 +299,6 @@ async fn package_json_catalog_resolution_reads_nearest_workspace_file() {
         .iter()
         .find(|dependency| dependency.name == "react")
         .unwrap();
-    assert_eq!(react.version, "^18.3.1");
+    assert_eq!(react.version, "catalog:");
+    assert_eq!(react.resolved_version.as_deref(), Some("^18.3.1"));
 }


### PR DESCRIPTION
## Goal
Add support for `pnpm-workspace.yaml` catalog-managed dependencies so Node.js/TypeScript developers in pnpm monorepos can use Dependi without switching editors.

## Scenario PRs
- #314: default catalog entry discovery; covers issues #292-#294
- #315: default `catalog:` package reference resolution; covers issues #295-#302
- #316: named catalog entry discovery; covers issues #303-#305
- #317: named `catalog:react18` package reference resolution; covers issues #306-#313

## Verification
- `cargo test --manifest-path dependi-lsp/Cargo.toml --test pnpm_workspace_catalog_test`
- `cargo test --manifest-path dependi-lsp/Cargo.toml --lib parsers`
- Scenario PR checks passed before merge into the integration branch.

## ATDD Artifacts
- `specs/pnpm-workspace-catalog-support/`
- Parent/user story issue: #291

## Escalations
None.

Checkpoint: final integration PR opened for human review. This PR should not be auto-merged by the ATDD runner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `pnpm` workspace catalog support by parsing `pnpm-workspace.yaml` and resolving `catalog:` and `catalog:<name>` references in npm packages. Resolution runs in the LSP and scan command by reading the nearest workspace file, meeting #291.

- New Features
  - Parse default and named catalogs from block and flow map YAML (supports inline comments, quotes, and escaped characters).
  - Resolve `catalog:` from the default catalog and `catalog:<name>` from named catalogs during LSP processing and scans.

- Bug Fixes
  - Preserve `catalog:`/`catalog:<name>` in manifests; store the resolved range separately and suppress Update actions for catalog-managed deps.
  - Integrate catalog resolution into `package.json` processing in editor and CLI; harden YAML parsing for edge cases and fix clippy warnings.

<sup>Written for commit 19bb0656dc6992ab0dd791e115feda2aa5682d77. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/zed-dependi/pull/318?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PNPM workspace catalog support: parse default and named catalogs and resolve catalog-based dependency placeholders during package scans.
  * Scans now locate and consult the nearest workspace file on disk to expand PNPM catalog references before further processing.

* **Tests**
  * Added tests covering multiple workspace shapes, inline comments/quotes, default vs named catalog behavior, named-catalog resolution, and on-disk workspace resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/zed-dependi/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->