### PR TITLE
[Scenario #321] Dependi LSP uses the trimmed Tokio feature set

### DIFF
--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -2246,16 +2246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,9 +2529,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 tower-lsp = "0.20"
-tokio = { version = "1.52.3", features = ["full"] }
+tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 reqwest = { version = "0.13.3", features = ["json", "rustls"], default-features = false }

--- a/dependi-lsp/tests/tokio_feature_set_test.rs
+++ b/dependi-lsp/tests/tokio_feature_set_test.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use toml::Value;
 
 const DEPENDI_LSP_MANIFEST: &str = include_str!("../Cargo.toml");
-const EXPECTED_TOKIO_FEATURES: [&str; 4] = ["fs", "io-util", "macros", "rt-multi-thread"];
+const EXPECTED_TOKIO_FEATURES: [&str; 5] = ["fs", "io-std", "io-util", "macros", "rt-multi-thread"];
 
 fn tokio_features(manifest: &str) -> BTreeSet<String> {
     let manifest = toml::from_str::<Value>(manifest).expect("dependi-lsp Cargo.toml is valid TOML");
@@ -30,9 +30,9 @@ fn expected_tokio_features() -> BTreeSet<String> {
 #[test]
 fn dependi_lsp_uses_the_trimmed_tokio_feature_set() {
     // Given the `dependi-lsp/Cargo.toml` dependency line for `tokio` is:
-    //   tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "fs"] }
+    //   tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs"] }
     // When the Tokio dependency features are inspected
-    // Then the direct Tokio feature set is exactly "fs, io-util, macros, rt-multi-thread"
+    // Then the direct Tokio feature set is exactly "fs, io-std, io-util, macros, rt-multi-thread"
     // And the direct Tokio feature set does not include "full"
     let features = tokio_features(DEPENDI_LSP_MANIFEST);
 

--- a/dependi-lsp/tests/tokio_feature_set_test.rs
+++ b/dependi-lsp/tests/tokio_feature_set_test.rs
@@ -1,0 +1,41 @@
+use std::collections::BTreeSet;
+
+use toml::Value;
+
+const DEPENDI_LSP_MANIFEST: &str = include_str!("../Cargo.toml");
+const EXPECTED_TOKIO_FEATURES: [&str; 4] = ["fs", "io-util", "macros", "rt-multi-thread"];
+
+fn tokio_features(manifest: &str) -> BTreeSet<String> {
+    let manifest = toml::from_str::<Value>(manifest).expect("dependi-lsp Cargo.toml is valid TOML");
+    manifest["dependencies"]["tokio"]["features"]
+        .as_array()
+        .expect("tokio dependency declares explicit features")
+        .iter()
+        .map(|feature| {
+            feature
+                .as_str()
+                .expect("tokio features are strings")
+                .to_string()
+        })
+        .collect()
+}
+
+fn expected_tokio_features() -> BTreeSet<String> {
+    EXPECTED_TOKIO_FEATURES
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+}
+
+#[test]
+fn dependi_lsp_uses_the_trimmed_tokio_feature_set() {
+    // Given the `dependi-lsp/Cargo.toml` dependency line for `tokio` is:
+    //   tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "fs"] }
+    // When the Tokio dependency features are inspected
+    // Then the direct Tokio feature set is exactly "fs, io-util, macros, rt-multi-thread"
+    // And the direct Tokio feature set does not include "full"
+    let features = tokio_features(DEPENDI_LSP_MANIFEST);
+
+    assert_eq!(features, expected_tokio_features());
+    assert!(!features.contains("full"));
+}


### PR DESCRIPTION
Closes #321\n\nRule: R-01\n\nNotes:\n- Removes Tokio full feature from dependi-lsp.\n- Adds io-std because cargo check showed tokio::io::stdin/stdout require it.\n- Adds manifest guard test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed `tokio` features in `dependi-lsp` from `full` to a minimal set to reduce build surface and transitive deps. Adds a manifest guard test to enforce the feature set for Scenario #321 (R-01).

- **Dependencies**
  - Switched `tokio` features to `["rt-multi-thread", "macros", "io-util", "io-std", "fs"]` (includes `io-std` for stdin/stdout).
  - Lockfile shrinks, dropping unused crates such as `signal-hook-registry` and `parking_lot`.

<sup>Written for commit 56d4e880128315769e451bc636d7b7fe7f8383cb. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/zed-dependi/pull/334?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

