### PR TITLE
[US] perf-reduce-tokio-feature-set-decrease: trim Tokio feature set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Declared `tokio` features explicitly in `dependi-lsp/Cargo.toml`: the
+  trimmed set now includes `sync` and `time` alongside `rt-multi-thread`,
+  `macros`, `io-util`, `io-std`, and `fs`. The crate uses
+  `tokio::sync::{RwLock, Mutex, Semaphore}` and
+  `tokio::time::{sleep, timeout, interval}` directly, so relying on
+  transitive feature unification through other dependencies was fragile.
+  Acceptance scenarios and `tokio_feature_set_test.rs` were updated to
+  match the seven-feature set.
+  ([#336](https://github.com/mpiton/zed-dependi/pull/336))
+
 ## [1.9.0] - 2026-05-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tokio::time::{sleep, timeout, interval}` directly, so relying on
   transitive feature unification through other dependencies was fragile.
   Acceptance scenarios and `tokio_feature_set_test.rs` were updated to
-  match the seven-feature set.
+  match the seven-feature set. Added a `tokio` entry under
+  `[dev-dependencies]` with the `net` feature so the
+  `vulnerabilities::osv` test server's use of `tokio::net::TcpListener`
+  no longer depends on `wiremock`'s transitive feature enablement.
   ([#336](https://github.com/mpiton/zed-dependi/pull/336))
 
 ## [1.9.0] - 2026-05-20

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -2246,16 +2246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,9 +2529,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 tower-lsp = "0.20"
-tokio = { version = "1.52.3", features = ["full"] }
+tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 reqwest = { version = "0.13.3", features = ["json", "rustls"], default-features = false }

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 tower-lsp = "0.20"
-tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs"] }
+tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "sync", "time"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 reqwest = { version = "0.13.3", features = ["json", "rustls"], default-features = false }

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -48,6 +48,7 @@ tempfile = "3"
 regex = "1.12.3"
 walkdir = "2.5.0"
 criterion = { version = "4.6.0", package = "codspeed-criterion-compat", features = ["html_reports"] }
+tokio = { version = "1.52.3", features = ["net"] }
 
 [[bench]]
 name = "benchmarks"

--- a/dependi-lsp/tests/fixtures/tokio_feature_measurements.toml
+++ b/dependi-lsp/tests/fixtures/tokio_feature_measurements.toml
@@ -1,0 +1,30 @@
+# Checked ATDD fixture for issue #234.
+# Values mirror the lower-bound examples from the accepted spec so the
+# acceptance test validates threshold behavior from fixture data, not inline
+# literals in the assertion body.
+
+[cases.pass_lower_bound]
+baseline_binary_size = 50000000
+baseline_clean_seconds = 120
+trimmed_binary_size = 47500000
+trimmed_clean_seconds = 108
+
+[cases.pass_inside_range]
+baseline_binary_size = 50000000
+baseline_clean_seconds = 120
+trimmed_binary_size = 45000000
+trimmed_clean_seconds = 102
+
+[cases.fail_binary]
+baseline_binary_size = 50000000
+baseline_clean_seconds = 120
+trimmed_binary_size = 48000000
+trimmed_clean_seconds = 108
+reason = "binary reduction is only 4%"
+
+[cases.fail_build_time]
+baseline_binary_size = 50000000
+baseline_clean_seconds = 120
+trimmed_binary_size = 47500000
+trimmed_clean_seconds = 109
+reason = "build-time reduction is under 10%"

--- a/dependi-lsp/tests/tokio_feature_set_test.rs
+++ b/dependi-lsp/tests/tokio_feature_set_test.rs
@@ -296,15 +296,39 @@ fn missing_direct_tokio_features_break_required_capabilities() {
             "fn main() { let _stdin = tokio::io::stdin(); }\n",
         ),
         (
-            ["rt-multi-thread", "macros", "io-util", "io-std", "sync", "time"].as_slice(),
+            [
+                "rt-multi-thread",
+                "macros",
+                "io-util",
+                "io-std",
+                "sync",
+                "time",
+            ]
+            .as_slice(),
             "fn main() { let _read = tokio::fs::read_to_string(\"Cargo.toml\"); }\n",
         ),
         (
-            ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "time"].as_slice(),
+            [
+                "rt-multi-thread",
+                "macros",
+                "io-util",
+                "io-std",
+                "fs",
+                "time",
+            ]
+            .as_slice(),
             "fn main() { let _lock = tokio::sync::RwLock::new(0_u8); }\n",
         ),
         (
-            ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "sync"].as_slice(),
+            [
+                "rt-multi-thread",
+                "macros",
+                "io-util",
+                "io-std",
+                "fs",
+                "sync",
+            ]
+            .as_slice(),
             "fn main() { let _f = tokio::time::sleep(std::time::Duration::from_millis(0)); }\n",
         ),
     ];

--- a/dependi-lsp/tests/tokio_feature_set_test.rs
+++ b/dependi-lsp/tests/tokio_feature_set_test.rs
@@ -1,0 +1,41 @@
+use std::collections::BTreeSet;
+
+use toml::Value;
+
+const DEPENDI_LSP_MANIFEST: &str = include_str!("../Cargo.toml");
+const EXPECTED_TOKIO_FEATURES: [&str; 5] = ["fs", "io-std", "io-util", "macros", "rt-multi-thread"];
+
+fn tokio_features(manifest: &str) -> BTreeSet<String> {
+    let manifest = toml::from_str::<Value>(manifest).expect("dependi-lsp Cargo.toml is valid TOML");
+    manifest["dependencies"]["tokio"]["features"]
+        .as_array()
+        .expect("tokio dependency declares explicit features")
+        .iter()
+        .map(|feature| {
+            feature
+                .as_str()
+                .expect("tokio features are strings")
+                .to_string()
+        })
+        .collect()
+}
+
+fn expected_tokio_features() -> BTreeSet<String> {
+    EXPECTED_TOKIO_FEATURES
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+}
+
+#[test]
+fn dependi_lsp_uses_the_trimmed_tokio_feature_set() {
+    // Given the `dependi-lsp/Cargo.toml` dependency line for `tokio` is:
+    //   tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs"] }
+    // When the Tokio dependency features are inspected
+    // Then the direct Tokio feature set is exactly "fs, io-std, io-util, macros, rt-multi-thread"
+    // And the direct Tokio feature set does not include "full"
+    let features = tokio_features(DEPENDI_LSP_MANIFEST);
+
+    assert_eq!(features, expected_tokio_features());
+    assert!(!features.contains("full"));
+}

--- a/dependi-lsp/tests/tokio_feature_set_test.rs
+++ b/dependi-lsp/tests/tokio_feature_set_test.rs
@@ -1,8 +1,9 @@
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, fs, process::Command};
 
 use toml::Value;
 
 const DEPENDI_LSP_MANIFEST: &str = include_str!("../Cargo.toml");
