### PR TITLE
fix(lsp): preserve version constraints in update actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Dependency update actions now preserve recognized version constraint
+  operators, spacing, wrappers, and range-shaping precision across supported
+  ecosystems. Unsafe compound or indirect declarations are omitted from
+  individual and bulk updates instead of being replaced with a bare version.
+  ([#351](https://github.com/mpiton/zed-dependi/issues/351))
+
 ## [1.9.1] - 2026-06-29
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   individual and bulk updates instead of being replaced with a bare version.
   ([#351](https://github.com/mpiton/zed-dependi/issues/351))
 
+### Security
+
+- Updated `quick-xml` to 0.41.0 and `crossbeam-epoch` to 0.9.20 to address
+  RUSTSEC-2026-0194, RUSTSEC-2026-0195, and RUSTSEC-2026-0204.
+
 ## [1.9.1] - 2026-06-29
 
 ### Documentation

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1661,9 +1661,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -36,7 +36,7 @@ clap = { version = "4.5.60", features = ["derive"] }
 futures = "0.3.32"
 taplo = "0.14"
 hashbrown = { version = "0.17.1", features = ["serde"] }
-quick-xml = "0.40.1"
+quick-xml = "0.41.0"
 url = "2.5"
 async-trait = "0.1"
 json-spanned-value = "0.2.2"

--- a/dependi-lsp/src/backend.rs
+++ b/dependi-lsp/src/backend.rs
@@ -2004,6 +2004,7 @@ mod tests {
             optional: false,
             registry: None,
             resolved_version: resolved.map(str::to_string),
+            has_additional_version_constraints: false,
         }
     }
 

--- a/dependi-lsp/src/docs/swift_tutorial_fixture.rs
+++ b/dependi-lsp/src/docs/swift_tutorial_fixture.rs
@@ -42,6 +42,7 @@
 //!     optional: false,
 //!     registry: None,
 //!     resolved_version: None,
+//!     has_additional_version_constraints: false,
 //! };
 //! assert_eq!(dep.effective_version(), "1.3.0");
 //! ```
@@ -103,6 +104,7 @@
 //!                 optional: false,
 //!                 registry: None,
 //!                 resolved_version: None,
+//!                 has_additional_version_constraints: false,
 //!             });
 //!         }
 //!         deps
@@ -240,6 +242,7 @@
 //!             optional: false,
 //!             registry: None,
 //!             resolved_version: None,
+//!             has_additional_version_constraints: false,
 //!         }]
 //!     }
 //! }

--- a/dependi-lsp/src/parsers/cargo.rs
+++ b/dependi-lsp/src/parsers/cargo.rs
@@ -171,6 +171,7 @@ fn parse_dependency(
                 optional: false,
                 registry: None,
                 resolved_version: None,
+                has_additional_version_constraints: false,
             })
         }
         Node::Table(table) => {
@@ -211,6 +212,7 @@ fn parse_dependency(
                 optional,
                 registry,
                 resolved_version: None,
+                has_additional_version_constraints: false,
             })
         }
         _ => None,

--- a/dependi-lsp/src/parsers/cargo_lock.rs
+++ b/dependi-lsp/src/parsers/cargo_lock.rs
@@ -561,6 +561,7 @@ version = "1.0.0"
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         };
         // Root package's dependency string `"multi 1.0.0"` should override
         // the first-wins `"2.0.0"` from the graph order.
@@ -603,6 +604,7 @@ version = "5.5.5"
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         };
         assert_eq!(
             resolver.resolve_version(&dep, &graph),

--- a/dependi-lsp/src/parsers/composer_lock.rs
+++ b/dependi-lsp/src/parsers/composer_lock.rs
@@ -352,6 +352,7 @@ mod tests {
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         };
         assert_eq!(
             resolver.resolve_version(&dep, &graph),

--- a/dependi-lsp/src/parsers/csharp.rs
+++ b/dependi-lsp/src/parsers/csharp.rs
@@ -117,6 +117,7 @@ fn parse_package_reference(line: &str, line_num: u32) -> Option<Dependency> {
         optional: false,
         registry: None,
         resolved_version: None,
+        has_additional_version_constraints: false,
     })
 }
 

--- a/dependi-lsp/src/parsers/csharp.rs
+++ b/dependi-lsp/src/parsers/csharp.rs
@@ -80,15 +80,12 @@ fn parse_package_reference(line: &str, line_num: u32) -> Option<Dependency> {
         let version_content = &line[version_attr_start + 9..];
         let version_end = version_content.find('"')?;
         version_content[..version_end].to_string()
-    } else if let Some(version_elem_start) = line.find("<Version>") {
+    } else {
+        let version_elem_start = line.find("<Version>")?;
         // Format: <Version>1.0.0</Version>
         let version_content = &line[version_elem_start + 9..];
         let version_end = version_content.find('<')?;
         version_content[..version_end].to_string()
-    } else {
-        // Version might be centrally managed (Directory.Packages.props)
-        // Skip for now
-        return None;
     };
 
     // Calculate positions

--- a/dependi-lsp/src/parsers/dart.rs
+++ b/dependi-lsp/src/parsers/dart.rs
@@ -205,6 +205,7 @@ fn parse_dart_dependency_line(line: &str, line_num: u32, dev: bool) -> Option<De
         optional: false,
         registry: None,
         resolved_version: None,
+        has_additional_version_constraints: false,
     })
 }
 

--- a/dependi-lsp/src/parsers/gemfile_lock.rs
+++ b/dependi-lsp/src/parsers/gemfile_lock.rs
@@ -606,6 +606,7 @@ BUNDLED WITH
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         };
         assert_eq!(
             resolver.resolve_version(&dep, &graph),

--- a/dependi-lsp/src/parsers/go.rs
+++ b/dependi-lsp/src/parsers/go.rs
@@ -174,6 +174,7 @@ fn parse_require_with_positions(
         optional: is_indirect,
         registry: None,
         resolved_version: None,
+        has_additional_version_constraints: false,
     })
 }
 

--- a/dependi-lsp/src/parsers/go_sum.rs
+++ b/dependi-lsp/src/parsers/go_sum.rs
@@ -306,6 +306,7 @@ github.com/foo/bar v1.0.0
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         };
         assert_eq!(
             resolver.resolve_version(&dep_with_match, &graph),
@@ -371,6 +372,7 @@ github.com/foo/bar v1.0.0
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         };
         // Two identical entries collapse to one unique candidate → return it.
         assert_eq!(

--- a/dependi-lsp/src/parsers/lockfile_resolver.rs
+++ b/dependi-lsp/src/parsers/lockfile_resolver.rs
@@ -223,6 +223,7 @@ version = "0.0.1"
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         }
     }
 

--- a/dependi-lsp/src/parsers/maven.rs
+++ b/dependi-lsp/src/parsers/maven.rs
@@ -288,6 +288,7 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
                                 optional,
                                 registry: None,
                                 resolved_version,
+                                has_additional_version_constraints: false,
                             });
                         }
                     }

--- a/dependi-lsp/src/parsers/mod.rs
+++ b/dependi-lsp/src/parsers/mod.rs
@@ -54,6 +54,12 @@ pub struct Dependency {
     /// When set, [`Self::effective_version`] returns this value instead of
     /// [`Self::version`] for registry comparisons and hover text.
     pub resolved_version: Option<String>,
+    /// Whether source syntax contains additional version constraints outside
+    /// [`Self::version`] and [`Self::version_span`].
+    ///
+    /// Providers use this source-shape metadata to avoid edits that would
+    /// update only one anchor of a compound declaration.
+    pub has_additional_version_constraints: bool,
 }
 
 /// A half-open byte range within a single source line.
@@ -105,6 +111,7 @@ impl Dependency {
     ///     optional: false,
     ///     registry: None,
     ///     resolved_version: Some("1.0.196".into()),
+    ///     has_additional_version_constraints: false,
     /// };
     /// assert_eq!(dep.effective_version(), "1.0.196");
     /// ```

--- a/dependi-lsp/src/parsers/npm.rs
+++ b/dependi-lsp/src/parsers/npm.rs
@@ -139,6 +139,7 @@ fn parse_section(
             optional,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         });
     }
 }

--- a/dependi-lsp/src/parsers/packages_lock_json.rs
+++ b/dependi-lsp/src/parsers/packages_lock_json.rs
@@ -328,6 +328,7 @@ mod tests {
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         };
         assert_eq!(
             resolver.resolve_version(&dep, &graph),

--- a/dependi-lsp/src/parsers/php.rs
+++ b/dependi-lsp/src/parsers/php.rs
@@ -112,6 +112,7 @@ fn parse_section(
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         });
     }
 }

--- a/dependi-lsp/src/parsers/pnpm_workspace.rs
+++ b/dependi-lsp/src/parsers/pnpm_workspace.rs
@@ -431,6 +431,7 @@ fn parse_catalog_entry(line_number: u32, line: &str) -> Option<Dependency> {
         optional: false,
         registry: None,
         resolved_version: None,
+        has_additional_version_constraints: false,
     })
 }
 
@@ -477,6 +478,7 @@ fn parse_flow_catalog_entry(
         optional: false,
         registry: None,
         resolved_version: None,
+        has_additional_version_constraints: false,
     })
 }
 

