### PR TITLE
chore(release): prepare v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-07-11
+
 ### Added
 
 - Direct LSP support for `Directory.Build.props` and
@@ -784,7 +786,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory caching for version data
 - Parallel registry requests (5 concurrent)
 
-[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.9.1...HEAD
+[Unreleased]: https://github.com/mpiton/zed-dependi/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/mpiton/zed-dependi/compare/v1.9.1...v1.10.0
 [1.9.1]: https://github.com/mpiton/zed-dependi/compare/v1.9.0...v1.9.1
 [1.9.0]: https://github.com/mpiton/zed-dependi/compare/v1.8.1...v1.9.0
 [1.8.1]: https://github.com/mpiton/zed-dependi/compare/v1.8.0...v1.8.1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Dependency management extension for the [Zed](https://zed.dev) editor.
 
-**Version:** 1.9.1
+**Version:** 1.10.0
 
 ![Demo](docs/demo.gif)
 

--- a/dependi-lsp/Cargo.lock
+++ b/dependi-lsp/Cargo.lock
@@ -545,7 +545,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "dependi-lsp"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dependi-lsp/Cargo.toml
+++ b/dependi-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-lsp"
-version = "1.9.1"
+version = "1.10.0"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/dependi-lsp/fuzz/Cargo.lock
+++ b/dependi-lsp/fuzz/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-lsp"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -391,7 +391,6 @@ dependencies = [
  "serde",
  "serde_json",
  "taplo",
- "thiserror 2.0.18",
  "tokio",
  "toml",
  "tower-lsp",
@@ -1309,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/dependi-zed/Cargo.lock
+++ b/dependi-zed/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "dependi-zed"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "sha2",
  "zed_extension_api",

--- a/dependi-zed/Cargo.toml
+++ b/dependi-zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependi-zed"
-version = "1.9.1"
+version = "1.10.0"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT"

--- a/dependi-zed/extension.toml
+++ b/dependi-zed/extension.toml
@@ -1,7 +1,7 @@
 id = "dependi"
 name = "Dependi"
 description = "Dependency management for Zed - version hints, updates, and vulnerability detection"
-version = "1.9.1"
+version = "1.10.0"
 schema_version = 1
 authors = ["Mathieu Piton"]
 repository = "https://github.com/mpiton/zed-dependi"


### PR DESCRIPTION
## Summary

- bump Dependi LSP, Zed extension, README, and lockfiles to 1.10.0
- publish the current changelog entries as the 2026-07-11 release
- update release comparison links and synchronize the fuzz lockfile

## Type

chore

## Verification

- format, Clippy, tests, fuzz check, and release builds pass


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the v1.10.0 release: bump versions across `dependi-lsp`, `dependi-zed`, and the Zed extension, publish the 2026-07-11 changelog, and sync lockfiles.

- **Dependencies**
  - Set versions to 1.10.0 across crates and extension; updated README and changelog comparison links.
  - Synced lockfiles; `dependi-lsp/fuzz` now uses `quick-xml` 0.41.0 and drops a stale `thiserror` entry.

<sup>Written for commit 8a1176c3b0fece54a665010c8f824b24cd682a9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/zed-dependi/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the product and extension version to **1.10.0**.
  * Added release notes and comparison links for version 1.10.0.
  * Updated the displayed version information in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->