+const TOKIO_FEATURE_MEASUREMENTS: &str = include_str!("fixtures/tokio_feature_measurements.toml");
 const EXPECTED_TOKIO_FEATURES: [&str; 5] = ["fs", "io-std", "io-util", "macros", "rt-multi-thread"];
 
 fn tokio_features(manifest: &str) -> BTreeSet<String> {
@@ -20,11 +21,138 @@ fn tokio_features(manifest: &str) -> BTreeSet<String> {
         .collect()
 }
 
+fn manifest_with_dependencies(dependencies: &str) -> String {
+    format!("[dependencies]\n{dependencies}")
+}
+
+fn has_dependency(manifest: &str, dependency_name: &str) -> bool {
+    let manifest = toml::from_str::<Value>(manifest).expect("manifest fixture is valid TOML");
+    manifest["dependencies"].get(dependency_name).is_some()
+}
+
+fn manifest_without_dependency(manifest: &str, dependency_name: &str) -> String {
+    let mut manifest = toml::from_str::<Value>(manifest).expect("manifest fixture is valid TOML");
+    manifest["dependencies"]
+        .as_table_mut()
+        .expect("manifest has dependency table")
+        .remove(dependency_name)
+        .expect("dependency exists before removal");
+    toml::to_string(&manifest).expect("mutated manifest serializes as TOML")
+}
+
+fn has_reqwest_network_capability(manifest: &str) -> bool {
+    has_dependency(manifest, "reqwest") && !tokio_features(manifest).contains("net")
+}
+
+fn cargo_check_probe_succeeds(features: &[&str], main_rs: &str) -> bool {
+    let project = tempfile::tempdir().expect("probe temp dir is created");
+    let src_dir = project.path().join("src");
+    fs::create_dir(&src_dir).expect("probe src dir is created");
+    let feature_list = features
+        .iter()
+        .map(|feature| format!(r#""{feature}""#))
+        .collect::<Vec<_>>()
+        .join(", ");
+    fs::write(
+        project.path().join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "tokio-feature-probe"
+version = "0.0.0"
+edition = "2024"
+
+[dependencies]
+tokio = {{ version = "=1.52.3", features = [{feature_list}] }}
+"#
+        ),
+    )
+    .expect("probe manifest is written");
+    fs::write(src_dir.join("main.rs"), main_rs).expect("probe main is written");
+
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    Command::new(cargo)
+        .arg("check")
+        .arg("--quiet")
+        .arg("--manifest-path")
+        .arg(project.path().join("Cargo.toml"))
+        .arg("--target-dir")
+        .arg(project.path().join("target"))
+        .output()
+        .expect("cargo check probe runs")
+        .status
+        .success()
+}
+
 fn expected_tokio_features() -> BTreeSet<String> {
     EXPECTED_TOKIO_FEATURES
         .into_iter()
         .map(str::to_string)
         .collect()
+}
+
+fn missing_expected_tokio_features(features: &BTreeSet<String>) -> BTreeSet<String> {
+    expected_tokio_features()
+        .difference(features)
+        .cloned()
+        .collect()
+}
+
+fn unrelated_tokio_features(features: &BTreeSet<String>) -> BTreeSet<String> {
+    features
+        .difference(&expected_tokio_features())
+        .cloned()
+        .collect()
+}
+
+fn performance_floor_satisfied(
+    baseline_binary_size: u64,
+    baseline_clean_seconds: u64,
+    trimmed_binary_size: u64,
+    trimmed_clean_seconds: u64,
+) -> bool {
+    trimmed_binary_size * 100 <= baseline_binary_size * 95
+        && trimmed_clean_seconds * 100 <= baseline_clean_seconds * 90
+}
+
+fn measurement_case(case_name: &str) -> (u64, u64, u64, u64) {
+    let fixture =
+        toml::from_str::<Value>(TOKIO_FEATURE_MEASUREMENTS).expect("measurement fixture is valid");
+    let case = &fixture["cases"][case_name];
+    let get_u64 = |key: &str| {
+        case[key]
+            .as_integer()
+            .unwrap_or_else(|| panic!("{case_name}.{key} is an integer")) as u64
+    };
+
+    (
+        get_u64("baseline_binary_size"),
+        get_u64("baseline_clean_seconds"),
+        get_u64("trimmed_binary_size"),
+        get_u64("trimmed_clean_seconds"),
+    )
+}
+
+#[derive(Debug)]
+struct BuildMeasurement<'a> {
+    source_revision: &'a str,
+    profile: &'a str,
+    clean_build: bool,
+}
+
+fn comparable_measurements(
+    baseline: &BuildMeasurement<'_>,
+    trimmed: &BuildMeasurement<'_>,
+) -> Result<(), &'static str> {
+    if !baseline.clean_build || !trimmed.clean_build {
+        return Err("clean build condition differs");
+    }
+    if baseline.source_revision != trimmed.source_revision {
+        return Err("source revision differs");
+    }
+    if baseline.profile != trimmed.profile {
+        return Err("build profile differs");
+    }
+    Ok(())
 }
 
 #[test]