--- a/dependi-lsp/src/parsers/pubspec_lock.rs
+++ b/dependi-lsp/src/parsers/pubspec_lock.rs
@@ -161,6 +161,7 @@ mod tests {
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         };
         assert_eq!(
             resolver.resolve_version(&dep, &graph),

--- a/dependi-lsp/src/parsers/python.rs
+++ b/dependi-lsp/src/parsers/python.rs
@@ -175,87 +175,19 @@ fn parse_requirements_txt(content: &str) -> Vec<Dependency> {
 
 /// Parse a single requirement line
 fn parse_requirement_line(line: &str, line_num: u32, dev: bool) -> Option<Dependency> {
-    let trimmed = line.trim();
-
-    // Remove inline comments
-    let without_comment = if let Some(pos) = trimmed.find('#') {
-        &trimmed[..pos]
-    } else {
-        trimmed
-    };
-    let without_comment = without_comment.trim();
-
-    if without_comment.is_empty() {
-        return None;
-    }
-
-    // Extract package name (before version specifier or extras)
-    // Operators: ==, >=, <=, !=, ~=, >, <, ===
-    let operators = ["===", "==", ">=", "<=", "!=", "~=", ">", "<"];
-
-    let mut name_end_pos = without_comment.len();
-    let mut version_op_pos = None;
-    let mut version_op_len = 0;
-
-    for op in &operators {
-        if let Some(pos) = without_comment.find(op)
-            && pos < name_end_pos
-        {
-            name_end_pos = pos;
-            version_op_pos = Some(pos);
-            version_op_len = op.len();
-        }
-    }
-
-    // Handle extras: package[extra1,extra2]>=1.0
-    let name_part = &without_comment[..name_end_pos];
-    let name = if let Some(bracket_pos) = name_part.find('[') {
-        &name_part[..bracket_pos]
-    } else {
-        name_part
-    };
-    let name = name.trim();
-
-    if name.is_empty() {
-        return None;
-    }
-
-    // Extract version (including the operator, to align with Ruby/npm behavior)
-    let version = {
-        let op_pos = version_op_pos?;
-        let operator = &without_comment[op_pos..op_pos + version_op_len];
-        let version_part = &without_comment[op_pos + version_op_len..];
-        // Handle comma-separated version constraints: >=1.0,<2.0
-        let version_num = if let Some(comma_pos) = version_part.find(',') {
-            &version_part[..comma_pos]
-        } else {
-            version_part
-        };
-        // Remove environment markers: ; python_version >= "3.8"
-        let version_num = if let Some(semi_pos) = version_num.find(';') {
-            &version_num[..semi_pos]
-        } else {
-            version_num
-        };
-        let version_num = version_num.trim();
-        format!("{operator}{version_num}")
-    };
-
-    if version.is_empty() {
-        return None;
-    }
-
-    // Calculate positions
-    let name_start = line.find(name)? as u32;
-    let name_end = name_start + name.len() as u32;
-
-    // Find version (with operator) position in the original line
-    let version_start = line.find(&version)? as u32;
-    let version_end = version_start + version.len() as u32;
+    let without_comment = line
+        .split_once('#')
+        .map_or(line, |(before_comment, _)| before_comment)
+        .trim_end();
+    let parsed = parse_pep508_dependency(without_comment)?;
+    let name_start = u32::try_from(parsed.name_byte_range.0).ok()?;
+    let name_end = u32::try_from(parsed.name_byte_range.1).ok()?;
+    let version_start = u32::try_from(parsed.version_byte_range.0).ok()?;
+    let version_end = u32::try_from(parsed.version_byte_range.1).ok()?;
 
     Some(Dependency {
-        name: name.to_string(),
-        version,
+        name: parsed.name,
+        version: parsed.version,
         name_span: Span {
             line: line_num,
             line_start: name_start,
@@ -270,6 +202,7 @@ fn parse_requirement_line(line: &str, line_num: u32, dev: bool) -> Option<Depend
         optional: false,
         registry: None,
         resolved_version: None,
+        has_additional_version_constraints: parsed.has_additional_version_constraints,
     })
 }
 
@@ -419,6 +352,7 @@ fn parse_pep621_deps(dom: &Node, line_ranges: &[TextRange], deps: &mut Vec<Depen
         let Some((name_span, version_span)) = pep508_spans(item, &parsed, line_ranges) else {
             continue;
         };
+        let has_additional_version_constraints = parsed.has_additional_version_constraints;
         deps.push(Dependency {
             name: parsed.name,
             version: parsed.version,
@@ -428,6 +362,7 @@ fn parse_pep621_deps(dom: &Node, line_ranges: &[TextRange], deps: &mut Vec<Depen
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints,
         });
     }
 }
@@ -457,6 +392,7 @@ fn parse_pep621_optional(dom: &Node, line_ranges: &[TextRange], deps: &mut Vec<D
             let Some((name_span, version_span)) = pep508_spans(item, &parsed, line_ranges) else {
                 continue;
             };
+            let has_additional_version_constraints = parsed.has_additional_version_constraints;
             deps.push(Dependency {
                 name: parsed.name,
                 version: parsed.version,
@@ -466,6 +402,7 @@ fn parse_pep621_optional(dom: &Node, line_ranges: &[TextRange], deps: &mut Vec<D
                 optional: true,
                 registry: None,
                 resolved_version: None,
+                has_additional_version_constraints,
             });
         }
     }
@@ -506,6 +443,7 @@ fn parse_poetry_main(dom: &Node, line_ranges: &[TextRange], deps: &mut Vec<Depen
             optional,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         });
     }
 }
@@ -541,6 +479,7 @@ fn parse_poetry_dev_legacy(dom: &Node, line_ranges: &[TextRange], deps: &mut Vec
             optional,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         });
     }
 }
@@ -590,6 +529,7 @@ fn parse_poetry_groups(dom: &Node, line_ranges: &[TextRange], deps: &mut Vec<Dep
                 optional,
                 registry: None,
                 resolved_version: None,
+                has_additional_version_constraints: false,
             });
         }
     }
@@ -620,6 +560,7 @@ fn parse_pep735_groups(dom: &Node, line_ranges: &[TextRange], deps: &mut Vec<Dep
             let Some((name_span, version_span)) = pep508_spans(item, &parsed, line_ranges) else {
                 continue;
             };
+            let has_additional_version_constraints = parsed.has_additional_version_constraints;
             deps.push(Dependency {
                 name: parsed.name,
                 version: parsed.version,
@@ -629,6 +570,7 @@ fn parse_pep735_groups(dom: &Node, line_ranges: &[TextRange], deps: &mut Vec<Dep
                 optional: false,
                 registry: None,
                 resolved_version: None,
+                has_additional_version_constraints,
             });
         }
     }
@@ -664,6 +606,7 @@ fn parse_hatch_envs(envs_node: &Node, line_ranges: &[TextRange], deps: &mut Vec<
                 else {
                     continue;
                 };
+                let has_additional_version_constraints = parsed.has_additional_version_constraints;
                 deps.push(Dependency {
                     name: parsed.name,
                     version: parsed.version,
@@ -673,6 +616,7 @@ fn parse_hatch_envs(envs_node: &Node, line_ranges: &[TextRange], deps: &mut Vec<
                     optional: false,
                     registry: None,
                     resolved_version: None,
+                    has_additional_version_constraints,
                 });
             }
         }
@@ -708,12 +652,14 @@ fn parse_hatch_toml(content: &str) -> Vec<Dependency> {
 /// LSP quick-fixes can edit safely.
 struct Pep508Parsed {
     name: String,
-    /// Operator + version, formatted with no whitespace (e.g., `">=2.28.0"`).
+    /// Operator + first version anchor with source whitespace preserved.
     version: String,
     /// Byte range in `dep_str` covering the package name (excludes extras like `[security]`).
     name_byte_range: (usize, usize),
     /// Byte range in `dep_str` covering operator + version (whitespace inside is preserved).
     version_byte_range: (usize, usize),
+    /// Whether later comma-separated constraints exist outside `version_byte_range`.
+    has_additional_version_constraints: bool,
 }
 
 /// Parse PEP 508 dependency string: "package>=1.0.0" or "package[extra]>=1.0.0"
@@ -768,7 +714,6 @@ fn parse_pep508_dependency(dep_str: &str) -> Option<Pep508Parsed> {
     let name_end = name_start + name_trimmed.len();
 
     // Extract version (operator + numeric part, taking only the first constraint).
-    let operator = &without_markers[op_pos..op_pos + op_len];
     let version_part = &without_markers[op_pos + op_len..];
     let version_num_substr = if let Some(comma_pos) = version_part.find(',') {
         &version_part[..comma_pos]
@@ -786,12 +731,14 @@ fn parse_pep508_dependency(dep_str: &str) -> Option<Pep508Parsed> {
     let version_num_end_in_part = version_num_substr.trim_end().len();
     let v_start = wm_offset + op_pos;
     let v_end = wm_offset + op_pos + op_len + version_num_end_in_part;
+    let version = dep_str.get(v_start..v_end)?.to_string();
 
     Some(Pep508Parsed {
         name: name_trimmed.to_string(),
-        version: format!("{operator}{version_num}"),
+        version,
         name_byte_range: (name_start, name_end),
         version_byte_range: (v_start, v_end),
+        has_additional_version_constraints: version_part.contains(','),
     })
 }
 
@@ -1655,5 +1602,40 @@ dependencies = ["ruff>=0.1.0"]
         assert_eq!(dep.version, ">=0.1.0");
         assert_eq!(slice_span(content, &dep.version_span), ">=0.1.0");
         assert_eq!(slice_span(content, &dep.name_span), "ruff");
+    }
+
+    #[test]
+    fn requirements_preserve_spacing_and_track_additional_constraints() {
+        let content = "single>= 1.0\ncompound>= 1.0, < 2.0\n";
+        let deps = PythonParser::new().parse(content);
+
+        let single = deps.iter().find(|dep| dep.name == "single").unwrap();
+        assert_eq!(single.version, ">= 1.0");
+        assert_eq!(slice_span(content, &single.version_span), ">= 1.0");
+        assert!(!single.has_additional_version_constraints);
+
+        let compound = deps.iter().find(|dep| dep.name == "compound").unwrap();
+        assert_eq!(compound.version, ">= 1.0");
+        assert_eq!(slice_span(content, &compound.version_span), ">= 1.0");
+        assert!(compound.has_additional_version_constraints);
+    }
+
+    #[test]
+    fn pep508_arrays_preserve_spacing_and_track_additional_constraints() {
+        let content = concat!(
+            "[project]\n",
+            "dependencies = [\"single>= 1.0\", \"compound>= 1.0, < 2.0\"]\n"
+        );
+        let deps = PythonParser::new().parse(content);
+
+        let single = deps.iter().find(|dep| dep.name == "single").unwrap();
+        assert_eq!(single.version, ">= 1.0");
+        assert_eq!(slice_span(content, &single.version_span), ">= 1.0");
+        assert!(!single.has_additional_version_constraints);
+
+        let compound = deps.iter().find(|dep| dep.name == "compound").unwrap();
+        assert_eq!(compound.version, ">= 1.0");
+        assert_eq!(slice_span(content, &compound.version_span), ">= 1.0");
+        assert!(compound.has_additional_version_constraints);
     }
 }

--- a/dependi-lsp/src/parsers/python_lock.rs
+++ b/dependi-lsp/src/parsers/python_lock.rs
@@ -1127,6 +1127,7 @@ version = "0.5.0"
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         };
         // PEP 503: "some.package" → "some-package" should match "Some-Package" → "some-package"
         let v = resolver.resolve_version(&dep, &graph);

