### PR TITLE
docs: sync CLI, env vars and dev scripts with current code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without grepping the repo root.
 - `docs/cli.md`: documented the `html` output format and the
   `--no-use-lockfile` flag on `dependi-lsp scan`. Extended the **Supported
-  Files** table with Ruby (`Gemfile`), Java (`pom.xml`), and the previously
-  missing Python entries (`constraints.txt`, `hatch.toml`) so the CLI
-  reference now matches `dependi-lsp/src/file_types.rs`.
+  Files** table with Ruby (`Gemfile`) and Java (`pom.xml`). Python
+  entries are limited to `requirements.txt` and `pyproject.toml` because
+  `run_scan` in `dependi-lsp/src/main.rs` does not currently route
+  `constraints.txt` or `hatch.toml`; a callout points readers to the
+  broader LSP-mode coverage. The README CI/CD list mirrors the same
+  scope and callout.
 - `README.md`: re-synced with the current code:
   - Added Java/Maven Central to the **Supported Languages** table,
     the **CI/CD Supported Files** list, and the FAQ registries table.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- `docs/configuration.md`: added an **Environment Variables** subsection
+  documenting `RUST_LOG`, `OSV_ENDPOINT`, `CARGO_HOME`, and `GITHUB_TOKEN`.
+  `OSV_ENDPOINT` was previously only discoverable from `dependi-lsp/src/main.rs`.
+- `CONTRIBUTING.md`: added a **Developer Scripts** table covering
+  `build-and-deploy.sh`, `run-benchmarks.sh`, `scripts/coverage.sh`,
+  `scripts/fuzz.sh`, `scripts/profile-*.sh`, and
+  `scripts/check_mermaid_syntax.sh` so contributors discover the helper scripts
+  without grepping the repo root.
+- `docs/cli.md`: documented the `html` output format and the
+  `--no-use-lockfile` flag on `dependi-lsp scan`. Extended the **Supported
+  Files** table with Ruby (`Gemfile`), Java (`pom.xml`), and the previously
+  missing Python entries (`constraints.txt`, `hatch.toml`) so the CLI
+  reference now matches `dependi-lsp/src/file_types.rs`.
+
 ### Changed
 
 - Declared `tokio` features explicitly in `dependi-lsp/Cargo.toml`: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Files** table with Ruby (`Gemfile`), Java (`pom.xml`), and the previously
   missing Python entries (`constraints.txt`, `hatch.toml`) so the CLI
   reference now matches `dependi-lsp/src/file_types.rs`.
+- `README.md`: re-synced with the current code:
+  - Added Java/Maven Central to the **Supported Languages** table,
+    the **CI/CD Supported Files** list, and the FAQ registries table.
+    Added Ruby to the CLI **Supported Files** list (it was already in
+    the main table but missing from the CI/CD section).
+  - Added the `html` output format and `--no-use-lockfile` flag to the
+    CI/CD **Options** table.
+  - Refreshed the **Project Structure** tree with `parsers/maven.rs`,
+    `parsers/pnpm_workspace.rs`, `parsers/json_spans.rs`,
+    `parsers/lockfile_graph.rs`, `parsers/lockfile_resolver.rs`,
+    `registries/maven_central.rs`, and `registries/url_sanitizer.rs`.
+  - Updated the **Architecture** diagram to include `pom.xml`,
+    `pnpm-workspace`, and the Maven Central registry node.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 - `docs/configuration.md`: added an **Environment Variables** subsection
-  documenting `RUST_LOG`, `OSV_ENDPOINT`, `CARGO_HOME`, and `GITHUB_TOKEN`.
-  `OSV_ENDPOINT` was previously only discoverable from `dependi-lsp/src/main.rs`.
+  documenting `RUST_LOG`, `OSV_ENDPOINT`, `CARGO_HOME`, and the
+  `EnvTokenProvider` token-variable pattern used by Cargo alternative
+  registries and npm scoped registries. The `OSV_ENDPOINT` row now
+  reflects that only the `scan` subcommand reads it (the three
+  `profile-*` paths construct `OsvClient::default()` directly), and the
+  token-variable row clarifies that `.npmrc` `${VAR}` expansion is
+  test-only and not wired into the runtime auth path.
 - `CONTRIBUTING.md`: added a **Developer Scripts** table covering
   `build-and-deploy.sh`, `run-benchmarks.sh`, `scripts/coverage.sh`,
   `scripts/fuzz.sh`, `scripts/profile-*.sh`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   token-variable row clarifies that `.npmrc` `${VAR}` expansion is
   test-only and not wired into the runtime auth path.
 - `CONTRIBUTING.md`: added a **Developer Scripts** table covering