@@ -38,4 +166,259 @@ fn dependi_lsp_uses_the_trimmed_tokio_feature_set() {
 
     assert_eq!(features, expected_tokio_features());
     assert!(!features.contains("full"));
+}
+
+#[test]
+fn the_full_tokio_feature_remains_enabled() {
+    // Given the `dependi-lsp/Cargo.toml` dependency line for `tokio` is:
+    //   tokio = { version = "1.52.3", features = ["full"] }
+    // When the Tokio dependency features are inspected
+    // Then the dependency violates R-01 because the direct Tokio feature set includes "full"
+    let manifest =
+        manifest_with_dependencies(r#"tokio = { version = "1.52.3", features = ["full"] }"#);
+    let features = tokio_features(&manifest);
+
+    assert!(features.contains("full"));
+    assert_ne!(features, expected_tokio_features());
+}
+
+#[test]
+fn a_required_explicit_tokio_feature_is_missing() {
+    // Given the `dependi-lsp/Cargo.toml` dependency line for `tokio` is:
+    //   tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util"] }
+    // When the Tokio dependency features are inspected
+    // Then the dependency violates R-01 because the direct Tokio feature set is missing "fs, io-std"
+    let manifest = manifest_with_dependencies(
+        r#"tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util"] }"#,
+    );
+    let features = tokio_features(&manifest);
+
+    assert_eq!(
+        missing_expected_tokio_features(&features),
+        BTreeSet::from(["fs".to_string(), "io-std".to_string()])
+    );
+}
+
+#[test]
+fn extra_unrelated_direct_tokio_features_are_rejected() {
+    // Given the `dependi-lsp/Cargo.toml` dependency line for `tokio` is:
+    //   tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "sync", "time"] }
+    // When the Tokio dependency features are inspected
+    // Then the dependency violates R-01 because the direct Tokio feature set includes unrelated features "sync, time"
+    let manifest = manifest_with_dependencies(
+        r#"tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "sync", "time"] }"#,
+    );
+    let features = tokio_features(&manifest);
+
+    assert_eq!(
+        unrelated_tokio_features(&features),
+        BTreeSet::from(["sync".to_string(), "time".to_string()])
+    );
+}
+
+#[test]
+fn feature_equality_ignores_cargo_list_ordering() {
+    // Given the `dependi-lsp/Cargo.toml` dependency line for `tokio` is:
+    //   tokio = { version = "1.52.3", features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread"] }
+    // When the Tokio dependency features are inspected
+    // Then the direct Tokio feature set is exactly "fs, io-std, io-util, macros, rt-multi-thread"
+    // And the dependency satisfies R-01
+    let manifest = manifest_with_dependencies(
+        r#"tokio = { version = "1.52.3", features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread"] }"#,
+    );
+    let features = tokio_features(&manifest);
+
+    assert_eq!(features, expected_tokio_features());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn trimmed_features_keep_each_required_tokio_and_reqwest_capability() {
+    // Given the `dependi-lsp` crate directly enables Tokio features "rt-multi-thread, macros, io-util, io-std, fs"
+    // And the `dependi-lsp` crate depends on `reqwest` version "0.13.3"
+    // When `cargo check -p dependi-lsp` runs
+    // Then code using "<capability_code>" for "<capability>" compiles
+    // And the dependency graph satisfies R-02
+    use tokio::io::AsyncReadExt;
+
+    let mut reader = tokio::io::empty();
+    let mut buffer = [];
+    let bytes_read = reader.read(&mut buffer).await.unwrap();
+    let cargo_toml = tokio::fs::read_to_string("Cargo.toml").await.unwrap();
+    let _stdin = tokio::io::stdin();
+    let _client = reqwest::Client::new();
+
+    assert_eq!(bytes_read, 0);
+    assert!(cargo_toml.contains("[package]"));
+    assert_eq!(
+        tokio_features(DEPENDI_LSP_MANIFEST),
+        expected_tokio_features()
+    );
+    assert!(has_dependency(DEPENDI_LSP_MANIFEST, "reqwest"));
+}
+
+#[test]
+fn missing_direct_tokio_features_break_required_capabilities() {
+    // Given the `dependi-lsp` crate directly enables Tokio features "<enabled_features>"
+    // And the `dependi-lsp` crate depends on `reqwest` version "0.13.3"
+    // When `cargo check -p dependi-lsp` runs
+    // Then code using "<failing_capability_code>" for "<missing_feature>" fails to compile
+    // And the dependency graph violates R-02
+    let cases = [
+        (
+            ["rt-multi-thread", "io-util", "io-std", "fs"].as_slice(),
+            "#[tokio::main]\nasync fn main() {}\n",
+        ),
+        (
+            ["macros", "io-util", "io-std", "fs"].as_slice(),
+            "#[tokio::main]\nasync fn main() {}\n",
+        ),
+        (
+            ["rt-multi-thread", "macros", "fs", "io-std"].as_slice(),
+            "use tokio::io::AsyncReadExt;\nfn main() {}\n",
+        ),
+        (
+            ["rt-multi-thread", "macros", "io-util", "fs"].as_slice(),
+            "fn main() { let _stdin = tokio::io::stdin(); }\n",
+        ),
+        (
+            ["rt-multi-thread", "macros", "io-util", "io-std"].as_slice(),
+            "fn main() { let _read = tokio::fs::read_to_string(\"Cargo.toml\"); }\n",
+        ),
+    ];
+
+    for (enabled_features, capability_code) in cases {
+        assert!(
+            !cargo_check_probe_succeeds(enabled_features, capability_code),
+            "{capability_code} should fail to compile with features {enabled_features:?}"
+        );
+    }
+}
+
+#[test]
+fn missing_reqwest_support_breaks_network_capability() {
+    // Given the `dependi-lsp` crate directly enables Tokio features "rt-multi-thread, macros, io-util, io-std, fs"
+    // And the `dependi-lsp` crate does not depend on `reqwest`
+    // When `cargo check -p dependi-lsp` runs
+    // Then code issuing an HTTPS request through `reqwest::Client` fails to compile
+    // And the dependency graph violates R-02
+    let manifest = manifest_without_dependency(DEPENDI_LSP_MANIFEST, "reqwest");
+
+    assert!(has_reqwest_network_capability(DEPENDI_LSP_MANIFEST));
+    assert!(!has_reqwest_network_capability(&manifest));
+}
+
+#[test]
+fn network_capability_comes_from_reqwest_instead_of_a_direct_tokio_feature() {
+    // Given the `dependi-lsp` crate directly enables Tokio features "rt-multi-thread, macros, io-util, io-std, fs"
+    // And the `dependi-lsp` crate depends on `reqwest` version "0.13.3"
+    // When the resolved Cargo dependency graph is inspected
+    // Then HTTPS client code through `reqwest::Client` is available
+    // And the direct Tokio feature set does not include "net"
+    // And the dependency graph satisfies R-02
+    let features = tokio_features(DEPENDI_LSP_MANIFEST);
+    let _client = reqwest::Client::new();
+
+    assert!(has_dependency(DEPENDI_LSP_MANIFEST, "reqwest"));
+    assert!(!features.contains("net"));
+}
+
+#[test]
+fn trimmed_build_meets_the_minimum_improvement_floor() {
+    // Given the `features = ["full"]` baseline binary size is 50000000 bytes
+    // And the `features = ["full"]` baseline clean build takes 120 seconds
+    // And the trimmed Tokio build binary size is <trimmed_binary_size> bytes
+    // And the trimmed Tokio clean build takes <trimmed_build_seconds> seconds
+    // When the improvement is calculated against the baseline
+    // Then the binary-size reduction is at least 5 percent
+    // And the clean-build-time reduction is at least 10 percent
+    // And the performance result satisfies R-03
+    for case_name in ["pass_lower_bound", "pass_inside_range"] {
+        let (baseline_binary, baseline_seconds, trimmed_binary, trimmed_seconds) =
+            measurement_case(case_name);
+
+        assert!(performance_floor_satisfied(
+            baseline_binary,
+            baseline_seconds,
+            trimmed_binary,
+            trimmed_seconds
+        ));
+    }
+}
+
+#[test]
+fn trimmed_build_below_either_improvement_floor_fails_the_rule() {
+    // Given the `features = ["full"]` baseline binary size is 50000000 bytes
+    // And the `features = ["full"]` baseline clean build takes 120 seconds
+    // And the trimmed Tokio build binary size is <trimmed_binary_size> bytes
+    // And the trimmed Tokio clean build takes <trimmed_build_seconds> seconds
+    // When the improvement is calculated against the baseline
+    // Then the performance result violates R-03 with reason "<reason>"
+    for case_name in ["fail_binary", "fail_build_time"] {
+        let (baseline_binary, baseline_seconds, trimmed_binary, trimmed_seconds) =
+            measurement_case(case_name);
+
+        assert!(!performance_floor_satisfied(
+            baseline_binary,
+            baseline_seconds,
+            trimmed_binary,
+            trimmed_seconds
+        ));
+    }
+}
+
+#[test]
+fn performance_comparison_uses_the_same_clean_build_conditions() {
+    // Given the `features = ["full"]` baseline is measured from a clean build
+    // And the trimmed Tokio build is measured from an incremental build
+    // When the improvement is calculated against the baseline
+    // Then the performance result is rejected as incomparable
+    // And R-03 requires both measurements to use clean build conditions
+    let baseline = BuildMeasurement {
+        source_revision: "a1b2c3d",
+        profile: "release",
+        clean_build: true,
+    };
+    let trimmed = BuildMeasurement {
+        source_revision: "a1b2c3d",
+        profile: "release",
+        clean_build: false,
+    };
+
+    assert_eq!(
+        comparable_measurements(&baseline, &trimmed),
+        Err("clean build condition differs")
+    );
+}
+
+#[test]
+fn performance_comparison_rejects_mismatched_source_revision_or_profile() {
+    // Given the `features = ["full"]` baseline is measured from source revision "a1b2c3d" using build profile "release"
+    // And the trimmed Tokio build is measured from source revision "<trimmed_revision>" using build profile "<trimmed_profile>"
+    // And both measurements use clean build conditions
+    // When the improvement is calculated against the baseline
+    // Then the performance result is rejected as incomparable with reason "<reason>"
+    let baseline = BuildMeasurement {
+        source_revision: "a1b2c3d",
+        profile: "release",
+        clean_build: true,
+    };
+    let different_revision = BuildMeasurement {
+        source_revision: "e4f5a6b",
+        profile: "release",
+        clean_build: true,
+    };
+    let different_profile = BuildMeasurement {
+        source_revision: "a1b2c3d",
+        profile: "debug",
+        clean_build: true,
+    };
+
+    assert_eq!(
+        comparable_measurements(&baseline, &different_revision),
+        Err("source revision differs")
+    );
+    assert_eq!(
+        comparable_measurements(&baseline, &different_profile),
+        Err("build profile differs")
+    );
 }

--- a/dependi-lsp/tests/tokio_feature_set_test.rs
+++ b/dependi-lsp/tests/tokio_feature_set_test.rs
@@ -4,7 +4,15 @@ use toml::Value;
 
 const DEPENDI_LSP_MANIFEST: &str = include_str!("../Cargo.toml");
 const TOKIO_FEATURE_MEASUREMENTS: &str = include_str!("fixtures/tokio_feature_measurements.toml");
-const EXPECTED_TOKIO_FEATURES: [&str; 5] = ["fs", "io-std", "io-util", "macros", "rt-multi-thread"];
+const EXPECTED_TOKIO_FEATURES: [&str; 7] = [
+    "fs",
+    "io-std",
+    "io-util",
+    "macros",
+    "rt-multi-thread",
+    "sync",
+    "time",
+];
 
 fn tokio_features(manifest: &str) -> BTreeSet<String> {
     let manifest = toml::from_str::<Value>(manifest).expect("dependi-lsp Cargo.toml is valid TOML");
@@ -158,9 +166,9 @@ fn comparable_measurements(
 #[test]
 fn dependi_lsp_uses_the_trimmed_tokio_feature_set() {
     // Given the `dependi-lsp/Cargo.toml` dependency line for `tokio` is:
-    //   tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs"] }
+    //   tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "sync", "time"] }
     // When the Tokio dependency features are inspected
-    // Then the direct Tokio feature set is exactly "fs, io-std, io-util, macros, rt-multi-thread"
+    // Then the direct Tokio feature set is exactly "fs, io-std, io-util, macros, rt-multi-thread, sync, time"
     // And the direct Tokio feature set does not include "full"
     let features = tokio_features(DEPENDI_LSP_MANIFEST);
 
@@ -187,7 +195,7 @@ fn a_required_explicit_tokio_feature_is_missing() {
     // Given the `dependi-lsp/Cargo.toml` dependency line for `tokio` is:
     //   tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util"] }
     // When the Tokio dependency features are inspected
-    // Then the dependency violates R-01 because the direct Tokio feature set is missing "fs, io-std"
+    // Then the dependency violates R-01 because the direct Tokio feature set is missing "fs, io-std, sync, time"
     let manifest = manifest_with_dependencies(
         r#"tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util"] }"#,
     );
@@ -195,36 +203,41 @@ fn a_required_explicit_tokio_feature_is_missing() {
 
     assert_eq!(
         missing_expected_tokio_features(&features),
-        BTreeSet::from(["fs".to_string(), "io-std".to_string()])
+        BTreeSet::from([
+            "fs".to_string(),
+            "io-std".to_string(),
+            "sync".to_string(),
+            "time".to_string(),
+        ])
     );
 }
 
 #[test]
 fn extra_unrelated_direct_tokio_features_are_rejected() {
     // Given the `dependi-lsp/Cargo.toml` dependency line for `tokio` is:
-    //   tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "sync", "time"] }
+    //   tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "sync", "time", "signal", "process"] }
     // When the Tokio dependency features are inspected
-    // Then the dependency violates R-01 because the direct Tokio feature set includes unrelated features "sync, time"
+    // Then the dependency violates R-01 because the direct Tokio feature set includes unrelated features "process, signal"
     let manifest = manifest_with_dependencies(
-        r#"tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "sync", "time"] }"#,
+        r#"tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "sync", "time", "signal", "process"] }"#,
     );
     let features = tokio_features(&manifest);
 
     assert_eq!(
         unrelated_tokio_features(&features),
-        BTreeSet::from(["sync".to_string(), "time".to_string()])
+        BTreeSet::from(["process".to_string(), "signal".to_string()])
     );
 }
 
 #[test]
 fn feature_equality_ignores_cargo_list_ordering() {
     // Given the `dependi-lsp/Cargo.toml` dependency line for `tokio` is:
-    //   tokio = { version = "1.52.3", features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread"] }
+    //   tokio = { version = "1.52.3", features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
     // When the Tokio dependency features are inspected
-    // Then the direct Tokio feature set is exactly "fs, io-std, io-util, macros, rt-multi-thread"
+    // Then the direct Tokio feature set is exactly "fs, io-std, io-util, macros, rt-multi-thread, sync, time"
     // And the dependency satisfies R-01
     let manifest = manifest_with_dependencies(
-        r#"tokio = { version = "1.52.3", features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread"] }"#,
+        r#"tokio = { version = "1.52.3", features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread", "sync", "time"] }"#,
     );
     let features = tokio_features(&manifest);
 
@@ -233,7 +246,7 @@ fn feature_equality_ignores_cargo_list_ordering() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn trimmed_features_keep_each_required_tokio_and_reqwest_capability() {
-    // Given the `dependi-lsp` crate directly enables Tokio features "rt-multi-thread, macros, io-util, io-std, fs"
+    // Given the `dependi-lsp` crate directly enables Tokio features "rt-multi-thread, macros, io-util, io-std, fs, sync, time"
     // And the `dependi-lsp` crate depends on `reqwest` version "0.13.3"
     // When `cargo check -p dependi-lsp` runs
     // Then code using "<capability_code>" for "<capability>" compiles
@@ -246,6 +259,8 @@ async fn trimmed_features_keep_each_required_tokio_and_reqwest_capability() {
     let cargo_toml = tokio::fs::read_to_string("Cargo.toml").await.unwrap();
     let _stdin = tokio::io::stdin();
     let _client = reqwest::Client::new();
+    let _lock = tokio::sync::RwLock::new(0_u8);
+    tokio::time::sleep(std::time::Duration::from_millis(0)).await;
 
     assert_eq!(bytes_read, 0);
     assert!(cargo_toml.contains("[package]"));
@@ -265,24 +280,32 @@ fn missing_direct_tokio_features_break_required_capabilities() {
     // And the dependency graph violates R-02
     let cases = [
         (
-            ["rt-multi-thread", "io-util", "io-std", "fs"].as_slice(),
+            ["rt-multi-thread", "io-util", "io-std", "fs", "sync", "time"].as_slice(),
             "#[tokio::main]\nasync fn main() {}\n",
         ),
         (
-            ["macros", "io-util", "io-std", "fs"].as_slice(),
+            ["macros", "io-util", "io-std", "fs", "sync", "time"].as_slice(),
             "#[tokio::main]\nasync fn main() {}\n",
         ),
         (
-            ["rt-multi-thread", "macros", "fs", "io-std"].as_slice(),
+            ["rt-multi-thread", "macros", "fs", "io-std", "sync", "time"].as_slice(),
             "use tokio::io::AsyncReadExt;\nfn main() {}\n",
         ),
         (
-            ["rt-multi-thread", "macros", "io-util", "fs"].as_slice(),
+            ["rt-multi-thread", "macros", "io-util", "fs", "sync", "time"].as_slice(),
             "fn main() { let _stdin = tokio::io::stdin(); }\n",
         ),
         (
-            ["rt-multi-thread", "macros", "io-util", "io-std"].as_slice(),
+            ["rt-multi-thread", "macros", "io-util", "io-std", "sync", "time"].as_slice(),
             "fn main() { let _read = tokio::fs::read_to_string(\"Cargo.toml\"); }\n",
+        ),
+        (
+            ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "time"].as_slice(),
+            "fn main() { let _lock = tokio::sync::RwLock::new(0_u8); }\n",
+        ),
+        (
+            ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "sync"].as_slice(),
+            "fn main() { let _f = tokio::time::sleep(std::time::Duration::from_millis(0)); }\n",
         ),
     ];
 
@@ -309,7 +332,7 @@ fn missing_reqwest_support_breaks_network_capability() {
 
 #[test]
 fn network_capability_comes_from_reqwest_instead_of_a_direct_tokio_feature() {
-    // Given the `dependi-lsp` crate directly enables Tokio features "rt-multi-thread, macros, io-util, io-std, fs"
+    // Given the `dependi-lsp` crate directly enables Tokio features "rt-multi-thread, macros, io-util, io-std, fs, sync, time"
     // And the `dependi-lsp` crate depends on `reqwest` version "0.13.3"
     // When the resolved Cargo dependency graph is inspected
     // Then HTTPS client code through `reqwest::Client` is available


### PR DESCRIPTION
## Goal
Trim `dependi-lsp` Tokio features so the crate no longer enables `full`, while keeping required runtime, macro, standard IO, IO utility, filesystem, and reqwest-backed network capabilities.

## Scenarios
- #321 via PR #334: Dependi LSP uses the trimmed Tokio feature set
- #322-#333 via PR #335: remaining R-01/R-02/R-03 acceptance guard scenarios

## Implementation
- `tokio` direct features changed from `full` to `rt-multi-thread`, `macros`, `io-util`, `io-std`, `fs`.
- `io-std` was added after `cargo check` showed `tokio::io::stdin/stdout` require it.
- Added manifest and compile-probe acceptance tests in `dependi-lsp/tests/tokio_feature_set_test.rs`.
- Lockfile no longer includes transitive deps pulled only by `full`, including `signal-hook-registry` and `parking_lot` from Tokio.

## Verification
- Local: `cargo test --test tokio_feature_set_test`
- Local: `cargo test`
- Scenario PR CI: #334 green, #335 green

## ATDD artifacts
Local ignored path: `specs/perf-reduce-tokio-feature-set-decrease/`

## Escalations
None.

Checkpoint #2: final integration PR for human review. Do not auto-merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the `tokio` feature set in `dependi-lsp`, dropping `full` and explicitly enabling `rt-multi-thread`, `macros`, `io-util`, `io-std`, `fs`, `sync`, and `time`. Kept HTTPS via `reqwest` and made test-only `tokio/net` usage explicit in `dev-dependencies`.

- **Dependencies**
  - Switched `tokio` from `full` to the seven-feature set; `net` stays off at runtime (HTTPS via `reqwest`).
  - Added `tokio = { version = "1.52.3", features = ["net"] }` under `[dev-dependencies]` for the OSV test server. Lockfile drops extras previously pulled by `full` (e.g., `signal-hook-registry`, `parking_lot`).

- **Tests**
  - Acceptance tests assert the exact seven-feature set and compile-probe required capabilities.
  - Added `tests/fixtures/tokio_feature_measurements.toml` and checks for ≥5% binary and ≥10% clean build time improvements vs `full`.

<sup>Written for commit ecb40d16b3d2cb137a42fa704705924de32e08bb. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/zed-dependi/pull/336?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched Tokio dependency from the full feature bundle to an explicit, trimmed set of required features.

* **Tests**
  * Added comprehensive integration tests validating Tokio feature trimming, dependency/capability rules, performance thresholds, and build/size comparisons; new fixture data drives measurements.

* **Documentation**
  * Updated changelog to document the explicit Tokio feature set and related acceptance-test updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/zed-dependi/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->