--- a/dependi-lsp/src/parsers/ruby.rs
+++ b/dependi-lsp/src/parsers/ruby.rs
@@ -113,36 +113,45 @@ fn parse_gem_declaration(line: &str, line_num: u32, dev: bool) -> Option<Depende
     };
 
     // Parse the arguments
-    let (name, version, name_start, name_end, version_start, version_end) =
-        parse_gem_args(line, after_gem)?;
+    let parsed = parse_gem_args(line, after_gem)?;
 
     Some(Dependency {
-        name,
-        version,
+        name: parsed.name,
+        version: parsed.version,
         name_span: Span {
             line: line_num,
-            line_start: name_start,
-            line_end: name_end,
+            line_start: parsed.name_start,
+            line_end: parsed.name_end,
         },
         version_span: Span {
             line: line_num,
-            line_start: version_start,
-            line_end: version_end,
+            line_start: parsed.version_start,
+            line_end: parsed.version_end,
         },
         dev,
         optional: false,
         registry: None,
         resolved_version: None,
+        has_additional_version_constraints: parsed.has_additional_version_constraints,
     })
 }
 
-/// Parses the argument list of a `gem` declaration and returns
-/// `(name, version, name_start, name_end, version_start, version_end)`.
+struct ParsedGemArgs {
+    name: String,
+    version: String,
+    name_start: u32,
+    name_end: u32,
+    version_start: u32,
+    version_end: u32,
+    has_additional_version_constraints: bool,
+}
+
+/// Parses the argument list of a `gem` declaration.
 ///
 /// Both single-quoted and double-quoted strings are accepted.
 /// Returns `None` when the second argument is absent, unquoted (e.g. a hash
 /// key), or contains a colon (version-as-symbol form).
-fn parse_gem_args(line: &str, args_str: &str) -> Option<(String, String, u32, u32, u32, u32)> {
+fn parse_gem_args(line: &str, args_str: &str) -> Option<ParsedGemArgs> {
     let bytes = args_str.as_bytes();
     let len = bytes.len();
 
@@ -175,7 +184,7 @@ fn parse_gem_args(line: &str, args_str: &str) -> Option<(String, String, u32, u3
     }
 
     // Parse second argument (version)
-    let (version, _) = parse_quoted_string(bytes, idx)?;
+    let (version, version_end_idx) = parse_quoted_string(bytes, idx)?;
 
     // Skip if version looks like a hash key
     if version.is_empty() || version.contains(':') {
@@ -185,15 +194,56 @@ fn parse_gem_args(line: &str, args_str: &str) -> Option<(String, String, u32, u3
     // Find positions in the original line
     let (name_start, name_end) = find_quoted_position(line, &name)?;
     let (version_start, version_end) = find_quoted_position(line, &version)?;
+    let has_additional_version_constraints = has_unproven_trailing_argument(bytes, version_end_idx);
 
-    Some((
+    Some(ParsedGemArgs {
         name,
         version,
         name_start,
         name_end,
         version_start,
         version_end,
-    ))
+        has_additional_version_constraints,
+    })
+}
+
+fn has_unproven_trailing_argument(bytes: &[u8], mut index: usize) -> bool {
+    while matches!(bytes.get(index), Some(b' ' | b'\t')) {
+        index += 1;
+    }
+    if bytes.get(index) != Some(&b',') {
+        return false;
+    }
+    index += 1;
+    while matches!(bytes.get(index), Some(b' ' | b'\t')) {
+        index += 1;
+    }
+
+    let Some(tail) = bytes.get(index..) else {
+        return true;
+    };
+    tail.is_empty() || !is_options_argument(tail)
+}
+
+fn is_options_argument(bytes: &[u8]) -> bool {
+    let Ok(argument) = std::str::from_utf8(bytes) else {
+        return false;
+    };
+    let argument = argument.trim_start();
+    if argument.starts_with('{') {
+        return true;
+    }
+    if let Some(symbol) = argument.strip_prefix(':') {
+        let key_end = symbol
+            .find(|character: char| !character.is_ascii_alphanumeric() && character != '_')
+            .unwrap_or(symbol.len());
+        return key_end > 0 && symbol[key_end..].trim_start().starts_with("=>");
+    }
+
+    let key_end = argument
+        .find(|character: char| !character.is_ascii_alphanumeric() && character != '_')
+        .unwrap_or(argument.len());
+    key_end > 0 && argument[key_end..].starts_with(':')
 }
 
 /// Parses a single- or double-quoted string from `bytes` starting at `start`.
@@ -464,5 +514,40 @@ end
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].name, "rails");
         assert_eq!(deps[0].version, "~> 7.0");
+    }
+
+    #[test]
+    fn tracks_additional_positional_constraints_but_not_options() {
+        let content = concat!(
+            "gem \"single\", \">= 1\", require: false\n",
+            "gem \"hash-option\", \">= 1\", { require: false }\n",
+            "gem \"legacy-option\", \">= 1\", :require => false\n",
+            "gem \"compound\", \">= 1\", \"< 2\"\n",
+            "gem \"variable-bound\", \">= 1\", UPPER_BOUND\n",
+            "gem(\"multiline-bound\", \">= 1\",\n",
+            "  \"< 2\")\n"
+        );
+        let deps = RubyParser::new().parse(content);
+
+        let single = deps.iter().find(|dep| dep.name == "single").unwrap();
+        assert!(!single.has_additional_version_constraints);
+        let hash_option = deps.iter().find(|dep| dep.name == "hash-option").unwrap();
+        assert!(!hash_option.has_additional_version_constraints);
+        let legacy_option = deps.iter().find(|dep| dep.name == "legacy-option").unwrap();
+        assert!(!legacy_option.has_additional_version_constraints);
+
+        let compound = deps.iter().find(|dep| dep.name == "compound").unwrap();
+        assert_eq!(compound.version, ">= 1");
+        assert!(compound.has_additional_version_constraints);
+        let variable_bound = deps
+            .iter()
+            .find(|dep| dep.name == "variable-bound")
+            .unwrap();
+        assert!(variable_bound.has_additional_version_constraints);
+        let multiline_bound = deps
+            .iter()
+            .find(|dep| dep.name == "multiline-bound")
+            .unwrap();
+        assert!(multiline_bound.has_additional_version_constraints);
     }
 }

--- a/dependi-lsp/src/providers/code_actions.rs
+++ b/dependi-lsp/src/providers/code_actions.rs
@@ -20,6 +20,7 @@ use crate::cache::ReadCache;
 use crate::file_types::FileType;
 use crate::parsers::Dependency;
 use crate::providers::inlay_hints::{VersionStatus, compare_versions};
+use crate::providers::version_edit::render_version_update;
 
 /// Classification of a semantic-version bump.
 ///