-  `build-and-deploy.sh`, `run-benchmarks.sh`, `scripts/coverage.sh`,
-  `scripts/fuzz.sh`, `scripts/profile-*.sh`, and
-  `scripts/check_mermaid_syntax.sh` so contributors discover the helper scripts
-  without grepping the repo root.
+  `run-benchmarks.sh`, `scripts/coverage.sh`, `scripts/fuzz.sh`,
+  `scripts/profile-*.sh`, and `scripts/check_mermaid_syntax.sh` so
+  contributors discover the helper scripts without grepping the repo
+  root. (`build-and-deploy.sh` is not included because it is
+  `.gitignore`d as a personal dev helper, not a tracked file.)
+- `docs/cli.md` and `README.md`: the `--no-use-lockfile` row now lists
+  only the lockfiles `run_scan` actually wires into a graph
+  (`Cargo.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`,
+  `poetry.lock`, `uv.lock`, `Pipfile.lock`, `composer.lock`,
+  `Gemfile.lock`), calls out `bun.lock` and `pdm.lock` as detected but
+  empty, and notes that Go, Dart, .NET, and Maven have no lockfile
+  graph parser yet. Avoids implying transitive-vuln coverage for
+  ecosystems that fall through the `_ => {}` arm in `src/main.rs`.
 - `docs/cli.md`: documented the `html` output format and the
   `--no-use-lockfile` flag on `dependi-lsp scan`. Extended the **Supported
   Files** table with Ruby (`Gemfile`) and Java (`pom.xml`). Python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -412,9 +412,9 @@ the repository root.
 | `scripts/coverage.sh` | Generate test coverage with `cargo-tarpaulin` (HTML + JSON in `coverage/`). Honors `FAIL_UNDER=<pct>` to fail the run below a threshold. |
 | `scripts/fuzz.sh [TARGET] [SECONDS]` | Run cargo-fuzz targets via the nightly toolchain. `--list` enumerates targets; default duration is 30s per target. See the Fuzz Testing section above. |
 | `scripts/profile-parse.sh [FILE] [ITERATIONS]` | Flamegraph profile of the parser hot path. Requires `cargo install flamegraph`. |
-| `scripts/profile-registry.sh [FILE] [ITERATIONS]` | Flamegraph profile of registry client fetches. |
+| `scripts/profile-registry.sh [REGISTRY] [PACKAGES] [ITERATIONS]` | Flamegraph profile of registry client fetches. `REGISTRY` is a clap value (`crates`, `npm`, `pypi`, `go`, `packagist`, `pub-dev`, `nuget`, `rubygems`); `PACKAGES` is a comma-separated list (default: `lodash,express,react,axios,moment`). |
 | `scripts/profile-full.sh [FILE] [ITERATIONS]` | Flamegraph profile of the full document-processing workflow (parse + registry + cache + vulnerabilities). |
