### PR TITLE
chore(release): prepare v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-05-20
+
+### Added
+
+- Support pnpm workspace catalog dependencies from `pnpm-workspace.yaml`,
+  including default catalog entries, shorthand `catalog:` references, and
+  named catalog references such as `catalog:react18`. Diagnostics, inlay
+  hints, and update code actions now resolve catalog-backed versions while
+  preserving catalog markers. ([#318](https://github.com/mpiton/zed-dependi/pull/318))
+- CodSpeed continuous performance testing for benchmarks on push and pull
+  request workflows, plus the README CodSpeed badge. ([#282](https://github.com/mpiton/zed-dependi/pull/282))
+
+### Changed
+
+- Updated project dependencies across Rust crates, docs gems, and GitHub
+  Actions workflows. This includes `tokio`, `reqwest`, `dashmap`,
+  `hashbrown`, `quick-xml`, Jekyll, Just the Docs, `actions/setup-node`, and
+  `moonrepo/setup-rust`. ([#319](https://github.com/mpiton/zed-dependi/pull/319))
+- CI now validates the Jekyll documentation build on pull requests with Ruby
+  3.2 and Bundler cache, while keeping GitHub Pages deployment restricted to
+  pushes to `main`. ([#319](https://github.com/mpiton/zed-dependi/pull/319))
+
+### Fixed
+
+- Cargo parser span handling no longer panics on malformed multiline TOML
+  strings that previously triggered `TextSize` underflow. Invalid ranges are
+  skipped instead of crashing the parser. ([#288](https://github.com/mpiton/zed-dependi/pull/288))
+- Cargo parser line ranges now exclude trailing newline bytes, preventing
+  spans whose `line_end` points past the visible line content. ([#289](https://github.com/mpiton/zed-dependi/pull/289))
+- Fuzz targets now validate the nested `name_span` and `version_span` API
+  independently, restoring fuzz build compatibility after the span model
+  change. ([#287](https://github.com/mpiton/zed-dependi/pull/287))
+
 ## [1.8.1] - 2026-05-01
 
 ### Fixed
@@ -655,7 +688,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory caching for version data
 - Parallel registry requests (5 concurrent)
 
-[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.8.1...HEAD
+[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/mpiton/zed-dependi/compare/v1.8.1...v1.9.0
 [1.8.1]: https://github.com/mpiton/zed-dependi/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/mpiton/zed-dependi/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/mpiton/zed-dependi/compare/v1.6.1...v1.7.0

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Dependency management extension for the [Zed](https://zed.dev) editor.
 
-**Version:** 1.8.1
+**Version:** 1.9.0
 
 ![Demo](docs/demo.gif)
 

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -545,7 +545,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "dependi-lsp"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-lsp"
-version = "1.8.1"
+version = "1.9.0"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/dependi-zed/Cargo.lock
+++ b/dependi-zed/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-zed"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "hex",
  "sha2",

--- a/dependi-zed/Cargo.toml
+++ b/dependi-zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-zed"
-version = "1.8.1"
+version = "1.9.0"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT"

--- a/dependi-zed/extension.toml
+++ b/dependi-zed/extension.toml
@@ -1,7 +1,7 @@
 id = "dependi"
 name = "Dependi"
 description = "Dependency management for Zed - version hints, updates, and vulnerability detection"
-version = "1.8.1"
+version = "1.9.0"
 schema_version = 1
 authors = ["Mathieu Piton"]
 repository = "https://github.com/mpiton/zed-dependi"


### PR DESCRIPTION
## Summary

• Bump Dependi manifests and README to 1.9.0
• Add 1.9.0 changelog notes for pnpm catalogs, CI, dependency updates, and parser fixes
• Refresh Cargo lock package versions for the release

## Type

chore


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v1.9.0 release by bumping versions across the extension and crates, updating the README, and adding changelog notes for pnpm catalog support, CI improvements, dependency updates, and parser fixes.

- New Features
  - Support pnpm workspace catalog dependencies from `pnpm-workspace.yaml`; diagnostics, inlay hints, and update actions preserve `catalog:` markers.
  - CI: add CodSpeed performance tests and README badge; validate Jekyll docs build on PRs.

- Bug Fixes
  - Fix Cargo parser panics on malformed multiline TOML and off-by-one line spans; update fuzz targets for the new span model.

<sup>Written for commit c5633a920ccab4c342207b94e300b343f8c9420c. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/zed-dependi/pull/320?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pnpm workspace catalog resolution support

* **Bug Fixes**
  * Fixed Cargo parser span-handling issues
  * Improved fuzz testing compatibility

* **Chores**
  * Updated project version to 1.9.0
  * Enhanced testing infrastructure with CodSpeed integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/zed-dependi/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->