@@ -194,8 +195,8 @@ pub async fn create_code_actions(
     //   - ignore_candidates:  in-range, non-ignored — eligible for the Ignore action
     //                         (property refs CAN still be ignored even though they
     //                         can't safely be Updated)
-    //   - update_candidates:  in-range, non-ignored, NOT managed indirectly —
-    //                         eligible for individual Update actions
+    // Update safety is decided by the shared renderer after version comparison;
+    // ignore candidates stay independent so unsafe declarations remain ignorable.
     let non_ignored: Vec<&Dependency> = dependencies
         .iter()
         .filter(|dep| !crate::config::is_package_ignored(&dep.name, ignored))
@@ -207,15 +208,9 @@ pub async fn create_code_actions(
         .filter(|dep| (range.start.line..=range.end.line).contains(&dep.version_span.line))
         .collect();
 
-    let update_candidates: Vec<&Dependency> = ignore_candidates
-        .iter()
-        .copied()
-        .filter(|dep| !is_indirectly_managed_version(dep))
-        .collect();
-
     let mut actions: Vec<CodeActionOrCommand> = Vec::new();
 
-    for dep in &update_candidates {
+    for dep in &ignore_candidates {
         if let Some(update) = create_update_action(dep, cache, uri, file_type, &cache_key_fn).await
         {
             actions.push(update);
@@ -239,31 +234,6 @@ pub async fn create_code_actions(
     actions
 }
 
-/// Whether the manifest text at `version_span` is a Maven property reference
-/// (e.g. `${spring.version}`). Replacing the placeholder with a literal would
-/// silently break property-driven version management for every other artifact
-/// sharing the same property — so the "update version" quick-fix is suppressed.
-fn is_property_reference(dep: &Dependency) -> bool {
-    dep.version.starts_with("${") && dep.version.ends_with('}')
-}
-
-fn is_catalog_reference(dep: &Dependency) -> bool {
-    dep.version.starts_with("catalog:")
-}
-
-fn is_indirectly_managed_version(dep: &Dependency) -> bool {
-    is_property_reference(dep) || is_catalog_reference(dep)
-}
-
-/// Extract Python version operator prefix from a version string (e.g., "~=" from "~=14.3")
-fn extract_python_operator(version: &str) -> Option<&str> {
-    let operators = ["===", "~=", "==", ">=", "<=", "!=", ">", "<"];
-    operators
-        .iter()
-        .find(|op| version.starts_with(*op))
-        .copied()
-}
-
 /// Create an "Update to X.Y.Z" code action for a dependency
 async fn create_update_action(
     dep: &Dependency,
@@ -279,7 +249,7 @@ async fn create_update_action(
     match compare_versions(dep.effective_version(), &version_info) {
         VersionStatus::UpdateAvailable(new_version) => {
             let update_type = compare_update_type(dep.effective_version(), &new_version);
-            let new_text = format_version_for_dep(&new_version, file_type, &dep.version);
+            let new_text = render_version_update(dep, &new_version, file_type)?;
 
             let edit = TextEdit {
                 range: Range {
@@ -367,15 +337,13 @@ async fn create_update_all_action(
     // number of `spawn_blocking` SQLite jobs (which are not cancelable). Tag each
     // future with its index so we can stitch results back to the right Dependency.
     const PREFETCH_CONCURRENCY: usize = 8;
-    let filtered: Vec<&Dependency> = dependencies
+    let cache_keys: Vec<String> = dependencies
         .iter()
-        .copied()
-        .filter(|dep| !is_indirectly_managed_version(dep))
+        .map(|dep| cache_key_fn(&dep.name))
         .collect();
 
-    let cache_keys: Vec<String> = filtered.iter().map(|dep| cache_key_fn(&dep.name)).collect();
-
-    let mut cache_results: Vec<Option<crate::registries::VersionInfo>> = vec![None; filtered.len()];
+    let mut cache_results: Vec<Option<crate::registries::VersionInfo>> =
+        vec![None; dependencies.len()];
     let lookups = cache_keys
         .into_iter()
         .enumerate()
@@ -385,39 +353,37 @@ async fn create_update_all_action(
         cache_results[idx] = value;
     }
 
-    let mut outdated_deps: Vec<(&Dependency, String)> = Vec::new();
-    for (dep, version_info) in filtered.iter().zip(cache_results) {
+    let mut safe_updates: Vec<(&Dependency, String)> = Vec::new();
+    for (dep, version_info) in dependencies.iter().copied().zip(cache_results) {
         let Some(version_info) = version_info else {
             continue;
         };
         if let VersionStatus::UpdateAvailable(new_version) =
             compare_versions(dep.effective_version(), &version_info)
+            && let Some(new_text) = render_version_update(dep, &new_version, file_type)
         {
-            outdated_deps.push((dep, new_version));
+            safe_updates.push((dep, new_text));
         }
     }
 
-    if outdated_deps.len() < 2 {
+    if safe_updates.len() < 2 {
         return None;
     }
 
-    let edits: Vec<TextEdit> = outdated_deps
+    let edits: Vec<TextEdit> = safe_updates
         .iter()
-        .map(|(dep, new_version)| {
-            let new_text = format_version_for_dep(new_version, file_type, &dep.version);
-            TextEdit {
-                range: Range {
-                    start: Position {
-                        line: dep.version_span.line,
-                        character: dep.version_span.line_start,
-                    },
-                    end: Position {
-                        line: dep.version_span.line,
-                        character: dep.version_span.line_end,
-                    },
+        .map(|(dep, new_text)| TextEdit {
+            range: Range {
+                start: Position {
+                    line: dep.version_span.line,
+                    character: dep.version_span.line_start,
                 },
-                new_text,
-            }
+                end: Position {
+                    line: dep.version_span.line,
+                    character: dep.version_span.line_end,
+                },
+            },
+            new_text: new_text.clone(),
         })
         .collect();
 
@@ -428,7 +394,7 @@ async fn create_update_all_action(
     let mut changes = std::collections::HashMap::new();
     changes.insert(uri.clone(), edits);
 
-    let count = outdated_deps.len();
+    let count = safe_updates.len();
     let title = format!("Update all {count} dependencies");
 
     Some(CodeActionOrCommand::CodeAction(CodeAction {
@@ -445,61 +411,6 @@ async fn create_update_all_action(
         disabled: None,
         data: None,
     }))
-}
-
-/// Format version string based on file type
-fn format_version(version: &str, file_type: FileType) -> String {
-    match file_type {
-        FileType::Cargo | FileType::Npm | FileType::Php => {
-            // Keep the version as-is. version_span covers the inner token text
-            // only (no surrounding quotes), so callers replace just the version
-            // literal and the existing quote pair is preserved.
-            version.to_string()
-        }
-        FileType::Python => {
-            // Python uses operators like == or >=
-            // Just replace the version number
-            version.to_string()
-        }
-        FileType::Go => {
-            // Go versions start with 'v'
-            if version.starts_with('v') {
-                version.to_string()
-            } else {
-                format!("v{version}")
-            }
-        }
-        FileType::Dart => {
-            // Dart pubspec.yaml uses caret syntax (^1.0.0) or simple versions
-            version.to_string()
-        }
-        FileType::Csharp => {
-            // C# .csproj uses simple version strings
-            version.to_string()
-        }
-        FileType::Ruby => {
-            // Ruby Gemfile uses operators like ~> or >=
-            version.to_string()
-        }
-        FileType::Maven => {
-            // Maven pom.xml uses plain version strings inside <version>...</version>
-            version.to_string()
-        }
-    }
-}
-
-/// Format version for a dependency update, preserving the original operator for Python
-fn format_version_for_dep(
-    new_version: &str,
-    file_type: FileType,
-    original_version: &str,
-) -> String {
-    if file_type == FileType::Python
-        && let Some(op) = extract_python_operator(original_version)
-    {
-        return format!("{op}{}", format_version(new_version, file_type));
-    }
-    format_version(new_version, file_type)
 }
 
 #[cfg(test)]
@@ -527,6 +438,7 @@ mod tests {
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         }
     }
 
@@ -663,15 +575,6 @@ mod tests {
         .await;
 
         assert_eq!(actions.len(), 0);
-    }
-
-    #[test]
-    fn test_format_version() {
-        assert_eq!(format_version("1.0.0", FileType::Cargo), "1.0.0");
-        assert_eq!(format_version("1.0.0", FileType::Npm), "1.0.0");
-        assert_eq!(format_version("1.0.0", FileType::Python), "1.0.0");
-        assert_eq!(format_version("1.0.0", FileType::Go), "v1.0.0");
-        assert_eq!(format_version("v1.0.0", FileType::Go), "v1.0.0");
     }
 
     #[tokio::test]
@@ -1086,20 +989,6 @@ mod tests {
     }
 
     #[test]
-    fn test_format_version_all_file_types() {
-        assert_eq!(format_version("1.0.0", FileType::Cargo), "1.0.0");
-        assert_eq!(format_version("1.0.0", FileType::Npm), "1.0.0");
-        assert_eq!(format_version("1.0.0", FileType::Python), "1.0.0");
-        assert_eq!(format_version("1.0.0", FileType::Go), "v1.0.0");
-        assert_eq!(format_version("v1.0.0", FileType::Go), "v1.0.0");
-        assert_eq!(format_version("1.0.0", FileType::Php), "1.0.0");
-        assert_eq!(format_version("1.0.0", FileType::Dart), "1.0.0");
-        assert_eq!(format_version("1.0.0", FileType::Csharp), "1.0.0");
-        assert_eq!(format_version("1.0.0", FileType::Ruby), "1.0.0");
-        assert_eq!(format_version("1.0.0", FileType::Maven), "1.0.0");
-    }
-
-    #[test]
     fn test_normalize_version_with_partial_versions() {
         let normalized = super::normalize_version("1");
         assert_eq!(normalized, "1.0.0");
@@ -1137,30 +1026,6 @@ mod tests {
 
         let normalized = super::normalize_version("!=1.0");
         assert_eq!(normalized, "1.0.0");
-    }
-
-    #[test]
-    fn test_format_version_for_dep_python_compatible_release() {
-        // ~= operator should be preserved in replacement
-        assert_eq!(
-            format_version_for_dep("14.3", FileType::Python, "~=14.2"),
-            "~=14.3"
-        );
-        // == operator preserved
-        assert_eq!(
-            format_version_for_dep("3.0.0", FileType::Python, "==2.0.0"),
-            "==3.0.0"
-        );
-        // >= operator preserved
-        assert_eq!(
-            format_version_for_dep("3.0.0", FileType::Python, ">=2.0.0"),
-            ">=3.0.0"
-        );
-        // Non-Python file types are unchanged
-        assert_eq!(
-            format_version_for_dep("2.0.0", FileType::Cargo, "1.0.0"),
-            "2.0.0"
-        );
     }
 
     #[tokio::test]
@@ -1699,5 +1564,214 @@ mod tests {
         assert_eq!(ignore.kind, Some(CodeActionKind::QUICKFIX));
         assert_eq!(ignore.is_preferred, Some(false));
         assert!(ignore.edit.is_some());
+    }
+
+    #[tokio::test]
+    async fn npm_update_preserves_the_declared_caret() {
+        let cache = MemoryCache::new();
+        cache
+            .insert(
+                "test:package".to_string(),
+                VersionInfo {
+                    latest: Some("5.1.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
+        let deps = vec![create_test_dependency("package", "^4.0.2", 1)];
+        let uri = Url::parse("file:///test/package.json").unwrap();
+        let range = Range {
+            start: Position::new(1, 0),
+            end: Position::new(1, 100),
+        };
+
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Npm,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        )
+        .await;
+
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("expected code action");
+        };
+        let edit = &action.edit.as_ref().unwrap().changes.as_ref().unwrap()[&uri][0];
+        assert_eq!(edit.new_text, "^5.1.0");
+    }
+
+    #[tokio::test]
+    async fn unsafe_constraint_keeps_only_the_ignore_action() {
+        let cache = MemoryCache::new();
+        cache
+            .insert(
+                "test:package".to_string(),
+                VersionInfo {
+                    latest: Some("2.0.0".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
+        let deps = vec![create_test_dependency("package", ">=1.0,<2.0", 1)];
+        let uri = Url::parse("file:///test/requirements.txt").unwrap();
+        let range = Range {
+            start: Position::new(1, 0),
+            end: Position::new(1, 100),
+        };
+        let workspace = std::path::Path::new("/tmp/ws");
+
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Python,
+            |name| format!("test:{name}"),
+            &[],
+            Some(workspace),
+            None,
+        )
+        .await;
+
+        assert_eq!(actions.len(), 1);
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("expected code action");
+        };
+        assert_eq!(action.title, "Ignore package \"package\"");
+    }
+
+    #[tokio::test]
+    async fn bulk_update_counts_and_edits_only_safe_constraints() {
+        let cache = MemoryCache::new();
+        for name in ["caret", "compound", "tilde"] {
+            cache
+                .insert(
+                    format!("test:{name}"),
+                    VersionInfo {
+                        latest: Some("2.1.0".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await;
+        }
+        let deps = vec![
+            create_test_dependency("caret", "^1.0.0", 1),
+            create_test_dependency("compound", ">=1.0.0 <2.0.0", 2),
+            create_test_dependency("tilde", "~1.0.0", 3),
+        ];
+        let uri = Url::parse("file:///test/package.json").unwrap();
+        let outside_range = Range {
+            start: Position::new(50, 0),
+            end: Position::new(50, 0),
+        };
+
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            outside_range,
+            FileType::Npm,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        )
+        .await;
+
+        assert_eq!(actions.len(), 1);
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("expected code action");
+        };
+        assert_eq!(action.title, "Update all 2 dependencies");
+        let edits = &action.edit.as_ref().unwrap().changes.as_ref().unwrap()[&uri];
+        assert_eq!(edits.len(), 2);
+        assert_eq!(edits[0].new_text, "^2.1.0");
+        assert_eq!(edits[1].new_text, "~2.1.0");
+    }
+
+    #[tokio::test]
+    async fn bulk_update_is_hidden_when_only_one_safe_edit_remains() {
+        let cache = MemoryCache::new();
+        for name in ["caret", "compound"] {
+            cache
+                .insert(
+                    format!("test:{name}"),
+                    VersionInfo {
+                        latest: Some("2.1.0".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await;
+        }
+        let deps = vec![
+            create_test_dependency("caret", "^1.0.0", 1),
+            create_test_dependency("compound", ">=1.0.0 <2.0.0", 2),
+        ];
+        let uri = Url::parse("file:///test/package.json").unwrap();
+        let outside_range = Range {
+            start: Position::new(50, 0),
+            end: Position::new(50, 0),
+        };
+
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            outside_range,
+            FileType::Npm,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        )
+        .await;
+
+        assert!(actions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn lockfile_backed_partial_constraints_do_not_create_noop_updates() {
+        let cache = MemoryCache::new();
+        for name in ["first", "second"] {
+            cache
+                .insert(
+                    format!("test:{name}"),
+                    VersionInfo {
+                        latest: Some("1.2.4".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await;
+        }
+        let mut first = create_test_dependency("first", "1.2", 1);
+        first.resolved_version = Some("1.2.3".to_string());
+        let mut second = create_test_dependency("second", "1.2", 2);
+        second.resolved_version = Some("1.2.3".to_string());
+        let deps = vec![first, second];
+        let uri = Url::parse("file:///test/Cargo.toml").unwrap();
+        let range = Range {
+            start: Position::new(0, 0),
+            end: Position::new(10, 0),
+        };
+
+        let actions = create_code_actions(
+            &deps,
+            &cache,
+            &uri,
+            range,
+            FileType::Cargo,
+            |name| format!("test:{name}"),
+            &[],
+            None,
+            None,
+        )
+        .await;
+
+        assert!(actions.is_empty());
     }
 }

--- a/dependi-lsp/src/providers/completion.rs
+++ b/dependi-lsp/src/providers/completion.rs
@@ -205,6 +205,7 @@ mod tests {
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         }
     }
 

--- a/dependi-lsp/src/providers/diagnostics.rs
+++ b/dependi-lsp/src/providers/diagnostics.rs
@@ -564,6 +564,7 @@ mod tests {
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         }
     }
 

--- a/dependi-lsp/src/providers/document_links.rs
+++ b/dependi-lsp/src/providers/document_links.rs
@@ -84,6 +84,7 @@ mod tests {
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         }
     }
 

--- a/dependi-lsp/src/providers/inlay_hints.rs
+++ b/dependi-lsp/src/providers/inlay_hints.rs
@@ -70,6 +70,7 @@ pub enum VersionStatus {
 ///     name_span: Span { line: 5, line_start: 0, line_end: 5 },
 ///     version_span: Span { line: 5, line_start: 9, line_end: 14 },
 ///     dev: false, optional: false, registry: None, resolved_version: None,
+///     has_additional_version_constraints: false,
 /// };
 /// let info = VersionInfo { latest: Some("1.0.0".to_string()), ..Default::default() };
 /// let hint = create_inlay_hint(&dep, Some(&info), FileType::Cargo);
@@ -720,6 +721,7 @@ mod tests {
             optional: false,
             registry: None,
             resolved_version: None,
+            has_additional_version_constraints: false,
         }
     }
 
@@ -1491,6 +1493,7 @@ mod tests {
             optional: false,
             registry: None,
             resolved_version: Some(resolved.to_string()),
+            has_additional_version_constraints: false,
         }
     }
 

--- a/dependi-lsp/src/providers/mod.rs
+++ b/dependi-lsp/src/providers/mod.rs
@@ -18,3 +18,5 @@ pub mod document_links;
 
 /// Inlay hint provider (latest version shown next to the declared version).
 pub mod inlay_hints;
+
+pub(crate) mod version_edit;

--- a/dependi-lsp/src/providers/version_edit.rs
+++ b/dependi-lsp/src/providers/version_edit.rs
@@ -218,7 +218,7 @@ fn validate_latest(latest: &str, file_type: FileType) -> Option<&str> {
 
 fn is_version_token(token: &str, file_type: FileType) -> bool {
     if token.is_empty()
-        || (file_type != FileType::Go && token.starts_with('v'))
+        || (!matches!(file_type, FileType::Go | FileType::Python) && token.starts_with('v'))
         || token.contains("..")
         || token.ends_with(['.', '-', '+', '_', '!'])
         || token.bytes().any(|byte| {
@@ -521,11 +521,18 @@ mod tests {
     }
 
     #[test]
-    fn rejects_v_prefixed_versions_outside_go() {
+    fn renders_python_v_prefixed_constraint() {
+        assert_eq!(
+            render_version_update(&dependency("==v1.2"), "2.3.4", FileType::Python),
+            Some("==2.3.4".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_v_prefixed_versions_outside_go_and_python() {
         let cases = [
             (FileType::Cargo, "^v1.2"),
             (FileType::Npm, "^v1.2"),
-            (FileType::Python, "==v1.2"),
             (FileType::Php, "^v1.2"),
             (FileType::Dart, "^v1.2"),
             (FileType::Csharp, "[v1.2]"),

--- a/dependi-lsp/src/providers/version_edit.rs
+++ b/dependi-lsp/src/providers/version_edit.rs
@@ -218,6 +218,7 @@ fn validate_latest(latest: &str, file_type: FileType) -> Option<&str> {
 
 fn is_version_token(token: &str, file_type: FileType) -> bool {
     if token.is_empty()
+        || (file_type != FileType::Go && token.starts_with('v'))
         || token.contains("..")
         || token.ends_with(['.', '-', '+', '_', '!'])
         || token.bytes().any(|byte| {
@@ -513,6 +514,28 @@ mod tests {
         for (file_type, original) in cases {
             assert_eq!(
                 render_version_update(&dependency(original), "9.8.7", file_type),
+                None,
+                "unexpectedly rendered {file_type:?} {original:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_v_prefixed_versions_outside_go() {
+        let cases = [
+            (FileType::Cargo, "^v1.2"),
+            (FileType::Npm, "^v1.2"),
+            (FileType::Python, "==v1.2"),
+            (FileType::Php, "^v1.2"),
+            (FileType::Dart, "^v1.2"),
+            (FileType::Csharp, "[v1.2]"),
+            (FileType::Ruby, "~> v1.2"),
+            (FileType::Maven, "v1.2"),
+        ];
+
+        for (file_type, original) in cases {
+            assert_eq!(
+                render_version_update(&dependency(original), "2.3.4", file_type),
                 None,
                 "unexpectedly rendered {file_type:?} {original:?}"
             );

--- a/dependi-lsp/src/providers/version_edit.rs
+++ b/dependi-lsp/src/providers/version_edit.rs
@@ -1,0 +1,571 @@
+use crate::file_types::FileType;
+use crate::parsers::Dependency;
+
+#[derive(Clone, Copy)]
+struct Operator {
+    text: &'static str,
+    preserves_precision: bool,
+    minimum_components: usize,
+}
+
+pub(crate) fn render_version_update(
+    dependency: &Dependency,
+    latest: &str,
+    file_type: FileType,
+) -> Option<String> {
+    if dependency.has_additional_version_constraints {
+        return None;
+    }
+
+    let original = dependency.version.as_str();
+    let trimmed_start = original.trim_start();
+    let leading_len = original.len().checked_sub(trimmed_start.len())?;
+    let core = trimmed_start.trim_end();
+    let trailing_start = leading_len.checked_add(core.len())?;
+    let leading = original.get(..leading_len)?;
+    let trailing = original.get(trailing_start..)?;
+    if core.is_empty() || !is_horizontal_whitespace(leading) || !is_horizontal_whitespace(trailing)
+    {
+        return None;
+    }
+
+    let rendered = match file_type {
+        FileType::Cargo => render_with_operators(
+            core,
+            latest,
+            file_type,
+            &[
+                operator(">=", false),
+                operator("<=", false),
+                operator("^", true),
+                operator("~", true),
+                operator("=", false),
+            ],
+            true,
+        ),
+        FileType::Npm => render_with_operators(
+            core,
+            latest,
+            file_type,
+            &[
+                operator(">=", false),
+                operator("<=", false),
+                operator("^", true),
+                operator("~", true),
+                operator("=", false),
+            ],
+            true,
+        ),
+        FileType::Python => render_with_operators(
+            core,
+            latest,
+            file_type,
+            &[
+                operator("===", false),
+                Operator {
+                    text: "~=",
+                    preserves_precision: true,
+                    minimum_components: 2,
+                },
+                operator("==", false),
+                operator(">=", false),
+                operator("<=", false),
+                operator("^", true),
+                operator("~", true),
+            ],
+            false,
+        ),
+        FileType::Php => render_with_operators(
+            core,
+            latest,
+            file_type,
+            &[
+                operator("==", false),
+                operator(">=", false),
+                operator("<=", false),
+                operator("^", true),
+                operator("~", true),
+                operator("=", false),
+            ],
+            false,
+        ),
+        FileType::Dart => render_with_operators(
+            core,
+            latest,
+            file_type,
+            &[
+                operator(">=", false),
+                operator("<=", false),
+                operator("^", true),
+            ],
+            false,
+        ),
+        FileType::Csharp => render_nuget(core, latest),
+        FileType::Ruby => render_with_operators(
+            core,
+            latest,
+            file_type,
+            &[
+                operator("~>", true),
+                operator("==", false),
+                operator(">=", false),
+                operator("<=", false),
+                operator("=", false),
+            ],
+            false,
+        ),
+        FileType::Go => render_go(core, latest),
+        FileType::Maven => render_bare(core, latest, file_type),
+    }?;
+
+    let updated = format!("{leading}{rendered}{trailing}");
+    (updated != original).then_some(updated)
+}
+
+const fn operator(text: &'static str, preserves_precision: bool) -> Operator {
+    Operator {
+        text,
+        preserves_precision,
+        minimum_components: 1,
+    }
+}
+
+fn is_horizontal_whitespace(value: &str) -> bool {
+    value.bytes().all(|byte| matches!(byte, b' ' | b'\t'))
+}
+
+fn render_with_operators(
+    original: &str,
+    latest: &str,
+    file_type: FileType,
+    operators: &[Operator],
+    preserve_bare_precision: bool,
+) -> Option<String> {
+    let latest = validate_latest(latest, file_type)?;
+
+    for operator in operators {
+        let Some(rest) = original.strip_prefix(operator.text) else {
+            continue;
+        };
+        let operand = rest.trim_start_matches([' ', '\t']);
+        let whitespace_len = rest.len().checked_sub(operand.len())?;
+        let whitespace = rest.get(..whitespace_len)?;
+        if !is_version_token(operand, file_type) {
+            return None;
+        }
+
+        let component_count = release_parts(operand, file_type)?.components.len();
+        if component_count < operator.minimum_components {
+            return None;
+        }
+        let target = if operator.preserves_precision {
+            preserve_precision(operand, latest, file_type)?
+        } else {
+            latest.to_string()
+        };
+        return Some(format!("{}{whitespace}{target}", operator.text));
+    }
+
+    if !is_version_token(original, file_type) {
+        return None;
+    }
+    let target = if preserve_bare_precision {
+        preserve_precision(original, latest, file_type)?
+    } else {
+        latest.to_string()
+    };
+    Some(target)
+}
+
+fn render_bare(original: &str, latest: &str, file_type: FileType) -> Option<String> {
+    let latest = validate_latest(latest, file_type)?;
+    is_version_token(original, file_type).then(|| latest.to_string())
+}
+
+fn render_nuget(original: &str, latest: &str) -> Option<String> {
+    let latest = validate_latest(latest, FileType::Csharp)?;
+    if let Some(inner) = original
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+    {
+        return is_version_token(inner, FileType::Csharp).then(|| format!("[{latest}]"));
+    }
+    is_version_token(original, FileType::Csharp).then(|| latest.to_string())
+}
+
+fn render_go(original: &str, latest: &str) -> Option<String> {
+    let original = original.strip_prefix('v')?;
+    if original.starts_with('v') || !is_version_token(original, FileType::Go) {
+        return None;
+    }
+    let latest = latest.strip_prefix('v').unwrap_or(latest);
+    if latest.starts_with('v') || !is_version_token(latest, FileType::Go) {
+        return None;
+    }
+    semver::Version::parse(latest).ok()?;
+    Some(format!("v{latest}"))
+}
+
+fn validate_latest(latest: &str, file_type: FileType) -> Option<&str> {
+    if latest.trim() != latest || !is_version_token(latest, file_type) {
+        return None;
+    }
+    if matches!(file_type, FileType::Cargo | FileType::Npm | FileType::Dart) {
+        semver::Version::parse(latest).ok()?;
+    }
+    Some(latest)
+}
+
+fn is_version_token(token: &str, file_type: FileType) -> bool {
+    if token.is_empty()
+        || token.contains("..")
+        || token.ends_with(['.', '-', '+', '_', '!'])
+        || token.bytes().any(|byte| {
+            byte.is_ascii_whitespace()
+                || matches!(
+                    byte,
+                    b',' | b'|'
+                        | b'*'
+                        | b'^'
+                        | b'~'
+                        | b'<'
+                        | b'>'
+                        | b'='
+                        | b'['
+                        | b']'
+                        | b'('
+                        | b')'
+                        | b'{'
+                        | b'}'
+                        | b':'
+                        | b'/'
+                        | b'\\'
+                        | b'@'
+                        | b'$'
+                        | b';'
+                        | b'\''
+                        | b'"'
+                )
+        })
+    {
+        return false;
+    }
+
+    if !token.bytes().all(|byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'+' | b'_' | b'!')
+    }) {
+        return false;
+    }
+
+    let without_v = token.strip_prefix('v').unwrap_or(token);
+    if without_v.starts_with('v') || !without_v.as_bytes().first().is_some_and(u8::is_ascii_digit) {
+        return false;
+    }
+
+    let mut bang_parts = without_v.split('!');
+    let first = bang_parts.next().unwrap_or_default();
+    if let Some(release) = bang_parts.next()
+        && (file_type != FileType::Python
+            || bang_parts.next().is_some()
+            || first.is_empty()
+            || !first.bytes().all(|byte| byte.is_ascii_digit())
+            || !release.as_bytes().first().is_some_and(u8::is_ascii_digit))
+    {
+        return false;
+    }
+
+    !without_v.split('.').any(|segment| {
+        if segment.eq_ignore_ascii_case("x") || segment.eq_ignore_ascii_case("any") {
+            return true;
+        }
+        if !matches!(file_type, FileType::Npm | FileType::Php) {
+            return false;
+        }
+        let marker = segment
+            .split(['-', '+', '_', '!'])
+            .next()
+            .unwrap_or(segment);
+        marker.eq_ignore_ascii_case("x") || marker.eq_ignore_ascii_case("any")
+    })
+}
+
+struct ReleaseParts<'a> {
+    prefix: &'a str,
+    components: Vec<&'a str>,
+    suffix: &'a str,
+}
+
+fn release_parts(token: &str, file_type: FileType) -> Option<ReleaseParts<'_>> {
+    let mut release_start = usize::from(token.starts_with('v'));
+    if file_type == FileType::Python
+        && let Some(epoch_end) = token.get(release_start..)?.find('!')
+    {
+        release_start = release_start.checked_add(epoch_end)?.checked_add(1)?;
+    }
+
+    let release = token.get(release_start..)?;
+    let bytes = release.as_bytes();
+    let mut cursor = 0;
+    let mut components = Vec::with_capacity(3);
+    loop {
+        let component_start = cursor;
+        while bytes.get(cursor).is_some_and(u8::is_ascii_digit) {
+            cursor += 1;
+        }
+        if cursor == component_start {
+            return None;
+        }
+        components.push(release.get(component_start..cursor)?);
+
+        if bytes.get(cursor) == Some(&b'.') && bytes.get(cursor + 1).is_some_and(u8::is_ascii_digit)
+        {
+            cursor += 1;
+            continue;
+        }
+        break;
+    }
+
+    Some(ReleaseParts {
+        prefix: token.get(..release_start)?,
+        components,
+        suffix: release.get(cursor..)?,
+    })
+}
+
+fn preserve_precision(original: &str, latest: &str, file_type: FileType) -> Option<String> {
+    let original_parts = release_parts(original, file_type)?;
+    let latest_parts = release_parts(latest, file_type)?;
+    match latest_parts
+        .components
+        .len()
+        .cmp(&original_parts.components.len())
+    {
+        core::cmp::Ordering::Less => None,
+        core::cmp::Ordering::Equal => Some(latest.to_string()),
+        core::cmp::Ordering::Greater if latest_parts.suffix.is_empty() => Some(format!(
+            "{}{}",
+            latest_parts.prefix,
+            latest_parts.components[..original_parts.components.len()].join(".")
+        )),
+        core::cmp::Ordering::Greater => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_version_update;
+    use crate::file_types::FileType;
+    use crate::parsers::{Dependency, Span};
+
+    fn dependency(version: &str) -> Dependency {
+        Dependency {
+            name: "package".to_string(),
+            version: version.to_string(),
+            name_span: Span {
+                line: 0,
+                line_start: 0,
+                line_end: 7,
+            },
+            version_span: Span {
+                line: 0,
+                line_start: 10,
+                line_end: 10 + version.len() as u32,
+            },
+            dev: false,
+            optional: false,
+            registry: None,
+            resolved_version: None,
+            has_additional_version_constraints: false,
+        }
+    }
+
+    #[test]
+    fn renders_recognized_constraints_for_every_ecosystem() {
+        let cases = [
+            (FileType::Cargo, "1.2", "2.3.4", "2.3"),
+            (FileType::Cargo, "^4.0.2", "5.1.0", "^5.1.0"),
+            (FileType::Cargo, "~ 1.2", "2.3.4", "~ 2.3"),
+            (FileType::Cargo, "=1.2", "2.3.4", "=2.3.4"),
+            (FileType::Cargo, ">= 1.2", "2.3.4", ">= 2.3.4"),
+            (FileType::Cargo, "<=1.2", "2.3.4", "<=2.3.4"),
+            (FileType::Npm, "1", "2.3.4", "2"),
+            (FileType::Npm, "^1.2", "2.3.4", "^2.3"),
+            (FileType::Npm, "~1.2.3", "2.3.4", "~2.3.4"),
+            (FileType::Npm, "= 1.2.3", "2.3.4", "= 2.3.4"),
+            (FileType::Npm, ">=1.2", "2.3.4", ">=2.3.4"),
+            (FileType::Npm, "<= 1.2", "2.3.4", "<= 2.3.4"),
+            (FileType::Python, "=== 1.2", "2.3.4", "=== 2.3.4"),
+            (FileType::Python, "~=14.2", "14.3.3", "~=14.3"),
+            (FileType::Python, "== 1.2", "2.3.4", "== 2.3.4"),
+            (FileType::Python, ">=1.2", "2.3.4", ">=2.3.4"),
+            (FileType::Python, "<= 1.2", "2.3.4", "<= 2.3.4"),
+            (FileType::Python, "^1.2", "2.3.4", "^2.3"),
+            (FileType::Python, "~ 1.2", "2.3.4", "~ 2.3"),
+            (FileType::Python, "1.2", "2.3.4", "2.3.4"),
+            (FileType::Php, "1.2", "2.3.4", "2.3.4"),
+            (FileType::Php, "^1.2", "2.3.4", "^2.3"),
+            (FileType::Php, "~ 1.2", "2.3.4", "~ 2.3"),
+            (FileType::Php, "=1.2", "2.3.4", "=2.3.4"),
+            (FileType::Php, "== 1.2", "2.3.4", "== 2.3.4"),
+            (FileType::Php, ">=1.2", "2.3.4", ">=2.3.4"),
+            (FileType::Php, "<= 1.2", "2.3.4", "<= 2.3.4"),
+            (FileType::Dart, "1.2", "2.3.4", "2.3.4"),
+            (FileType::Dart, "^1.2", "2.3.4", "^2.3"),
+            (FileType::Dart, ">= 1.2", "2.3.4", ">= 2.3.4"),
+            (FileType::Dart, "<=1.2", "2.3.4", "<=2.3.4"),
+            (FileType::Csharp, "1.2", "2.3.4", "2.3.4"),
+            (FileType::Csharp, "[1.2]", "2.3.4", "[2.3.4]"),
+            (FileType::Ruby, "1.2", "2.3.4", "2.3.4"),
+            (FileType::Ruby, "~> 7.0", "8.1.4", "~> 8.1"),
+            (FileType::Ruby, "=1.2", "2.3.4", "=2.3.4"),
+            (FileType::Ruby, "== 1.2", "2.3.4", "== 2.3.4"),
+            (FileType::Ruby, ">=1.2", "2.3.4", ">=2.3.4"),
+            (FileType::Ruby, "<= 1.2", "2.3.4", "<= 2.3.4"),
+            (FileType::Go, "v1.2.3", "1.3.0", "v1.3.0"),
+            (FileType::Go, "v1.2.3", "v1.4.0", "v1.4.0"),
+            (FileType::Maven, "1.0.0.Final", "2.0.0-RC1", "2.0.0-RC1"),
+            (FileType::Maven, "1.x-dev", "2.0.0", "2.0.0"),
+        ];
+
+        for (file_type, original, latest, expected) in cases {
+            assert_eq!(
+                render_version_update(&dependency(original), latest, file_type),
+                Some(expected.to_string()),
+                "failed for {file_type:?} {original:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn preserves_outer_and_operator_whitespace() {
+        assert_eq!(
+            render_version_update(&dependency("  ^\t4.0.2  "), "5.1.0", FileType::Npm),
+            Some("  ^\t5.1.0  ".to_string())
+        );
+    }
+
+    #[test]
+    fn preserves_full_target_qualifiers_when_precision_is_unchanged() {
+        let cases = [
+            (
+                FileType::Npm,
+                "^1.2.3-beta.1+old",
+                "2.0.0-rc.1+build.5",
+                "^2.0.0-rc.1+build.5",
+            ),
+            (
+                FileType::Python,
+                "==1!2.0.0rc1",
+                "2!3.0.0.post1",
+                "==2!3.0.0.post1",
+            ),
+            (FileType::Ruby, "~> 1.2.3.pre", "2.0.0.pre", "~> 2.0.0.pre"),
+            (
+                FileType::Go,
+                "v0.0.0-20240101000000-abcdef123456",
+                "0.0.0-20250101000000-fedcba654321",
+                "v0.0.0-20250101000000-fedcba654321",
+            ),
+        ];
+
+        for (file_type, original, latest, expected) in cases {
+            assert_eq!(
+                render_version_update(&dependency(original), latest, file_type),
+                Some(expected.to_string()),
+                "failed for {file_type:?} {original:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_ineligible_constraint_shapes() {
+        let cases = [
+            (FileType::Python, ">=5.2,<5.3"),
+            (FileType::Npm, ">=1 <2"),
+            (FileType::Csharp, "[1,2)"),
+            (FileType::Npm, "1 || 2"),
+            (FileType::Npm, "1.0 - 2.0"),
+            (FileType::Cargo, "*"),
+            (FileType::Npm, "1.x"),
+            (FileType::Php, "1.0.x-dev"),
+            (FileType::Npm, "X"),
+            (FileType::Dart, "any"),
+            (FileType::Cargo, "<2"),
+            (FileType::Ruby, "> 1"),
+            (FileType::Python, "!=1"),
+            (FileType::Npm, "npm:foo@^1"),
+            (FileType::Npm, "workspace:^"),
+            (FileType::Npm, "file:../foo"),
+            (FileType::Npm, "link:../foo"),
+            (FileType::Npm, "catalog:"),
+            (FileType::Maven, "${revision}"),
+            (FileType::Npm, "https://example.com/pkg.tgz"),
+            (FileType::Cargo, "git+https://example.com/pkg"),
+            (FileType::Npm, "latest"),
+            (FileType::Npm, "next"),
+            (FileType::Maven, "RELEASE"),
+            (FileType::Go, "1.2.3"),
+            (FileType::Go, "vv1.2.3"),
+            (FileType::Csharp, "(1.0,2.0]"),
+            (FileType::Python, "~=1"),
+        ];
+
+        for (file_type, original) in cases {
+            assert_eq!(
+                render_version_update(&dependency(original), "9.8.7", file_type),
+                None,
+                "unexpectedly rendered {file_type:?} {original:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_latest_versions() {
+        let cases = [
+            "",
+            " ",
+            "latest",
+            "^2.0.0",
+            "2.0.0 || 3.0.0",
+            "2.0.0,3.0.0",
+            "https://example.com/release",
+            "2.0.0/other",
+            "2..0",
+            "2.0.",
+            "2.0.0+build+again",
+            "v2.0.0",
+        ];
+
+        for latest in cases {
+            assert_eq!(
+                render_version_update(&dependency("^1.0.0"), latest, FileType::Npm),
+                None,
+                "unexpectedly accepted latest {latest:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_truncation_that_would_drop_a_target_qualifier() {
+        assert_eq!(
+            render_version_update(&dependency("^1.2"), "2.3.4-beta.1", FileType::Npm),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_updates_that_render_the_original_constraint_unchanged() {
+        assert_eq!(
+            render_version_update(&dependency("1.2"), "1.2.4", FileType::Cargo),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_declarations_with_hidden_additional_constraints() {
+        let mut dep = dependency(">= 1");
+        dep.has_additional_version_constraints = true;
+
+        assert_eq!(render_version_update(&dep, "2.0.0", FileType::Ruby), None);
+    }
+}

--- a/dependi-lsp/tests/integration_test.rs
+++ b/dependi-lsp/tests/integration_test.rs
@@ -186,6 +186,7 @@ fn test_inlay_hint_generation() {
         optional: false,
         registry: None,
         resolved_version: None,
+        has_additional_version_constraints: false,
     };
 
     let info_up_to_date = VersionInfo {
@@ -219,6 +220,7 @@ fn test_inlay_hint_generation() {
         optional: false,
         registry: None,
         resolved_version: None,
+        has_additional_version_constraints: false,
     };
 
     let info_outdated = VersionInfo {

--- a/dependi-lsp/tests/lockfile_resolver_integration.rs
+++ b/dependi-lsp/tests/lockfile_resolver_integration.rs
@@ -27,6 +27,7 @@ fn dep(name: &str, version: &str) -> Dependency {
         optional: false,
         registry: None,
         resolved_version: None,
+        has_additional_version_constraints: false,
     }
 }
 

--- a/dependi-lsp/tests/version_update_actions_test.rs
+++ b/dependi-lsp/tests/version_update_actions_test.rs
@@ -1,0 +1,214 @@
+use dependi_lsp::cache::{MemoryCache, WriteCache};
+use dependi_lsp::file_types::FileType;
+use dependi_lsp::parsers::Parser;
+use dependi_lsp::parsers::cargo::CargoParser;
+use dependi_lsp::parsers::csharp::CsharpParser;
+use dependi_lsp::parsers::dart::DartParser;
+use dependi_lsp::parsers::go::GoParser;
+use dependi_lsp::parsers::maven::MavenParser;
+use dependi_lsp::parsers::npm::NpmParser;
+use dependi_lsp::parsers::php::PhpParser;
+use dependi_lsp::parsers::python::PythonParser;
+use dependi_lsp::parsers::ruby::RubyParser;
+use dependi_lsp::providers::code_actions::create_code_actions;
+use dependi_lsp::registries::VersionInfo;
+use tower_lsp::lsp_types::{CodeActionOrCommand, Position, Range, TextEdit, Url};
+
+struct UpdateCase {
+    parser: Box<dyn Parser>,
+    file_type: FileType,
+    uri: &'static str,
+    package: &'static str,
+    manifest: &'static str,
+    latest: &'static str,
+    expected: &'static str,
+}
+
+fn position_offset(content: &str, position: Position) -> Option<usize> {
+    let line_offset: usize = content
+        .split_inclusive('\n')
+        .take(position.line as usize)
+        .map(str::len)
+        .sum();
+    let offset = line_offset.checked_add(position.character as usize)?;
+    (offset <= content.len()).then_some(offset)
+}
+
+fn apply_text_edit(content: &str, edit: &TextEdit) -> Option<String> {
+    let start = position_offset(content, edit.range.start)?;
+    let end = position_offset(content, edit.range.end)?;
+    let mut updated = String::with_capacity(content.len() + edit.new_text.len());
+    updated.push_str(content.get(..start)?);
+    updated.push_str(&edit.new_text);
+    updated.push_str(content.get(end..)?);
+    Some(updated)
+}
+
+async fn apply_individual_update(case: &UpdateCase) -> Option<String> {
+    let dependencies = case.parser.parse(case.manifest);
+    let dependency = dependencies.iter().find(|dep| dep.name == case.package)?;
+    let cache = MemoryCache::new();
+    cache
+        .insert(
+            format!("test:{}", case.package),
+            VersionInfo {
+                latest: Some(case.latest.to_string()),
+                ..Default::default()
+            },
+        )
+        .await;
+    let uri = Url::parse(case.uri).ok()?;
+    let range = Range {
+        start: Position::new(dependency.version_span.line, 0),
+        end: Position::new(dependency.version_span.line, u32::MAX),
+    };
+    let actions = create_code_actions(
+        &dependencies,
+        &cache,
+        &uri,
+        range,
+        case.file_type,
+        |name| format!("test:{name}"),
+        &[],
+        None,
+        None,
+    )
+    .await;
+    let edit = actions.into_iter().find_map(|action| {
+        let CodeActionOrCommand::CodeAction(action) = action else {
+            return None;
+        };
+        let changes = action.edit?.changes?;
+        changes.get(&uri)?.first().cloned()
+    })?;
+    apply_text_edit(case.manifest, &edit)
+}
+
+#[tokio::test]
+async fn parsed_manifests_keep_safe_constraint_shapes_when_updated() {
+    let cases = [
+        UpdateCase {
+            parser: Box::new(CargoParser::new()),
+            file_type: FileType::Cargo,
+            uri: "file:///test/Cargo.toml",
+            package: "package",
+            manifest: "[dependencies]\npackage = \"^4.0.2\"\n",
+            latest: "5.1.0",
+            expected: "[dependencies]\npackage = \"^5.1.0\"\n",
+        },
+        UpdateCase {
+            parser: Box::new(NpmParser::new()),
+            file_type: FileType::Npm,
+            uri: "file:///test/package.json",
+            package: "package",
+            manifest: "{\n  \"dependencies\": {\n    \"package\": \"^4.0.2\"\n  }\n}\n",
+            latest: "5.1.0",
+            expected: "{\n  \"dependencies\": {\n    \"package\": \"^5.1.0\"\n  }\n}\n",
+        },
+        UpdateCase {
+            parser: Box::new(PythonParser::new()),
+            file_type: FileType::Python,
+            uri: "file:///test/requirements.txt",
+            package: "package",
+            manifest: "package~=14.2\n",
+            latest: "14.3.3",
+            expected: "package~=14.3\n",
+        },
+        UpdateCase {
+            parser: Box::new(PhpParser::new()),
+            file_type: FileType::Php,
+            uri: "file:///test/composer.json",
+            package: "vendor/package",
+            manifest: "{\"require\": {\"vendor/package\": \"^1.2\"}}\n",
+            latest: "2.3.4",
+            expected: "{\"require\": {\"vendor/package\": \"^2.3\"}}\n",
+        },
+        UpdateCase {
+            parser: Box::new(DartParser::new()),
+            file_type: FileType::Dart,
+            uri: "file:///test/pubspec.yaml",
+            package: "package",
+            manifest: "name: app\ndependencies:\n  package: ^1.2\n",
+            latest: "2.3.4",
+            expected: "name: app\ndependencies:\n  package: ^2.3\n",
+        },
+        UpdateCase {
+            parser: Box::new(CsharpParser::new()),
+            file_type: FileType::Csharp,
+            uri: "file:///test/App.csproj",
+            package: "Package",
+            manifest: "<Project><ItemGroup><PackageReference Include=\"Package\" Version=\"[1.0]\" /></ItemGroup></Project>\n",
+            latest: "2.0",
+            expected: "<Project><ItemGroup><PackageReference Include=\"Package\" Version=\"[2.0]\" /></ItemGroup></Project>\n",
+        },
+        UpdateCase {
+            parser: Box::new(RubyParser::new()),
+            file_type: FileType::Ruby,
+            uri: "file:///test/Gemfile",
+            package: "package",
+            manifest: "gem \"package\", \"~> 7.0\"\n",
+            latest: "8.1.4",
+            expected: "gem \"package\", \"~> 8.1\"\n",
+        },
+        UpdateCase {
+            parser: Box::new(GoParser::new()),
+            file_type: FileType::Go,
+            uri: "file:///test/go.mod",
+            package: "example.com/package",
+            manifest: "module example.com/app\n\nrequire example.com/package v1.2.3\n",
+            latest: "1.3.0",
+            expected: "module example.com/app\n\nrequire example.com/package v1.3.0\n",
+        },
+        UpdateCase {
+            parser: Box::new(MavenParser::new()),
+            file_type: FileType::Maven,
+            uri: "file:///test/pom.xml",
+            package: "org.example:package",
+            manifest: "<project>\n  <dependencies>\n    <dependency>\n      <groupId>org.example</groupId>\n      <artifactId>package</artifactId>\n      <version>1.0.0.Final</version>\n    </dependency>\n  </dependencies>\n</project>\n",
+            latest: "2.0.0-RC1",
+            expected: "<project>\n  <dependencies>\n    <dependency>\n      <groupId>org.example</groupId>\n      <artifactId>package</artifactId>\n      <version>2.0.0-RC1</version>\n    </dependency>\n  </dependencies>\n</project>\n",
+        },
+    ];
+
+    for case in cases {
+        assert_eq!(
+            apply_individual_update(&case).await.as_deref(),
+            Some(case.expected),
+            "failed for {:?}",
+            case.file_type
+        );
+    }
+}
+
+#[tokio::test]
+async fn compound_python_and_ruby_declarations_have_no_update_action() {
+    let cases = [
+        UpdateCase {
+            parser: Box::new(PythonParser::new()),
+            file_type: FileType::Python,
+            uri: "file:///test/requirements.txt",
+            package: "package",
+            manifest: "package>=1.0,<2.0\n",
+            latest: "3.0.0",
+            expected: "",
+        },
+        UpdateCase {
+            parser: Box::new(RubyParser::new()),
+            file_type: FileType::Ruby,
+            uri: "file:///test/Gemfile",
+            package: "package",
+            manifest: "gem \"package\", \">= 1\", \"< 2\"\n",
+            latest: "3.0.0",
+            expected: "",
+        },
+    ];
+
+    for case in cases {
+        assert_eq!(
+            apply_individual_update(&case).await,
+            None,
+            "unexpected update for {:?}",
+            case.file_type
+        );
+    }
+}

--- a/docs/features/code-actions.md
+++ b/docs/features/code-actions.md
@@ -129,7 +129,9 @@ The same safety rules apply to individual and bulk updates:
 
 Operators, spacing, exact-version wrappers, and range-shaping precision are
 retained when Dependi can prove that replacing the single version anchor is
-safe. Go module updates also retain exactly one `v` prefix.
+safe. Go module updates preserve exactly one existing `v` prefix. Unprefixed,
+multiply-prefixed, or otherwise unsupported prefix shapes receive no automatic
+update.
 
 Compound ranges and indirect versions do not receive automatic update actions.
 This includes multiple bounds, unions, wildcards, strict or exclusion

--- a/docs/features/code-actions.md
+++ b/docs/features/code-actions.md
@@ -114,7 +114,8 @@ This encourages safer update practices while still making major updates accessib
 
 ## Version Constraints
 
-Code actions respect your version constraint syntax:
+Code actions preserve the structure of simple, recognized version constraints.
+The same safety rules apply to individual and bulk updates:
 
 | Original | Action | Result |
 |----------|--------|--------|
@@ -122,6 +123,20 @@ Code actions respect your version constraint syntax:
 | `"^1.0.0"` | Update to 1.5.0 | `"^1.5.0"` |
 | `"~1.0.0"` | Update to 1.0.5 | `"~1.0.5"` |
 | `">=1.0"` | Update to 1.5.0 | `">=1.5.0"` |
+| `"~=14.2"` | Update to 14.3.3 | `"~=14.3"` |
+| `"~> 7.0"` | Update to 8.1.4 | `"~> 8.1"` |
+| `"[1.0]"` | Update to 2.0 | `"[2.0]"` |
+
+Operators, spacing, exact-version wrappers, and range-shaping precision are
+retained when Dependi can prove that replacing the single version anchor is
+safe. Go module updates also retain exactly one `v` prefix.
+
+Compound ranges and indirect versions do not receive automatic update actions.
+This includes multiple bounds, unions, wildcards, strict or exclusion
+constraints, aliases, workspace protocols, pnpm catalogs, Maven properties,
+URLs, and other unknown forms. Dependi omits the update instead of replacing
+the declaration with a bare version; other actions such as **Ignore package**
+remain available.
 
 ## Workflow Tips
 


### PR DESCRIPTION
## Summary

- preserve recognized operators, spacing, wrappers, and range-shaping precision with one fail-closed renderer across all supported ecosystems
- suppress unsafe individual and bulk edits, including hidden compound constraints in Python and Ruby declarations
- add renderer, parser, provider, and parse-to-TextEdit regression coverage plus documentation and changelog updates

## Testing

- `cargo test --lib`
- `cargo test --tests --quiet`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- real stdio LSP `didOpen` → diagnostics → `textDocument/codeAction` verification

Closes #351

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LSP “Update to …” actions to preserve constraint shapes, accept Python PEP 440 `v` prefixes, and skip unsafe edits across ecosystems. Adds a fail‑closed renderer so updates keep operators, spacing, wrappers, Go’s single `v`, and avoid no‑ops for lockfile‑backed partial versions.

- **Bug Fixes**
  - Preserve operators (`^`, `~`, `>=`, `~>`, `~=`, `===`, etc.), inner spacing, exact‑version wrappers (e.g. `[1.0]`), Python’s PEP 440 `v` prefixes, and Go’s single leading `v`.
  - Detect compound/hidden bounds and indirect/property/catalog/workspace/URL/wildcard/union/alias forms; suppress Update and keep Ignore where applicable.
  - Bulk Update uses the shared renderer, counts and edits only safe declarations, and stays hidden if fewer than two safe edits exist.

- **Dependencies**
  - Update `quick-xml` to 0.41.0 and `crossbeam-epoch` to 0.9.20 to address RUSTSEC-2026-0194/0195/0204.
  - CI: align with Rust 1.97 and Clippy 1.97.

<sup>Written for commit 22d29d66e89a8cbc745efa86eb8177f05bd5a678. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/zed-dependi/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Version update code actions now preserve recognized constraint operators, spacing/wrappers, and precision when applying safe updates.
  * Automatic updates no longer convert unsafe compound/indirect constraints to bare versions; those cases are omitted while **Ignore** remains available.
  * “Update all” now applies edits only for constraints that can be safely rewritten.
* **Documentation**
  * Expanded version-constraints guidance with clearer examples of precision retention and unsupported/compound syntax handling.
* **Security**
  * Updated `quick-xml` and `crossbeam-epoch` for Rust advisory fixes.
* **Tests**
  * Added multi-ecosystem coverage for safe constraint shape preservation and for rejecting compound specifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->