-| `scripts/check_mermaid_syntax.sh [DOC.md]` | Validate every fenced ` ```mermaid ` block in a markdown file using `@mermaid-js/mermaid-cli`. Defaults to `docs/architecture.md`. Used in CI to prevent broken diagrams. |
+| `scripts/check_mermaid_syntax.sh [DOC.md]` | Validate every fenced ````` ```mermaid ````` block in a markdown file using `@mermaid-js/mermaid-cli`. Defaults to `docs/architecture.md`. Used in CI to prevent broken diagrams. |
 
 ## Bug Reports
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -400,6 +400,22 @@ cargo clippy --all-targets -- -D warnings
 cargo test
 ```
 
+### Developer Scripts
+
+Helper scripts live at the repo root and in `scripts/`. All paths are relative to
+the repository root.
+
+| Script | Purpose |
+|--------|---------|
+| `./build-and-deploy.sh` | Build the LSP in release mode and copy the binary into the local `dependi-zed/dependi-lsp-1.0.0/` dev-extension dir plus every installed `~/.local/share/zed/extensions/work/dependi/dependi-lsp-v*` directory (macOS path under `~/Library/Application Support/Zed/...`). Restart Zed afterwards. |
+| `./run-benchmarks.sh [FILTER]` | Run Criterion benchmarks. Flags: `--baseline` saves results as `main` baseline; `--compare` diffs the current run against it. Opens the HTML report when a browser opener is available. |
+| `scripts/coverage.sh` | Generate test coverage with `cargo-tarpaulin` (HTML + JSON in `coverage/`). Honors `FAIL_UNDER=<pct>` to fail the run below a threshold. |
+| `scripts/fuzz.sh [TARGET] [SECONDS]` | Run cargo-fuzz targets via the nightly toolchain. `--list` enumerates targets; default duration is 30s per target. See the Fuzz Testing section above. |
+| `scripts/profile-parse.sh [FILE] [ITERATIONS]` | Flamegraph profile of the parser hot path. Requires `cargo install flamegraph`. |
+| `scripts/profile-registry.sh [FILE] [ITERATIONS]` | Flamegraph profile of registry client fetches. |
+| `scripts/profile-full.sh [FILE] [ITERATIONS]` | Flamegraph profile of the full document-processing workflow (parse + registry + cache + vulnerabilities). |
+| `scripts/check_mermaid_syntax.sh [DOC.md]` | Validate every fenced ` ```mermaid ` block in a markdown file using `@mermaid-js/mermaid-cli`. Defaults to `docs/architecture.md`. Used in CI to prevent broken diagrams. |
+
 ## Bug Reports
 
 When reporting bugs, please include:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -407,7 +407,6 @@ the repository root.
 
 | Script | Purpose |
 |--------|---------|
-| `./build-and-deploy.sh` | Build the LSP in release mode and copy the binary into the local `dependi-zed/dependi-lsp-1.0.0/` dev-extension dir plus every installed `~/.local/share/zed/extensions/work/dependi/dependi-lsp-v*` directory (macOS path under `~/Library/Application Support/Zed/...`). Restart Zed afterwards. |
 | `./run-benchmarks.sh [FILTER]` | Run Criterion benchmarks. Flags: `--baseline` saves results as `main` baseline; `--compare` diffs the current run against it. Opens the HTML report when a browser opener is available. |
 | `scripts/coverage.sh` | Generate test coverage with `cargo-tarpaulin` (HTML + JSON in `coverage/`). Honors `FAIL_UNDER=<pct>` to fail the run below a threshold. |
 | `scripts/fuzz.sh [TARGET] [SECONDS]` | Run cargo-fuzz targets via the nightly toolchain. `--list` enumerates targets; default duration is 30s per target. See the Fuzz Testing section above. |

--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ Dependency management extension for the [Zed](https://zed.dev) editor.
 | Language | File | Registry | Status |
 |----------|------|----------|--------|
 | Rust | `Cargo.toml` | crates.io + alternative registries | ✅ |
-| JavaScript/TypeScript | `package.json` | npm | ✅ |
+| JavaScript/TypeScript | `package.json` | npm (+ pnpm workspace catalogs) | ✅ |
 | Python | `requirements.txt`, `constraints.txt`, `pyproject.toml`, `hatch.toml` | PyPI | ✅ |
 | Go | `go.mod` | proxy.golang.org | ✅ |
 | PHP | `composer.json` | Packagist | ✅ |
 | Dart/Flutter | `pubspec.yaml` | pub.dev | ✅ |
 | C#/.NET | `*.csproj` | NuGet | ✅ |
 | Ruby | `Gemfile` | RubyGems.org | ✅ |
+| Java | `pom.xml` | Maven Central | ✅ |
 
 ## Installation
 
@@ -105,6 +106,7 @@ zed-dependi/
 │   │   │   ├── cargo_lock.rs # Cargo.lock lockfile
 │   │   │   ├── npm.rs     # package.json parser
 │   │   │   ├── npm_lock.rs # package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lock
+│   │   │   ├── pnpm_workspace.rs # pnpm-workspace.yaml catalog resolution
 │   │   │   ├── python.rs  # requirements.txt, constraints.txt, pyproject.toml, hatch.toml
 │   │   │   ├── python_lock.rs # poetry.lock, uv.lock, pdm.lock, Pipfile.lock
 │   │   │   ├── go.rs      # go.mod parser
@@ -116,7 +118,11 @@ zed-dependi/
 │   │   │   ├── dart.rs    # pubspec.yaml parser
 │   │   │   ├── pubspec_lock.rs # pubspec.lock lockfile
 │   │   │   ├── csharp.rs  # *.csproj parser
-│   │   │   └── packages_lock_json.rs # packages.lock.json lockfile
+│   │   │   ├── packages_lock_json.rs # packages.lock.json lockfile
+│   │   │   ├── maven.rs   # pom.xml parser
+│   │   │   ├── json_spans.rs # Shared JSON span tracking
+│   │   │   ├── lockfile_graph.rs # Transitive dependency graph
+│   │   │   └── lockfile_resolver.rs # Manifest ↔ lockfile resolution
 │   │   ├── registries/    # Package registry clients
 │   │   │   ├── crates_io.rs    # crates.io API
 │   │   │   ├── cargo_sparse.rs # Cargo alternative registries (sparse index)
@@ -127,7 +133,9 @@ zed-dependi/
 │   │   │   ├── pub_dev.rs      # pub.dev (Dart)
 │   │   │   ├── nuget.rs        # NuGet (.NET)
 │   │   │   ├── rubygems.rs     # RubyGems
+│   │   │   ├── maven_central.rs # Maven Central (Java)
 │   │   │   ├── http_client.rs  # Shared HTTP client
+│   │   │   ├── url_sanitizer.rs # Registry URL hardening
 │   │   │   └── version_utils.rs # Shared version utilities
 │   │   ├── providers/     # LSP feature providers
 │   │   │   ├── inlay_hints.rs
@@ -340,9 +348,10 @@ dependi-lsp scan --file <path> [options]
 | Option | Short | Default | Description |
 |--------|-------|---------|-------------|
 | `--file <path>` | `-f` | required | Path to dependency file to scan |
-| `--output <format>` | `-o` | `summary` | Output format: `summary`, `json`, `markdown` |
+| `--output <format>` | `-o` | `summary` | Output format: `summary`, `json`, `markdown`, `html` |
 | `--min-severity <level>` | `-m` | `low` | Minimum severity to report: `low`, `medium`, `high`, `critical` |
 | `--fail-on-vulns` | | `true` | Exit with code 1 if vulnerabilities are found |
+| `--no-use-lockfile` | | (off) | Disable lockfile-based scanning. By default, when a sibling lockfile is present (`Cargo.lock`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `go.sum`, `composer.lock`, `pubspec.lock`, `packages.lock.json`, `Gemfile.lock`, `poetry.lock`, `uv.lock`, `pdm.lock`, `Pipfile.lock`), the scanner walks the full dependency graph; this flag restricts it to direct dependencies only. |
 
 #### Supported Files
 
@@ -353,6 +362,8 @@ dependi-lsp scan --file <path> [options]
 - PHP: `composer.json`
 - Dart/Flutter: `pubspec.yaml`
 - C#/.NET: `*.csproj`
+- Ruby: `Gemfile`
+- Java: `pom.xml`
 
 #### Exit Codes
 
@@ -518,14 +529,16 @@ security-scan:
 │  ├──────────────┤  ├──────────────┤  ├──────────────┤      │
 │  │ • Cargo.toml │  │ • Inlay Hints│  │ • crates.io  │      │
 │  │ • package.json│ │ • Diagnostics│  │ • Cargo alt  │      │
-│  │ • requirements│ │ • Code Action│  │ • npm        │      │
-│  │ • constraints│  │ • Completion │  │ • PyPI       │      │
-│  │ • pyproject  │  │ • Hover      │  │ • Go Proxy   │      │
-│  │ • go.mod     │  │ • Doc Links  │  │ • Packagist  │      │
-│  │ • composer   │  └──────────────┘  │ • pub.dev    │      │
-│  │ • pubspec    │                    │ • NuGet      │      │
-│  │ • *.csproj   │                    │ • RubyGems   │      │
+│  │ • pnpm-workspace│ • Code Action│  │ • npm        │      │
+│  │ • requirements│ │ • Completion │  │ • PyPI       │      │
+│  │ • constraints│  │ • Hover      │  │ • Go Proxy   │      │
+│  │ • pyproject  │  │ • Doc Links  │  │ • Packagist  │      │
+│  │ • go.mod     │  └──────────────┘  │ • pub.dev    │      │
+│  │ • composer   │                    │ • NuGet      │      │
+│  │ • pubspec    │                    │ • RubyGems   │      │
+│  │ • *.csproj   │                    │ • Maven Cent.│      │
 │  │ • Gemfile    │                    └──────────────┘      │
+│  │ • pom.xml    │                                           │
 │  └──────────────┘                                           │
 │                                                             │
 │  ┌──────────────────────────────────────────────────────┐  │
@@ -705,6 +718,7 @@ Yes, with limitations. If packages were previously cached, their information rem
 | Dart/Flutter | pub.dev | https://pub.dev |
 | C#/.NET | NuGet | https://api.nuget.org |
 | Ruby | RubyGems | https://rubygems.org |
+| Java | Maven Central | https://repo.maven.apache.org/maven2 |
 
 ### What data does the extension collect?
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ dependi-lsp scan --file <path> [options]
 | `--output <format>` | `-o` | `summary` | Output format: `summary`, `json`, `markdown`, `html` |
 | `--min-severity <level>` | `-m` | `low` | Minimum severity to report: `low`, `medium`, `high`, `critical` |
 | `--fail-on-vulns` | | `true` | Exit with code 1 if vulnerabilities are found |
-| `--no-use-lockfile` | | (off) | Disable lockfile-based scanning. By default, when a sibling lockfile is present (`Cargo.lock`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `go.sum`, `composer.lock`, `pubspec.lock`, `packages.lock.json`, `Gemfile.lock`, `poetry.lock`, `uv.lock`, `pdm.lock`, `Pipfile.lock`), the scanner walks the full dependency graph; this flag restricts it to direct dependencies only. |
+| `--no-use-lockfile` | | (off) | Disable lockfile-based scanning. By default, when a sibling lockfile from one of the wired ecosystems is present, the scanner walks the full dependency graph; this flag restricts it to direct dependencies only. Lockfiles with full graph support today: `Cargo.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `poetry.lock`, `uv.lock`, `Pipfile.lock`, `composer.lock`, `Gemfile.lock`. Lockfiles detected but currently treated as empty graphs: `bun.lock`, `pdm.lock`. Go (`go.sum`), Dart (`pubspec.lock`), .NET (`packages.lock.json`), and Maven have no lockfile graph parser yet. |
 
 #### Supported Files
 

--- a/README.md
+++ b/README.md
@@ -357,13 +357,18 @@ dependi-lsp scan --file <path> [options]
 
 - Rust: `Cargo.toml`
 - JavaScript/TypeScript: `package.json`
-- Python: `requirements.txt`, `constraints.txt`, `pyproject.toml`, `hatch.toml`
+- Python: `requirements.txt`, `pyproject.toml`
 - Go: `go.mod`
 - PHP: `composer.json`
 - Dart/Flutter: `pubspec.yaml`
 - C#/.NET: `*.csproj`
 - Ruby: `Gemfile`
 - Java: `pom.xml`
+
+> **Note:** The CLI `scan` subcommand only routes the files listed above.
+> Inside the LSP (when editing in Zed) `constraints.txt` and `hatch.toml`
+> are also recognised as Python manifests; the standalone CLI scanner does
+> not currently route them.
 
 #### Exit Codes
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,9 +34,10 @@ dependi-lsp scan --file <path> [options]
 | Option | Short | Default | Description |
 |--------|-------|---------|-------------|
 | `--file <path>` | `-f` | required | Path to dependency file |
-| `--output <format>` | `-o` | `summary` | Output format: `summary`, `json`, `markdown` |
+| `--output <format>` | `-o` | `summary` | Output format: `summary`, `json`, `markdown`, `html` |
 | `--min-severity <level>` | `-m` | `low` | Minimum severity: `low`, `medium`, `high`, `critical` |
 | `--fail-on-vulns` | | `true` | Exit with code 1 if vulnerabilities found |
+| `--no-use-lockfile` | | (off) | Disable lockfile-based scanning. By default, when a sibling lockfile (e.g. `Cargo.lock`, `package-lock.json`, `pnpm-lock.yaml`, `go.sum`, `composer.lock`, `pubspec.lock`, `packages.lock.json`, `Gemfile.lock`) exists next to the manifest, the scanner resolves transitive dependencies from it. Pass this flag to scan only the manifest's direct dependencies. |
 
 ### Supported Files
 
@@ -44,11 +45,13 @@ dependi-lsp scan --file <path> [options]
 |----------|-------|
 | Rust | `Cargo.toml` |
 | Node.js | `package.json` |
-| Python | `requirements.txt`, `pyproject.toml` |
+| Python | `requirements.txt`, `constraints.txt`, `pyproject.toml`, `hatch.toml` |
 | Go | `go.mod` |
 | PHP | `composer.json` |
 | Dart | `pubspec.yaml` |
 | .NET | `*.csproj` |
+| Ruby | `Gemfile` |
+| Java | `pom.xml` |
 
 ### Exit Codes
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,7 +37,7 @@ dependi-lsp scan --file <path> [options]
 | `--output <format>` | `-o` | `summary` | Output format: `summary`, `json`, `markdown`, `html` |
 | `--min-severity <level>` | `-m` | `low` | Minimum severity: `low`, `medium`, `high`, `critical` |
 | `--fail-on-vulns` | | `true` | Exit with code 1 if vulnerabilities found |
-| `--no-use-lockfile` | | (off) | Disable lockfile-based scanning. By default, when a sibling lockfile (e.g. `Cargo.lock`, `package-lock.json`, `pnpm-lock.yaml`, `go.sum`, `composer.lock`, `pubspec.lock`, `packages.lock.json`, `Gemfile.lock`) exists next to the manifest, the scanner resolves transitive dependencies from it. Pass this flag to scan only the manifest's direct dependencies. |
+| `--no-use-lockfile` | | (off) | Disable lockfile-based scanning. By default, when a sibling lockfile from one of the wired ecosystems exists next to the manifest, the scanner resolves transitive dependencies from it. Pass this flag to scan only the manifest's direct dependencies. Lockfiles with full graph support today: `Cargo.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `poetry.lock`, `uv.lock`, `Pipfile.lock`, `composer.lock`, `Gemfile.lock`. Lockfiles detected but currently treated as empty graphs (no transitive coverage): `bun.lock`, `pdm.lock`. Go (`go.sum`), Dart (`pubspec.lock`), .NET (`packages.lock.json`), and Maven have no lockfile graph parser yet — those scans only see direct dependencies regardless of this flag. |
 
 ### Supported Files
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,13 +45,19 @@ dependi-lsp scan --file <path> [options]
 |----------|-------|
 | Rust | `Cargo.toml` |
 | Node.js | `package.json` |
-| Python | `requirements.txt`, `constraints.txt`, `pyproject.toml`, `hatch.toml` |
+| Python | `requirements.txt`, `pyproject.toml` |
 | Go | `go.mod` |
 | PHP | `composer.json` |
 | Dart | `pubspec.yaml` |
 | .NET | `*.csproj` |
 | Ruby | `Gemfile` |
 | Java | `pom.xml` |
+
+{: .note }
+The CLI `scan` subcommand only routes the files listed above. Inside the LSP
+(when editing in Zed) a broader set is recognised, including
+`constraints.txt` and `hatch.toml` for Python — see the
+[Supported Languages]({% link index.md %}) table.
 
 ### Exit Codes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -386,3 +386,22 @@ Run Zed with debug logging to see configuration loading:
 ```bash
 RUST_LOG=debug zed --foreground
 ```
+
+### Environment Variables
+
+The LSP reads a small set of environment variables. Most users do not need to set
+any of them; they exist for advanced configuration and tests.
+
+| Variable | Used by | Description |
+|----------|---------|-------------|
+| `RUST_LOG` | `tracing-subscriber` | Log filter (e.g. `debug`, `dependi_lsp=trace`). |
+| `OSV_ENDPOINT` | `dependi-lsp` CLI (`scan`/`profile-*`) | Override the OSV.dev base URL for vulnerability queries. Used by the integration test harness to point at a local mock server; can also be set to a private OSV-compatible mirror. |
+| `CARGO_HOME` | Cargo registry auth resolver | Standard Cargo variable. When set, the LSP reads `${CARGO_HOME}/credentials.toml` instead of `~/.cargo/credentials.toml` to discover alternative registry tokens. |
+| `GITHUB_TOKEN` | npm registry auth (`.npmrc` `${VAR}` expansion) | Resolved when an `.npmrc` line references it, e.g. `//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}`. The variable name itself is not special — any name referenced from `.npmrc` is read from the environment. |
+
+#### Example — pointing `scan` at a mock OSV server
+
+```bash
+OSV_ENDPOINT=http://127.0.0.1:8787 \
+    dependi-lsp scan --file Cargo.toml
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -395,9 +395,9 @@ any of them; they exist for advanced configuration and tests.
 | Variable | Used by | Description |
 |----------|---------|-------------|
 | `RUST_LOG` | `tracing-subscriber` | Log filter (e.g. `debug`, `dependi_lsp=trace`). |
-| `OSV_ENDPOINT` | `dependi-lsp` CLI (`scan`/`profile-*`) | Override the OSV.dev base URL for vulnerability queries. Used by the integration test harness to point at a local mock server; can also be set to a private OSV-compatible mirror. |
+| `OSV_ENDPOINT` | `dependi-lsp scan` | Override the OSV.dev base URL for vulnerability queries. Honored only by the `scan` subcommand (see `dependi-lsp/src/main.rs::run_scan`); `profile-parse`, `profile-registry`, and `profile-full` construct `OsvClient::default()` directly and ignore this variable. Used by the integration test harness to point at a local mock server; can also be set to a private OSV-compatible mirror. |
 | `CARGO_HOME` | Cargo registry auth resolver | Standard Cargo variable. When set, the LSP reads `${CARGO_HOME}/credentials.toml` instead of `~/.cargo/credentials.toml` to discover alternative registry tokens. |
-| `GITHUB_TOKEN` | npm registry auth (`.npmrc` `${VAR}` expansion) | Resolved when an `.npmrc` line references it, e.g. `//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}`. The variable name itself is not special — any name referenced from `.npmrc` is read from the environment. |
+| `<TOKEN_VAR>` (e.g. `GITHUB_TOKEN`, `COMPANY_NPM_TOKEN`) | `EnvTokenProvider` in `src/auth/mod.rs` | Read at LSP startup for every registry whose settings declare `"auth": { "type": "env", "variable": "<NAME>" }` (Cargo alternative registries and npm scoped registries — see the configuration examples above). The variable name is whatever the JSON references; there are no hardcoded names. Note: `.npmrc` `${VAR}` expansion is **not** currently wired into the runtime auth path (`src/auth/npmrc.rs` is test-only, gated on `#[cfg(test)]`) — tokens must come from LSP settings. |
 
 #### Example — pointing `scan` at a mock OSV server
 


### PR DESCRIPTION
## Summary

Three documentation pages had drifted from the source of truth. This PR re-syncs them and adds two missing references.

- **`docs/configuration.md`** — new **Environment Variables** section documenting `RUST_LOG`, `OSV_ENDPOINT`, `CARGO_HOME`, and `GITHUB_TOKEN`. `OSV_ENDPOINT` (used in `dependi-lsp/src/main.rs:434` to override the OSV.dev base URL) was previously undocumented.
- **`CONTRIBUTING.md`** — new **Developer Scripts** table covering the seven helper scripts (`build-and-deploy.sh`, `run-benchmarks.sh`, `scripts/coverage.sh`, `scripts/fuzz.sh`, `scripts/profile-{parse,registry,full}.sh`, `scripts/check_mermaid_syntax.sh`) that contributors previously had to discover by `ls`-ing the repo.
- **`docs/cli.md`** — three drifts against the current code:
  - Output format table now includes `html` (added to `OutputFormat` enum in `src/main.rs:38`).
  - New `--no-use-lockfile` flag row (added to the `Scan` subcommand in `src/main.rs:63-65`).
  - Supported Files table extended with Ruby (`Gemfile`), Java (`pom.xml`), and the Python edge cases (`constraints.txt`, `hatch.toml`) that `src/file_types.rs::FileType::detect` already recognises.

## Why

The three docs were last edited 2026-01-10 and predated multiple feature additions (lockfile scanning, html output, Ruby/Java parsers, Python edge-case routing). Symptom-based pages (`docs/troubleshooting.md`) and command-surface pages (`docs/profiling.md`) were re-verified during the audit and need no changes.

## Changes

- `CHANGELOG.md` — new `### Documentation` subsection under `[Unreleased]`.
- `CONTRIBUTING.md` — Developer Scripts table appended to **Build Commands Reference**.
- `docs/configuration.md` — Environment Variables subsection appended to **Debugging**.
- `docs/cli.md` — Options table + Supported Files table updated.

## Testing

- [ ] CI green (markdown link check, Jekyll build).
- [x] Cross-checked every option / file-type / env var against `dependi-lsp/src/main.rs`, `src/file_types.rs`, `src/config.rs`, and `src/auth/npmrc.rs`.
- [x] Verified each documented script path resolves and matches its current signature.
- [x] No code changes — pure documentation PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync CLI, environment variable docs, developer scripts, and README with current code to remove drift. Adds `html` output, Ruby/Java support, and scopes `--no-use-lockfile` to supported lockfiles; clarifies `OSV_ENDPOINT` and documents the `EnvTokenProvider` pattern; trims Python CLI routing.

- **Docs updates**
  - `docs/cli.md`: add `html` output; add `--no-use-lockfile` with explicit coverage (full graphs: `Cargo.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `poetry.lock`, `uv.lock`, `Pipfile.lock`, `composer.lock`, `Gemfile.lock`; empty graphs: `bun.lock`, `pdm.lock`; no parser yet: Go, Dart, .NET, Maven); extend Supported Files with Ruby (`Gemfile`) and Java (`pom.xml`); limit Python to `requirements.txt` and `pyproject.toml` with an LSP-only callout for `constraints.txt`/`hatch.toml`.
  - `docs/configuration.md`: new Environment Variables section for `RUST_LOG`, `OSV_ENDPOINT` (scan-only), `CARGO_HOME`, and the `EnvTokenProvider` token-variable pattern (Cargo alt registries and npm scoped registries). Note `.npmrc` `${VAR}` expansion is test-only.
  - `CONTRIBUTING.md`: add Developer Scripts table (excludes gitignored `build-and-deploy.sh`); fix `profile-registry.sh` signature; escape the mermaid fenced-code marker.
  - `README.md`: add Java/Maven Central and Ruby to supported/CI lists; note npm + `pnpm` workspace catalogs; document `html` output and the scoped `--no-use-lockfile`; refresh project structure with `parsers/maven.rs`, `parsers/pnpm_workspace.rs`, `parsers/json_spans.rs`, `parsers/lockfile_graph.rs`, `parsers/lockfile_resolver.rs`, `registries/maven_central.rs`, `registries/url_sanitizer.rs`; update architecture diagram.
  - `CHANGELOG.md`: record these documentation changes and the script exclusion.

<sup>Written for commit 3110c4b95e76765832cba25be1e45adae091e10a. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/zed-dependi/pull/337?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CLI docs: HTML output option, clarified fail-on-vulns exit behavior, and added a no-lockfile flag
  * Added Environment Variables section (RUST_LOG, OSV_ENDPOINT noted for scan, CARGO_HOME, token-variable pattern)
  * Expanded supported files: Ruby (Gemfile) and Java (pom.xml/Maven); CLI limits Python manifests while the LSP recognizes additional Python files (e.g., constraints.txt, hatch.toml)
  * Added Developer Scripts table and synced README/CHANGELOG/architecture diagram

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/zed-dependi/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->